### PR TITLE
Honor raw refresh cache metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Populate local raw data from public Google Maps lists:
 bun run sync:sources
 ```
 
-This refreshes every configured source and then rebuilds generated site data. URL sources always re-fetch; CSV sources skip rewrites when their input hash is unchanged.
+This refreshes every configured source and then rebuilds generated site data. URL sources skip network refreshes until their `refresh_after` window expires unless the source config changes; CSV sources skip rewrites when their input hash is unchanged.
 
 Force-refresh all configured raw source imports:
 
@@ -94,5 +94,5 @@ bun run dev
 - Raw place `is_favorite` should flow through as the default top-pick signal.
 - Manual `note` and `top_pick` overrides still win.
 - Google Places cache entries now carry `input_signature` and `refresh_after`; invalidation is not a single global TTL anymore.
-- Raw saved-list snapshots now carry `fetched_at` and `source_signature`; URL sources always re-fetch on `--refresh`, while CSV sources can skip rewrites when the input hash is unchanged.
+- Raw saved-list snapshots now carry `fetched_at`, `refresh_after`, and `source_signature`; URL sources skip network refreshes until the refresh window expires unless the source config changes, while CSV sources can skip rewrites when the input hash is unchanged.
 - Do not reintroduce tracked generated JSON unless the user explicitly asks for fixture-style examples in git.

--- a/README.md
+++ b/README.md
@@ -196,8 +196,10 @@ Optional fallback title example:
 bun run sync:sources
 ```
 
-This writes local JSON files into `data/raw/`, including refresh metadata like `fetched_at`
-and a source signature. CSV-backed sources skip rewrites when the input file hash is unchanged.
+This writes local JSON files into `data/raw/`, including refresh metadata like `fetched_at`,
+`refresh_after`, and a source signature. URL-backed sources skip network refreshes until
+their refresh window expires unless the source config changes. CSV-backed sources skip rewrites
+when the input file hash is unchanged.
 It also rebuilds the generated site JSON afterward.
 
 4. Add manual curation files in `src/data/overrides/`.

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -33,6 +33,7 @@ LOW_CONFIDENCE_CACHE_TTL = timedelta(days=3)
 RATINGS_CACHE_TTL = timedelta(days=7)
 NON_OPERATIONAL_CACHE_TTL = timedelta(days=3)
 OPERATIONAL_CACHE_TTL = timedelta(days=14)
+RAW_SOURCE_CACHE_TTL = timedelta(days=14)
 STRONG_MATCH_SCORE = 45
 PLACES_TEXT_SEARCH_URL = "https://places.googleapis.com/v1/places:searchText"
 PLACES_FIELD_MASK = ",".join(
@@ -176,7 +177,22 @@ def refresh_raw_sources(
         source_url = source.url
         if not source_url:
             raise RuntimeError(f"Configured source {source.slug} is missing a URL.")
-        print(f"Refreshing {source.slug} from {source_url}")
+
+        refresh_reason = (
+            None
+            if force_refresh or bool(selected_sources)
+            else raw_source_refresh_reason(source, existing_payload)
+        )
+        if not force_refresh and not bool(selected_sources) and refresh_reason is None:
+            print(f"Skipping {source.slug} (raw snapshot fresh)")
+            continue
+
+        if force_refresh:
+            print(f"Refreshing {source.slug} from {source_url} (forced)")
+        elif selected_sources:
+            print(f"Refreshing {source.slug} from {source_url} (selected)")
+        else:
+            print(f"Refreshing {source.slug} from {source_url} ({refresh_reason})")
         refresh_jobs.append((source, raw_path))
 
     if not refresh_jobs:
@@ -809,11 +825,68 @@ def raw_source_signature(source: SourceConfig) -> str:
 def stamp_raw_saved_list(payload: RawSavedList, source: SourceConfig, *, source_signature: str) -> None:
     fetched_at = datetime.now(UTC)
     payload.fetched_at = fetched_at.isoformat()
-    payload.refresh_after = None
+    payload.refresh_after = (fetched_at + RAW_SOURCE_CACHE_TTL).isoformat()
     payload.source_signature = source_signature
     payload.configured_source_type = source.type
     payload.configured_source_url = source.url
     payload.configured_source_path = source.path
+
+
+def raw_source_refresh_reason(source: SourceConfig, existing_payload: RawSavedList | None) -> str | None:
+    if existing_payload is None:
+        return "missing-raw-snapshot"
+
+    if not raw_source_signature_matches(source, existing_payload.source_signature):
+        return "source-config-changed"
+
+    if existing_payload.refresh_after:
+        try:
+            refresh_after_dt = parse_metadata_datetime(existing_payload.refresh_after)
+        except ValueError:
+            return "invalid-refresh-after"
+        if datetime.now(UTC) >= refresh_after_dt:
+            return "refresh-window-expired"
+        return None
+
+    if existing_payload.fetched_at:
+        try:
+            fetched_at_dt = parse_metadata_datetime(existing_payload.fetched_at)
+        except ValueError:
+            return "invalid-fetched-at"
+        if datetime.now(UTC) - fetched_at_dt >= RAW_SOURCE_CACHE_TTL:
+            return "legacy-refresh-window-expired"
+        return None
+
+    return "missing-refresh-metadata"
+
+
+def parse_metadata_datetime(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def raw_source_signature_matches(source: SourceConfig, signature: str | None) -> bool:
+    return signature in raw_source_signature_candidates(source)
+
+
+def raw_source_signature_candidates(source: SourceConfig) -> set[str]:
+    signatures = {raw_source_signature(source)}
+    if source.type == "google_list_url":
+        signatures.add(legacy_google_list_source_signature(source))
+    return signatures
+
+
+def legacy_google_list_source_signature(source: SourceConfig) -> str:
+    payload = {
+        "slug": source.slug,
+        "url": source.url,
+        "title": source.title,
+        "refresh_days": RAW_SOURCE_CACHE_TTL.days,
+    }
+    serialized = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
 def resolve_refresh_sources(sources: list[SourceConfig], selectors: list[str]) -> list[SourceConfig]:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import unittest
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -194,6 +195,120 @@ class BuildDataTests(unittest.TestCase):
         selected_sources = build_data.resolve_refresh_sources(sources, ["data/raw/alishan-taiwan.csv"])
 
         self.assertEqual([source.slug for source in selected_sources], ["alishan-taiwan"])
+
+    def test_raw_source_refresh_reason_respects_future_refresh_after(self) -> None:
+        source = SourceConfig(
+            slug="tokyo-japan",
+            type="google_list_url",
+            url="https://maps.app.goo.gl/tokyo",
+        )
+        saved_list = RawSavedList(
+            fetched_at=datetime.now(UTC).isoformat(),
+            refresh_after=(datetime.now(UTC) + timedelta(days=1)).isoformat(),
+            source_signature=build_data.raw_source_signature(source),
+        )
+
+        self.assertIsNone(build_data.raw_source_refresh_reason(source, saved_list))
+
+    def test_raw_source_refresh_reason_detects_config_change_despite_future_refresh_after(self) -> None:
+        source = SourceConfig(
+            slug="tokyo-japan",
+            type="google_list_url",
+            url="https://maps.app.goo.gl/tokyo",
+        )
+        saved_list = RawSavedList(
+            fetched_at=datetime.now(UTC).isoformat(),
+            refresh_after=(datetime.now(UTC) + timedelta(days=1)).isoformat(),
+            source_signature="old-signature",
+        )
+
+        self.assertEqual(build_data.raw_source_refresh_reason(source, saved_list), "source-config-changed")
+
+    def test_raw_source_refresh_reason_accepts_legacy_url_source_signature(self) -> None:
+        source = SourceConfig(
+            slug="tokyo-japan",
+            type="google_list_url",
+            url="https://maps.app.goo.gl/tokyo",
+        )
+        saved_list = RawSavedList(
+            fetched_at=datetime.now(UTC).isoformat(),
+            refresh_after=(datetime.now(UTC) + timedelta(days=1)).isoformat(),
+            source_signature=build_data.legacy_google_list_source_signature(source),
+        )
+
+        self.assertIsNone(build_data.raw_source_refresh_reason(source, saved_list))
+
+    def test_refresh_raw_sources_skips_fresh_url_snapshot(self) -> None:
+        source = SourceConfig(
+            slug="tokyo-japan",
+            type="google_list_url",
+            url="https://maps.app.goo.gl/tokyo",
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            raw_dir = Path(tmpdir)
+            raw_path = raw_dir / "tokyo-japan.json"
+            build_data.write_json(
+                raw_path,
+                RawSavedList(
+                    fetched_at=datetime.now(UTC).isoformat(),
+                    refresh_after=(datetime.now(UTC) + timedelta(days=1)).isoformat(),
+                    source_signature=build_data.raw_source_signature(source),
+                    places=[],
+                ),
+            )
+
+            with (
+                patch.object(build_data, "RAW_DIR", raw_dir),
+                patch.object(build_data, "load_sources", return_value=[source]),
+                patch.object(build_data, "scrape_google_list_url") as scrape,
+            ):
+                build_data.refresh_raw_sources(
+                    headed=False,
+                    force_refresh=False,
+                    refresh_lists=[],
+                    refresh_workers=1,
+                )
+
+        scrape.assert_not_called()
+
+    def test_refresh_raw_sources_force_bypasses_fresh_url_snapshot(self) -> None:
+        source = SourceConfig(
+            slug="tokyo-japan",
+            type="google_list_url",
+            url="https://maps.app.goo.gl/tokyo",
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            raw_dir = Path(tmpdir)
+            raw_path = raw_dir / "tokyo-japan.json"
+            build_data.write_json(
+                raw_path,
+                RawSavedList(
+                    fetched_at=datetime.now(UTC).isoformat(),
+                    refresh_after=(datetime.now(UTC) + timedelta(days=1)).isoformat(),
+                    source_signature=build_data.raw_source_signature(source),
+                    places=[],
+                ),
+            )
+
+            with (
+                patch.object(build_data, "RAW_DIR", raw_dir),
+                patch.object(build_data, "load_sources", return_value=[source]),
+                patch.object(
+                    build_data,
+                    "scrape_google_list_url",
+                    return_value=RawSavedList(title="Fresh", places=[]),
+                ) as scrape,
+            ):
+                build_data.refresh_raw_sources(
+                    headed=False,
+                    force_refresh=True,
+                    refresh_lists=[],
+                    refresh_workers=1,
+                )
+
+        scrape.assert_called_once_with(source, headed=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes raw Google list refreshes so URL-backed snapshots respect fresh `refresh_after` metadata unless forced, selected, expired, missing, or changed by source config.
Restores `refresh_after` stamping for raw snapshots and accepts the legacy URL-source signature format already present in checked-in raw data.
Adds Python regression tests for fresh snapshots, config-change invalidation, legacy signatures, skip behavior, and forced refreshes.
Updates README and AGENTS notes to document the new refresh behavior.

Verification: `bun run test`, `bun run build:data`, `bun run check`, `bun run build`, `bun run refresh:data`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented intelligent caching for URL-based raw data sources with a 14-day refresh window; sources now refresh only when the window expires or configuration changes
  * Raw data snapshots now include refresh metadata for improved cache management

* **Documentation**
  * Updated documentation to reflect new refresh behavior and metadata handling for data sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->