### PR TITLE
Add deterministic worktree dev ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,5 @@
 GOOGLE_PLACES_API_KEY=
+
+# bun run dev derives PORT and WORKTREE_DEV_PORT from the git worktree path.
+WORKTREE_DEV_BASE_PORT=4321
+WORKTREE_DEV_PORT_SPAN=1000

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "packageManager": "bun@1.3.12",
   "scripts": {
-    "dev": "astro dev",
+    "dev": "bun scripts/dev.mjs",
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,91 @@
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  WORKTREE_DEV_PORT_ENV,
+  WORKTREE_DEV_PORT_OFFSET_ENV,
+  WORKTREE_DEV_ROOT_ENV,
+  resolveWorktreeDevPort,
+} from "./worktree_dev_port.mjs";
+
+const PORT_ARG_NAMES = new Set(["--port", "-p"]);
+
+function gitWorktreeRoot() {
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+  });
+
+  if (result.status === 0) {
+    return result.stdout.trim();
+  }
+
+  return process.cwd();
+}
+
+function parseCliPort(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg.startsWith("--port=")) {
+      return arg.slice("--port=".length);
+    }
+
+    if (PORT_ARG_NAMES.has(arg)) {
+      return args[index + 1];
+    }
+  }
+
+  return undefined;
+}
+
+const forwardedArgs = process.argv.slice(2);
+const cliPort = parseCliPort(forwardedArgs);
+const worktreeRoot = gitWorktreeRoot();
+const portConfig = resolveWorktreeDevPort({
+  env:
+    cliPort === undefined
+      ? process.env
+      : { ...process.env, [WORKTREE_DEV_PORT_ENV]: cliPort },
+  worktreeRoot,
+});
+
+const astroArgs = ["dev"];
+if (cliPort === undefined) {
+  astroArgs.push("--port", String(portConfig.port));
+}
+astroArgs.push(...forwardedArgs);
+
+const childEnv = {
+  ...process.env,
+  PORT: String(portConfig.port),
+  [WORKTREE_DEV_PORT_ENV]: String(portConfig.port),
+  [WORKTREE_DEV_PORT_OFFSET_ENV]: String(portConfig.offset),
+  [WORKTREE_DEV_ROOT_ENV]: worktreeRoot,
+};
+
+const astroBin = join(
+  worktreeRoot,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "astro.cmd" : "astro",
+);
+const command = existsSync(astroBin) ? astroBin : "astro";
+const source = portConfig.usingExplicitPort
+  ? "explicit port"
+  : `base ${portConfig.basePort} + offset ${portConfig.offset}`;
+
+console.log(`Starting Astro on port ${portConfig.port} (${source})`);
+
+const child = spawn(command, astroArgs, {
+  env: childEnv,
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -81,6 +81,11 @@ const child = spawn(command, astroArgs, {
   stdio: "inherit",
 });
 
+child.on("error", (error) => {
+  console.error(`Failed to start Astro: ${error.message}`);
+  process.exit(1);
+});
+
 child.on("exit", (code, signal) => {
   if (signal) {
     process.kill(process.pid, signal);

--- a/scripts/worktree_dev_port.mjs
+++ b/scripts/worktree_dev_port.mjs
@@ -55,6 +55,19 @@ export function resolveWorktreeDevPort({ env = process.env, worktreeRoot }) {
     parsePortLike(env[WORKTREE_DEV_PORT_ENV], WORKTREE_DEV_PORT_ENV) ??
     parsePortLike(env.PORT, "PORT");
 
+  const pathKey = worktreePathKey(worktreeRoot);
+  if (explicitPort !== undefined) {
+    const span = DEFAULT_WORKTREE_DEV_PORT_SPAN;
+    return {
+      basePort: DEFAULT_WORKTREE_DEV_BASE_PORT,
+      offset: worktreePortOffset(worktreeRoot, span),
+      pathKey,
+      port: explicitPort,
+      span,
+      usingExplicitPort: true,
+    };
+  }
+
   const basePort =
     parsePortLike(env[WORKTREE_DEV_BASE_PORT_ENV], WORKTREE_DEV_BASE_PORT_ENV) ??
     DEFAULT_WORKTREE_DEV_BASE_PORT;
@@ -74,9 +87,9 @@ export function resolveWorktreeDevPort({ env = process.env, worktreeRoot }) {
   return {
     basePort,
     offset,
-    pathKey: worktreePathKey(worktreeRoot),
+    pathKey,
     port: explicitPort ?? derivedPort,
     span,
-    usingExplicitPort: explicitPort !== undefined,
+    usingExplicitPort: false,
   };
 }

--- a/scripts/worktree_dev_port.mjs
+++ b/scripts/worktree_dev_port.mjs
@@ -1,0 +1,82 @@
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
+
+export const DEFAULT_WORKTREE_DEV_BASE_PORT = 4321;
+export const DEFAULT_WORKTREE_DEV_PORT_SPAN = 1000;
+export const WORKTREE_DEV_BASE_PORT_ENV = "WORKTREE_DEV_BASE_PORT";
+export const WORKTREE_DEV_PORT_ENV = "WORKTREE_DEV_PORT";
+export const WORKTREE_DEV_PORT_OFFSET_ENV = "WORKTREE_DEV_PORT_OFFSET";
+export const WORKTREE_DEV_PORT_SPAN_ENV = "WORKTREE_DEV_PORT_SPAN";
+export const WORKTREE_DEV_ROOT_ENV = "WORKTREE_DEV_ROOT";
+
+const MAX_PORT = 65535;
+
+function parsePortLike(value, name) {
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_PORT) {
+    throw new Error(`${name} must be an integer from 1 to ${MAX_PORT}.`);
+  }
+
+  return parsed;
+}
+
+function parsePositiveInteger(value, name) {
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+
+  return parsed;
+}
+
+export function worktreePathKey(worktreeRoot) {
+  return resolve(worktreeRoot).split(/[\\/]+/).filter(Boolean).join("/");
+}
+
+export function worktreePortOffset(worktreeRoot, span) {
+  const digest = createHash("sha256").update(worktreePathKey(worktreeRoot)).digest();
+  return digest.readUInt32BE(0) % span;
+}
+
+export function resolveWorktreeDevPort({ env = process.env, worktreeRoot }) {
+  if (!worktreeRoot) {
+    throw new Error("worktreeRoot is required to resolve the dev server port.");
+  }
+
+  const explicitPort =
+    parsePortLike(env[WORKTREE_DEV_PORT_ENV], WORKTREE_DEV_PORT_ENV) ??
+    parsePortLike(env.PORT, "PORT");
+
+  const basePort =
+    parsePortLike(env[WORKTREE_DEV_BASE_PORT_ENV], WORKTREE_DEV_BASE_PORT_ENV) ??
+    DEFAULT_WORKTREE_DEV_BASE_PORT;
+  const span =
+    parsePositiveInteger(env[WORKTREE_DEV_PORT_SPAN_ENV], WORKTREE_DEV_PORT_SPAN_ENV) ??
+    DEFAULT_WORKTREE_DEV_PORT_SPAN;
+
+  if (basePort + span - 1 > MAX_PORT) {
+    throw new Error(
+      `${WORKTREE_DEV_BASE_PORT_ENV} + ${WORKTREE_DEV_PORT_SPAN_ENV} - 1 must not exceed ${MAX_PORT}.`,
+    );
+  }
+
+  const offset = worktreePortOffset(worktreeRoot, span);
+  const derivedPort = basePort + offset;
+
+  return {
+    basePort,
+    offset,
+    pathKey: worktreePathKey(worktreeRoot),
+    port: explicitPort ?? derivedPort,
+    span,
+    usingExplicitPort: explicitPort !== undefined,
+  };
+}

--- a/tests/frontend/worktreeDevPort.test.mjs
+++ b/tests/frontend/worktreeDevPort.test.mjs
@@ -55,6 +55,20 @@ describe("worktree dev port", () => {
     expect(config.usingExplicitPort).toBe(true);
   });
 
+  it("does not validate derivation settings when an explicit port is set", () => {
+    const config = resolveWorktreeDevPort({
+      env: {
+        PORT: "6400",
+        WORKTREE_DEV_BASE_PORT: "99999",
+        WORKTREE_DEV_PORT_SPAN: "0",
+      },
+      worktreeRoot: "/repo/epsilon",
+    });
+
+    expect(config.port).toBe(6400);
+    expect(config.usingExplicitPort).toBe(true);
+  });
+
   it("normalizes paths into a filesystem-root-relative key", () => {
     expect(worktreePathKey("/Users/example/project")).toBe("Users/example/project");
   });

--- a/tests/frontend/worktreeDevPort.test.mjs
+++ b/tests/frontend/worktreeDevPort.test.mjs
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_WORKTREE_DEV_BASE_PORT,
+  DEFAULT_WORKTREE_DEV_PORT_SPAN,
+  resolveWorktreeDevPort,
+  worktreePathKey,
+} from "../../scripts/worktree_dev_port.mjs";
+
+describe("worktree dev port", () => {
+  it("derives a stable port from the worktree root path", () => {
+    const first = resolveWorktreeDevPort({ env: {}, worktreeRoot: "/repo/alpha" });
+    const second = resolveWorktreeDevPort({ env: {}, worktreeRoot: "/repo/alpha" });
+
+    expect(second).toEqual(first);
+    expect(first.port).toBeGreaterThanOrEqual(DEFAULT_WORKTREE_DEV_BASE_PORT);
+    expect(first.port).toBeLessThan(
+      DEFAULT_WORKTREE_DEV_BASE_PORT + DEFAULT_WORKTREE_DEV_PORT_SPAN,
+    );
+  });
+
+  it("uses configured base port and span for the deterministic offset", () => {
+    const config = resolveWorktreeDevPort({
+      env: {
+        WORKTREE_DEV_BASE_PORT: "5100",
+        WORKTREE_DEV_PORT_SPAN: "50",
+      },
+      worktreeRoot: "/repo/beta",
+    });
+
+    expect(config.basePort).toBe(5100);
+    expect(config.span).toBe(50);
+    expect(config.port).toBe(5100 + config.offset);
+    expect(config.offset).toBeGreaterThanOrEqual(0);
+    expect(config.offset).toBeLessThan(50);
+  });
+
+  it("lets an explicit worktree port override the derived port", () => {
+    const config = resolveWorktreeDevPort({
+      env: { WORKTREE_DEV_PORT: "6200" },
+      worktreeRoot: "/repo/gamma",
+    });
+
+    expect(config.port).toBe(6200);
+    expect(config.usingExplicitPort).toBe(true);
+  });
+
+  it("uses PORT as a fallback explicit override", () => {
+    const config = resolveWorktreeDevPort({
+      env: { PORT: "6300" },
+      worktreeRoot: "/repo/delta",
+    });
+
+    expect(config.port).toBe(6300);
+    expect(config.usingExplicitPort).toBe(true);
+  });
+
+  it("normalizes paths into a filesystem-root-relative key", () => {
+    expect(worktreePathKey("/Users/example/project")).toBe("Users/example/project");
+  });
+});


### PR DESCRIPTION
## Summary
- Make `bun run dev` start Astro through a wrapper that derives a deterministic port from the git worktree path.
- Export `PORT`, `WORKTREE_DEV_PORT`, `WORKTREE_DEV_PORT_OFFSET`, and `WORKTREE_DEV_ROOT` for the dev process.
- Document the base port/span env knobs and add Vitest coverage for derivation and override behavior.

## Verification
- `bun run test`
- `bun run check`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic automatic port assignment per git worktree to avoid port conflicts; explicit port overrides still supported.

* **Chores**
  * Dev startup now resolves and sets the appropriate port automatically and logs chosen port and source (computed vs explicit).

* **Tests**
  * Added tests to validate port derivation, overrides, and path normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->