### PR TITLE
Improve guide map interactions

### DIFF
--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -8,8 +8,11 @@ if (root) {
   const tagButtons = Array.from(root.querySelectorAll("[data-tag-filter]"));
   const resultsCount = root.querySelector("[data-results-count]");
   const emptyState = root.querySelector("[data-empty-state]");
+  const mapFilterStatus = root.querySelector("[data-map-filter-status]");
+  const mapFilterResetButtons = Array.from(root.querySelectorAll("[data-map-filter-reset]"));
 
   let activeTag = "";
+  let mapFramePlaceIds = null;
 
   const sorters = {
     curated: (left, right) => {
@@ -25,14 +28,23 @@ if (root) {
       || (left.dataset.name || "").localeCompare(right.dataset.name || ""),
   };
 
-  const update = () => {
+  const clearMapFrameFilter = () => {
+    mapFramePlaceIds = null;
+    update("map-reset");
+    root.dispatchEvent(new CustomEvent("guide:map-frame-reset", {
+      bubbles: true,
+    }));
+  };
+
+  const update = (source = "list-filter") => {
     const query = (searchInput?.value || "").trim().toLowerCase();
     const sort = sortSelect?.value || "curated";
 
     const visibleCards = cards.filter((card) => {
       const matchesQuery = !query || (card.dataset.search || "").includes(query);
       const matchesTag = !activeTag || (card.dataset.tags || "").split(" ").includes(activeTag);
-      const visible = matchesQuery && matchesTag;
+      const matchesMapFrame = !mapFramePlaceIds || mapFramePlaceIds.has(card.dataset.placeId || "");
+      const visible = matchesQuery && matchesTag && matchesMapFrame;
       card.hidden = !visible;
       return visible;
     });
@@ -42,23 +54,34 @@ if (root) {
     });
 
     if (resultsCount) {
-      resultsCount.textContent = `${visibleCards.length} place${visibleCards.length === 1 ? "" : "s"}`;
+      const suffix = mapFramePlaceIds ? " in map view" : "";
+      resultsCount.textContent = `${visibleCards.length} place${visibleCards.length === 1 ? "" : "s"}${suffix}`;
     }
 
     if (emptyState) {
       emptyState.dataset.visible = visibleCards.length === 0 ? "true" : "false";
     }
 
+    if (mapFilterStatus) {
+      mapFilterStatus.hidden = !mapFramePlaceIds;
+    }
+
+    mapFilterResetButtons.forEach((button) => {
+      button.hidden = !mapFramePlaceIds;
+    });
+
     root.dispatchEvent(new CustomEvent("guide:places-updated", {
       bubbles: true,
       detail: {
+        source,
+        mapFrameActive: Boolean(mapFramePlaceIds),
         visiblePlaceIds: visibleCards.map((card) => card.dataset.placeId).filter(Boolean),
       },
     }));
   };
 
-  searchInput?.addEventListener("input", update);
-  sortSelect?.addEventListener("change", update);
+  searchInput?.addEventListener("input", () => update());
+  sortSelect?.addEventListener("change", () => update());
   tagButtons.forEach((button) => {
     button.addEventListener("click", () => {
       activeTag = button.dataset.tag || "";
@@ -67,6 +90,18 @@ if (root) {
       });
       update();
     });
+  });
+
+  root.addEventListener("guide:map-frame-filter", (event) => {
+    const visiblePlaceIds = Array.isArray(event.detail?.visiblePlaceIds) ? event.detail.visiblePlaceIds : [];
+    mapFramePlaceIds = new Set(visiblePlaceIds);
+    update("map-frame");
+  });
+
+  root.addEventListener("guide:map-frame-reset-request", clearMapFrameFilter);
+
+  mapFilterResetButtons.forEach((button) => {
+    button.addEventListener("click", clearMapFrameFilter);
   });
 
   const allButton = tagButtons.find((button) => (button.dataset.tag || "") === "");

--- a/public/scripts/home-browser.js
+++ b/public/scripts/home-browser.js
@@ -6,11 +6,100 @@ if (root) {
   const countryButtons = Array.from(root.querySelectorAll("[data-country-filter]"));
   const resultsCount = root.querySelector("[data-home-results-count]");
   const emptyState = root.querySelector("[data-home-empty-state]");
+  const locationButton = root.querySelector("[data-location-target]");
+  const locationStatus = root.querySelector("[data-location-status]");
+  const locationGuideIndex = document.querySelector("[data-location-guide-index]");
 
   let activeCountry = "";
+  let locationMatchCountry = "";
 
   const pluralize = (count, singular, plural = `${singular}s`) =>
     `${count} ${count === 1 ? singular : plural}`;
+
+  const guideLocations = (() => {
+    try {
+      return JSON.parse(locationGuideIndex?.textContent || "[]").filter(
+        (guide) =>
+          guide &&
+          typeof guide.country === "string" &&
+          typeof guide.countryName === "string" &&
+          typeof guide.lat === "number" &&
+          typeof guide.lng === "number",
+      );
+    } catch {
+      return [];
+    }
+  })();
+
+  const setLocationStatus = (message, tone = "") => {
+    if (!locationStatus) {
+      return;
+    }
+
+    locationStatus.textContent = message;
+    locationStatus.dataset.tone = tone;
+  };
+
+  const setLocationButtonBusy = (busy) => {
+    if (!locationButton) {
+      return;
+    }
+
+    locationButton.disabled = busy;
+    locationButton.dataset.busy = busy ? "true" : "false";
+    locationButton.setAttribute("aria-busy", busy ? "true" : "false");
+  };
+
+  const toRadians = (degrees) => (degrees * Math.PI) / 180;
+
+  const distanceInKm = (fromLat, fromLng, toLat, toLng) => {
+    const earthRadiusKm = 6371;
+    const latDelta = toRadians(toLat - fromLat);
+    const lngDelta = toRadians(toLng - fromLng);
+    const fromLatRadians = toRadians(fromLat);
+    const toLatRadians = toRadians(toLat);
+    const a =
+      Math.sin(latDelta / 2) ** 2 +
+      Math.cos(fromLatRadians) * Math.cos(toLatRadians) * Math.sin(lngDelta / 2) ** 2;
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+    return earthRadiusKm * c;
+  };
+
+  const nearestGuideForLocation = (latitude, longitude) =>
+    guideLocations.reduce((nearest, guide) => {
+      const distance = distanceInKm(latitude, longitude, guide.lat, guide.lng);
+
+      if (!nearest || distance < nearest.distance) {
+        return { ...guide, distance };
+      }
+
+      return nearest;
+    }, null);
+
+  const selectCountry = (country, { fromLocation = false, scroll = false } = {}) => {
+    activeCountry = country;
+
+    if (fromLocation) {
+      locationMatchCountry = country;
+      if (searchInput) {
+        searchInput.value = "";
+      }
+    } else {
+      locationMatchCountry = "";
+      setLocationStatus("");
+    }
+
+    update();
+
+    if (scroll) {
+      const button = countryButtons.find((candidate) => (candidate.dataset.country || "") === country);
+      const block = countryBlocks.find((candidate) => (candidate.dataset.country || "") === country);
+
+      button?.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" });
+      block?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  };
 
   const updateCountryButtons = (matchingGuidesByCountry, totalMatchingGuides) => {
     countryButtons.forEach((button) => {
@@ -19,6 +108,7 @@ if (root) {
       const countLabel = button.querySelector(".country-filter-count");
 
       button.dataset.active = country === activeCountry ? "true" : "false";
+      button.dataset.locationMatch = country && country === locationMatchCountry ? "true" : "false";
       button.setAttribute("aria-pressed", country === activeCountry ? "true" : "false");
       button.disabled = Boolean(country) && country !== activeCountry && count === 0;
 
@@ -41,6 +131,7 @@ if (root) {
       const matchingCards = cards.filter((card) => !query || (card.dataset.search || "").includes(query));
       const matchingCardSet = new Set(matchingCards);
 
+      block.dataset.locationMatch = country && country === locationMatchCountry ? "true" : "false";
       matchingGuidesByCountry.set(country, matchingCards.length);
       totalMatchingGuides += matchingCards.length;
 
@@ -82,10 +173,60 @@ if (root) {
 
   countryButtons.forEach((button) => {
     button.addEventListener("click", () => {
-      activeCountry = button.dataset.country || "";
-      update();
+      selectCountry(button.dataset.country || "");
     });
   });
+
+  if (locationButton) {
+    if (!("geolocation" in navigator) || guideLocations.length === 0) {
+      locationButton.disabled = true;
+      setLocationStatus("Location is not available.", "error");
+    } else {
+      locationButton.addEventListener("click", () => {
+        setLocationButtonBusy(true);
+        setLocationStatus("Locating...", "pending");
+
+        navigator.geolocation.getCurrentPosition(
+          (position) => {
+            const nearestGuide = nearestGuideForLocation(
+              position.coords.latitude,
+              position.coords.longitude,
+            );
+
+            setLocationButtonBusy(false);
+
+            if (!nearestGuide) {
+              setLocationStatus("No guide countries have map data.", "error");
+              return;
+            }
+
+            selectCountry(nearestGuide.country, { fromLocation: true, scroll: true });
+            setLocationStatus(`Showing nearby guides in ${nearestGuide.countryName}.`, "success");
+          },
+          (error) => {
+            setLocationButtonBusy(false);
+
+            if (error.code === error.PERMISSION_DENIED) {
+              setLocationStatus("Location permission was not granted.", "error");
+              return;
+            }
+
+            if (error.code === error.TIMEOUT) {
+              setLocationStatus("Location timed out. Try again.", "error");
+              return;
+            }
+
+            setLocationStatus("Could not get your location.", "error");
+          },
+          {
+            enableHighAccuracy: false,
+            maximumAge: 10 * 60 * 1000,
+            timeout: 10000,
+          },
+        );
+      });
+    }
+  }
 
   update();
 }

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -11,6 +11,7 @@ from collections import Counter
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from statistics import median
 from typing import Any
 from urllib.parse import unquote
 from urllib.error import HTTPError, URLError
@@ -36,6 +37,7 @@ NON_OPERATIONAL_CACHE_TTL = timedelta(days=3)
 OPERATIONAL_CACHE_TTL = timedelta(days=14)
 RAW_SOURCE_CACHE_TTL = timedelta(days=14)
 STRONG_MATCH_SCORE = 45
+MAP_PIN_DISTANCE_WARNING_METERS = 200_000.0
 PLACES_TEXT_SEARCH_URL = "https://places.googleapis.com/v1/places:searchText"
 COUNTRY_LOCALITY_ALIASES = (
     "England",
@@ -554,6 +556,8 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
     top_categories = [name for name, _count in category_counter.most_common(4)]
     generated_at = datetime.now(UTC).isoformat()
     visible_places = [place for place in normalized_places if not place.hidden]
+    guide_center = guide_location_center(visible_places)
+    warn_far_map_pins(slug, visible_places, guide_center)
 
     return Guide(
         slug=slug,
@@ -569,6 +573,8 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
         top_categories=top_categories,
         generated_at=generated_at,
         place_count=len(visible_places),
+        center_lat=guide_center[0],
+        center_lng=guide_center[1],
         places=normalized_places,
     )
 
@@ -585,12 +591,93 @@ def summarize_guide(guide: Guide) -> GuideManifest:
         description=guide.description,
         country_name=guide.country_name,
         country_code=guide.country_code,
+        center_lat=guide.center_lat,
+        center_lng=guide.center_lng,
         city_name=guide.city_name,
         list_tags=guide.list_tags,
         place_count=guide.place_count,
         featured_names=featured_names[:3],
         top_categories=guide.top_categories,
     )
+
+
+def guide_location_center(places: list[NormalizedPlace]) -> tuple[float | None, float | None]:
+    coordinates = [
+        (place.lat, place.lng)
+        for place in places
+        if place.lat is not None and place.lng is not None
+    ]
+    if not coordinates:
+        return (None, None)
+
+    inlier_coordinates = guide_location_inliers(coordinates)
+    lat = sum(latitude for latitude, _longitude in inlier_coordinates) / len(inlier_coordinates)
+    lng = sum(longitude for _latitude, longitude in inlier_coordinates) / len(inlier_coordinates)
+    return (lat, lng)
+
+
+def warn_far_map_pins(
+    slug: str,
+    places: list[NormalizedPlace],
+    center: tuple[float | None, float | None],
+) -> None:
+    center_lat, center_lng = center
+    if center_lat is None or center_lng is None:
+        return
+
+    for place in places:
+        if place.lat is None or place.lng is None:
+            continue
+
+        distance_meters = haversine_meters(center_lat, center_lng, place.lat, place.lng)
+        if distance_meters < MAP_PIN_DISTANCE_WARNING_METERS:
+            continue
+
+        print(
+            "WARNING: "
+            f"{slug}:{place.id} map pin for {place.name!r} is "
+            f"{distance_meters / 1000:.0f} km from the guide center; "
+            "check whether it belongs in this city/country."
+        )
+
+
+def guide_location_inliers(coordinates: list[tuple[float, float]]) -> list[tuple[float, float]]:
+    if len(coordinates) < 4:
+        return coordinates
+
+    median_lat = median(latitude for latitude, _longitude in coordinates)
+    median_lng = median(longitude for _latitude, longitude in coordinates)
+    distances = [
+        haversine_meters(median_lat, median_lng, latitude, longitude)
+        for latitude, longitude in coordinates
+    ]
+    sorted_distances = sorted(distances)
+    first_quartile = percentile(sorted_distances, 0.25)
+    third_quartile = percentile(sorted_distances, 0.75)
+    iqr = third_quartile - first_quartile
+    outlier_threshold = max(50_000.0, third_quartile + 3 * iqr)
+
+    inliers = [
+        coordinate
+        for coordinate, distance in zip(coordinates, distances, strict=True)
+        if distance <= outlier_threshold
+    ]
+    return inliers or coordinates
+
+
+def percentile(sorted_values: list[float], fraction: float) -> float:
+    if not sorted_values:
+        raise ValueError("Cannot calculate percentile for an empty list.")
+
+    position = (len(sorted_values) - 1) * fraction
+    lower_index = math.floor(position)
+    upper_index = math.ceil(position)
+    if lower_index == upper_index:
+        return sorted_values[lower_index]
+
+    lower_value = sorted_values[lower_index]
+    upper_value = sorted_values[upper_index]
+    return lower_value + (upper_value - lower_value) * (position - lower_index)
 
 
 def enrich_raw_sources(*, force_refresh: bool) -> None:

--- a/scripts/pipeline_models.py
+++ b/scripts/pipeline_models.py
@@ -190,6 +190,8 @@ class Guide(PipelineModel):
     top_categories: list[str] = Field(default_factory=list)
     generated_at: str
     place_count: int
+    center_lat: float | None = None
+    center_lng: float | None = None
     places: list[NormalizedPlace] = Field(default_factory=list)
 
 
@@ -199,6 +201,8 @@ class GuideManifest(PipelineModel):
     description: str | None = None
     country_name: str
     country_code: str | None = None
+    center_lat: float | None = None
+    center_lng: float | None = None
     city_name: str
     list_tags: list[str] = Field(default_factory=list)
     place_count: int

--- a/src/components/GuideCard.astro
+++ b/src/components/GuideCard.astro
@@ -21,14 +21,46 @@ const guideSearchText = [
   .filter(Boolean)
   .join(" ")
   .toLowerCase();
-const guideDisplayTitle = guide.title.replace(/(?:\s*[\u{1F1E6}-\u{1F1FF}]{2})+$/u, "");
+const countryCodeAliases: Record<string, string[]> = {
+  AE: ["UAE"],
+  GB: ["UK"],
+  KR: ["Korea"],
+  US: ["USA"],
+};
+const countryNameAliases: Record<string, string[]> = {
+  "South Korea": ["Korea"],
+  "United Arab Emirates": ["UAE"],
+  "United Kingdom": ["UK"],
+  "United States": ["USA"],
+};
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const trimCountryFromTitle = (title: string) => {
+  const titleWithoutFlag = title.replace(/(?:\s*[\u{1F1E6}-\u{1F1FF}]{2})+$/u, "").trim();
+  const suffixes = [
+    guide.country_name,
+    ...(countryNameAliases[guide.country_name] ?? []),
+    guide.country_code,
+    ...(guide.country_code ? countryCodeAliases[guide.country_code] ?? [] : []),
+  ]
+    .filter((suffix): suffix is string => Boolean(suffix))
+    .sort((left, right) => right.length - left.length);
+
+  for (const suffix of suffixes) {
+    const trimmed = titleWithoutFlag.replace(new RegExp(`,\\s*${escapeRegExp(suffix)}$`, "i"), "").trim();
+    if (trimmed && trimmed !== titleWithoutFlag) {
+      return trimmed;
+    }
+  }
+
+  return titleWithoutFlag;
+};
+const guideDisplayTitle = trimCountryFromTitle(guide.title);
 ---
 
 <article class="guide-card" data-guide-card data-search={guideSearchText}>
   <a class="guide-card-link" href={`/guides/${guide.slug}/`} aria-label={`Open ${guideDisplayTitle}`}></a>
 
   <div class="section-stack">
-    <p class="eyebrow">{guide.country_name}</p>
     <h3>{guideDisplayTitle}</h3>
     {
       guideDescriptionHtml ? (

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -29,7 +29,7 @@ const mapPlaces = places
 
       <div class="map-actions" data-map-actions>
         <button class="map-control-button" type="button" data-map-frame-filter>Search this area</button>
-        <button class="map-control-button" type="button" data-map-full-area>Full area</button>
+        <button class="map-control-button" type="button" data-map-full-area>Reset Map</button>
         <button
           class="map-icon-button"
           type="button"

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -29,6 +29,7 @@ const mapPlaces = places
 
       <div class="map-actions" data-map-actions>
         <button class="map-control-button" type="button" data-map-frame-filter>Search this area</button>
+        <button class="map-control-button" type="button" data-map-full-area>Full area</button>
         <button
           class="map-icon-button"
           type="button"
@@ -45,7 +46,6 @@ const mapPlaces = places
             <path d="M12 2v3.2M12 18.8V22M2 12h3.2M18.8 12H22" />
           </svg>
         </button>
-        <button class="map-control-button" type="button" data-map-filter-reset hidden>Reset map</button>
       </div>
 
       <div class="guide-map" data-guide-map data-places={JSON.stringify(mapPlaces)} />
@@ -298,6 +298,7 @@ const mapPlaces = places
     const panel = element.closest<HTMLElement>("[data-map-panel]");
     const cards = root ? Array.from(root.querySelectorAll<HTMLElement>("[data-place-card][data-place-id]")) : [];
     const mapFrameButton = panel?.querySelector<HTMLButtonElement>("[data-map-frame-filter]");
+    const mapFullAreaButton = panel?.querySelector<HTMLButtonElement>("[data-map-full-area]");
     const locationButton = panel?.querySelector<HTMLButtonElement>("[data-map-location]");
     const mapResetButtons = root ? Array.from(root.querySelectorAll<HTMLButtonElement>("[data-map-filter-reset]")) : [];
     let currentPlaces = places;
@@ -494,6 +495,23 @@ const mapPlaces = places
       map.setView([currentLocation.lat, currentLocation.lng], 15, { animate: true });
     };
 
+    const resetToFullArea = () => {
+      selectedPlaceId = "";
+      hoveredPlaceId = "";
+      updateActiveMarker(false);
+      if (root) {
+        root.dispatchEvent(
+          new CustomEvent("guide:map-frame-reset-request", {
+            bubbles: true,
+          }),
+        );
+      } else {
+        currentPlaces = places;
+        markers.forEach((marker) => marker.addTo(map));
+        fitPlaces(map, places);
+      }
+    };
+
     places.forEach((place) => {
       const marker = placeCircle(place).addTo(map);
       marker.on("click", () => selectPlace(place.id));
@@ -524,6 +542,7 @@ const mapPlaces = places
     });
 
     mapFrameButton?.addEventListener("click", applyMapFrameFilter);
+    mapFullAreaButton?.addEventListener("click", resetToFullArea);
 
     mapElement.guideMap = map;
     mapElement.guideLocationBounds = locationBoundsForPlaces(places) ?? undefined;

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -27,6 +27,27 @@ const mapPlaces = places
         <span class="map-toggle-icon" aria-hidden="true" />
       </button>
 
+      <div class="map-actions" data-map-actions>
+        <button class="map-control-button" type="button" data-map-frame-filter>Search this area</button>
+        <button
+          class="map-icon-button"
+          type="button"
+          data-map-location
+          data-location-state="checking"
+          aria-label="Center map on current location"
+          aria-disabled="true"
+          aria-busy="true"
+          title="Center map on current location"
+        >
+          <svg aria-hidden="true" viewBox="0 0 24 24">
+            <circle cx="12" cy="12" r="7" />
+            <circle cx="12" cy="12" r="2.4" />
+            <path d="M12 2v3.2M12 18.8V22M2 12h3.2M18.8 12H22" />
+          </svg>
+        </button>
+        <button class="map-control-button" type="button" data-map-filter-reset hidden>Reset map</button>
+      </div>
+
       <div class="guide-map" data-guide-map data-places={JSON.stringify(mapPlaces)} />
 
       <noscript>
@@ -59,16 +80,31 @@ const mapPlaces = places
 
   interface PlacesUpdatedEvent extends CustomEvent {
     detail: {
+      source?: string;
+      mapFrameActive?: boolean;
       visiblePlaceIds: string[];
     };
+  }
+
+  interface GuideLocationBounds {
+    center: L.LatLng;
+    radiusKm: number;
+    maxDistanceKm: number;
   }
 
   interface GuideMapElement extends HTMLElement {
     guideMap?: L.Map;
     guideMapFit?: () => void;
+    guideLocationBounds?: GuideLocationBounds;
   }
 
   const MAP_COLLAPSED_KEY = "favoritePlacesMapCollapsed";
+
+  const DEFAULT_MARKER_COLOR = "#1f1a16";
+  const TOP_PICK_MARKER_COLOR = "#b64d1f";
+  const ACTIVE_MARKER_COLOR = "#c4312d";
+  const LOCATION_PROXIMITY_BUFFER_KM = 25;
+  const LOCATION_PROXIMITY_MULTIPLIER = 1.8;
 
   const escapeHtml = (value: string) =>
     value
@@ -87,15 +123,17 @@ const mapPlaces = places
     `;
   };
 
+  const markerStyle = (place: MapPlace, active = false): L.CircleMarkerOptions => ({
+    radius: active ? (place.topPick ? 11 : 9) : place.topPick ? 8 : 6,
+    color: active ? ACTIVE_MARKER_COLOR : place.topPick ? TOP_PICK_MARKER_COLOR : DEFAULT_MARKER_COLOR,
+    fillColor: active ? ACTIVE_MARKER_COLOR : place.topPick ? TOP_PICK_MARKER_COLOR : "#fffaf1",
+    fillOpacity: active ? 0.96 : place.topPick ? 0.92 : 0.86,
+    opacity: 0.95,
+    weight: active ? 3 : 2,
+  });
+
   const placeCircle = (place: MapPlace) =>
-    L.circleMarker([place.lat, place.lng], {
-      radius: place.topPick ? 8 : 6,
-      color: place.topPick ? "#b64d1f" : "#1f1a16",
-      fillColor: place.topPick ? "#b64d1f" : "#fffaf1",
-      fillOpacity: place.topPick ? 0.92 : 0.86,
-      opacity: 0.95,
-      weight: 2,
-    }).bindPopup(popupHtml(place), {
+    L.circleMarker([place.lat, place.lng], markerStyle(place)).bindPopup(popupHtml(place), {
       className: "guide-map-popup",
       closeButton: false,
     });
@@ -113,6 +151,56 @@ const mapPlaces = places
       padding: [28, 28],
       maxZoom: 15,
     });
+  };
+
+  const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
+
+  const distanceInKm = (fromLat: number, fromLng: number, toLat: number, toLng: number) => {
+    const earthRadiusKm = 6371;
+    const latDelta = toRadians(toLat - fromLat);
+    const lngDelta = toRadians(toLng - fromLng);
+    const fromLatRadians = toRadians(fromLat);
+    const toLatRadians = toRadians(toLat);
+    const a =
+      Math.sin(latDelta / 2) ** 2 +
+      Math.cos(fromLatRadians) * Math.cos(toLatRadians) * Math.sin(lngDelta / 2) ** 2;
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+    return earthRadiusKm * c;
+  };
+
+  const median = (values: number[]) => {
+    const sorted = [...values].sort((left, right) => left - right);
+    const middle = Math.floor(sorted.length / 2);
+
+    if (sorted.length % 2 === 0) {
+      return (sorted[middle - 1] + sorted[middle]) / 2;
+    }
+
+    return sorted[middle];
+  };
+
+  const percentile = (values: number[], percentileValue: number) => {
+    const sorted = [...values].sort((left, right) => left - right);
+    const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * percentileValue) - 1));
+    return sorted[index];
+  };
+
+  const locationBoundsForPlaces = (places: MapPlace[]): GuideLocationBounds | null => {
+    if (places.length === 0) return null;
+
+    const center = L.latLng(
+      median(places.map((place) => place.lat)),
+      median(places.map((place) => place.lng)),
+    );
+    const distances = places.map((place) => distanceInKm(center.lat, center.lng, place.lat, place.lng));
+    const radiusKm = places.length < 8 ? Math.max(...distances) : percentile(distances, 0.95);
+
+    return {
+      center,
+      radiusKm,
+      maxDistanceKm: Math.max(LOCATION_PROXIMITY_BUFFER_KM, radiusKm * LOCATION_PROXIMITY_MULTIPLIER),
+    };
   };
 
   const enableTrackpadPinchZoom = (map: L.Map, element: HTMLElement) => {
@@ -164,8 +252,12 @@ const mapPlaces = places
   const setPanelCollapsed = (panel: HTMLElement, collapsed: boolean, persist = true) => {
     const button = panel.querySelector<HTMLButtonElement>("[data-map-toggle]");
     const mapElement = panel.querySelector<GuideMapElement>("[data-guide-map]");
+    const layout = panel.closest<HTMLElement>("[data-browse-layout]");
 
     panel.dataset.collapsed = collapsed ? "true" : "false";
+    if (layout) {
+      layout.dataset.mapCollapsed = collapsed ? "true" : "false";
+    }
 
     if (button) {
       button.setAttribute("aria-expanded", collapsed ? "false" : "true");
@@ -202,6 +294,12 @@ const mapPlaces = places
 
     element.dataset.initialized = "true";
 
+    const root = element.closest<HTMLElement>("[data-guide-root]");
+    const panel = element.closest<HTMLElement>("[data-map-panel]");
+    const cards = root ? Array.from(root.querySelectorAll<HTMLElement>("[data-place-card][data-place-id]")) : [];
+    const mapFrameButton = panel?.querySelector<HTMLButtonElement>("[data-map-frame-filter]");
+    const locationButton = panel?.querySelector<HTMLButtonElement>("[data-map-location]");
+    const mapResetButtons = root ? Array.from(root.querySelectorAll<HTMLButtonElement>("[data-map-filter-reset]")) : [];
     let currentPlaces = places;
     const mapElement = element as GuideMapElement;
     const map = L.map(mapElement, {
@@ -221,12 +319,218 @@ const mapPlaces = places
     }).addTo(map);
 
     const markers = new Map<string, L.CircleMarker>();
+    const placeById = new Map(places.map((place) => [place.id, place]));
+    let selectedPlaceId = "";
+    let hoveredPlaceId = "";
+    let currentLocation: L.LatLng | null = null;
+
+    const activePlaceId = () => hoveredPlaceId || selectedPlaceId;
+
+    const setCardsActive = (placeId: string) => {
+      cards.forEach((card) => {
+        card.dataset.mapActive = card.dataset.placeId === placeId ? "true" : "false";
+      });
+    };
+
+    const updateActiveMarker = (openPopup = false) => {
+      const placeId = activePlaceId();
+      setCardsActive(placeId);
+
+      markers.forEach((marker, markerPlaceId) => {
+        const place = placeById.get(markerPlaceId);
+        if (!place) return;
+
+        marker.setStyle(markerStyle(place, markerPlaceId === placeId));
+        if (markerPlaceId === placeId && map.hasLayer(marker)) {
+          marker.bringToFront();
+          if (openPopup) {
+            marker.openPopup();
+          }
+        }
+      });
+
+      if (!placeId) {
+        map.closePopup();
+      }
+    };
+
+    const placeIsInSaneView = (place: MapPlace) => {
+      const zoom = map.getZoom();
+      return map.getBounds().pad(-0.08).contains(L.latLng(place.lat, place.lng)) && zoom >= 13 && zoom <= 17;
+    };
+
+    const showPlace = (
+      placeId: string,
+      { ensureVisible = false, expandCollapsed = false, openPopup = true } = {},
+    ) => {
+      const place = placeById.get(placeId);
+      const marker = markers.get(placeId);
+      if (!place || !marker) return;
+
+      if (expandCollapsed && panel?.dataset.collapsed === "true") {
+        setPanelCollapsed(panel, false);
+        window.setTimeout(() => {
+          showPlace(placeId, { ensureVisible, openPopup });
+        }, 220);
+        return;
+      }
+
+      updateActiveMarker(false);
+
+      if (ensureVisible && !placeIsInSaneView(place)) {
+        const zoom = map.getZoom();
+        const nextZoom = zoom < 13 ? 15 : Math.min(zoom, 17);
+        map.setView([place.lat, place.lng], nextZoom, { animate: true });
+        window.setTimeout(() => {
+          if (map.hasLayer(marker) && openPopup) marker.openPopup();
+        }, 180);
+        return;
+      }
+
+      if (map.hasLayer(marker) && openPopup) {
+        marker.openPopup();
+      }
+    };
+
+    const selectPlace = (placeId: string, expandCollapsed = false) => {
+      hoveredPlaceId = "";
+      selectedPlaceId = placeId;
+      showPlace(placeId, { ensureVisible: true, expandCollapsed });
+    };
+
+    const hoverPlace = (placeId: string) => {
+      hoveredPlaceId = placeId;
+      showPlace(placeId, { openPopup: panel?.dataset.collapsed !== "true" });
+    };
+
+    const clearHoveredPlace = (placeId: string) => {
+      if (hoveredPlaceId !== placeId) return;
+      hoveredPlaceId = "";
+      updateActiveMarker(Boolean(selectedPlaceId));
+    };
+
+    const updateMapFrameControls = (active: boolean) => {
+      mapResetButtons.forEach((button) => {
+        button.hidden = !active;
+      });
+    };
+
+    const applyMapFrameFilter = () => {
+      if (!root) return;
+
+      const bounds = map.getBounds();
+      const visiblePlaceIds = currentPlaces
+        .filter((place) => bounds.contains(L.latLng(place.lat, place.lng)))
+        .map((place) => place.id);
+
+      root.dispatchEvent(
+        new CustomEvent("guide:map-frame-filter", {
+          bubbles: true,
+          detail: { visiblePlaceIds },
+        }),
+      );
+    };
+
+    const setLocationButtonState = (
+      state: "checking" | "near" | "far" | "unavailable",
+      label: string,
+    ) => {
+      if (!locationButton) return;
+
+      locationButton.dataset.locationState = state;
+      locationButton.dataset.busy = state === "checking" ? "true" : "false";
+      locationButton.title = label;
+      locationButton.setAttribute("aria-label", label);
+      locationButton.setAttribute("aria-disabled", state === "near" ? "false" : "true");
+      locationButton.setAttribute("aria-busy", state === "checking" ? "true" : "false");
+    };
+
+    const locationIsNearGuide = (location: L.LatLng) => {
+      const guideLocationBounds = mapElement.guideLocationBounds;
+      if (!guideLocationBounds) return false;
+
+      const distanceFromGuideCenter = distanceInKm(
+        location.lat,
+        location.lng,
+        guideLocationBounds.center.lat,
+        guideLocationBounds.center.lng,
+      );
+
+      return distanceFromGuideCenter <= guideLocationBounds.maxDistanceKm;
+    };
+
+    const updateLocationFromPosition = (position: GeolocationPosition) => {
+      currentLocation = L.latLng(position.coords.latitude, position.coords.longitude);
+
+      if (locationIsNearGuide(currentLocation)) {
+        setLocationButtonState("near", "Center map on current location");
+      } else {
+        setLocationButtonState("far", "Current location is too far from this guide");
+      }
+    };
+
+    const startLocationAvailabilityWatch = () => {
+      if (!locationButton) return;
+
+      if (!navigator.geolocation) {
+        setLocationButtonState("unavailable", "Current location is not available");
+        return;
+      }
+
+      setLocationButtonState("checking", "Checking current location");
+      navigator.geolocation.watchPosition(
+        updateLocationFromPosition,
+        () => setLocationButtonState("unavailable", "Current location is not available"),
+        {
+          enableHighAccuracy: true,
+          maximumAge: 60_000,
+          timeout: 8_000,
+        },
+      );
+    };
+
+    const centerOnCurrentLocation = () => {
+      if (!currentLocation || !locationIsNearGuide(currentLocation)) return;
+      map.setView([currentLocation.lat, currentLocation.lng], 15, { animate: true });
+    };
+
     places.forEach((place) => {
       const marker = placeCircle(place).addTo(map);
+      marker.on("click", () => selectPlace(place.id));
       markers.set(place.id, marker);
     });
 
+    cards.forEach((card) => {
+      if (card.dataset.mapInteractionInitialized === "true") return;
+      card.dataset.mapInteractionInitialized = "true";
+
+      const placeId = card.dataset.placeId || "";
+      card.addEventListener("pointerenter", () => hoverPlace(placeId));
+      card.addEventListener("pointerleave", () => clearHoveredPlace(placeId));
+      card.addEventListener("focus", () => hoverPlace(placeId));
+      card.addEventListener("blur", () => clearHoveredPlace(placeId));
+      card.addEventListener("click", (event) => {
+        const target = event.target instanceof Element ? event.target : null;
+        if (target?.closest("a, button, input, select, textarea, [role='button']")) return;
+        selectPlace(placeId, true);
+      });
+      card.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        const target = event.target instanceof Element ? event.target : null;
+        if (target?.closest("a, button, input, select, textarea, [role='button']")) return;
+        event.preventDefault();
+        selectPlace(placeId, true);
+      });
+    });
+
+    mapFrameButton?.addEventListener("click", applyMapFrameFilter);
+
     mapElement.guideMap = map;
+    mapElement.guideLocationBounds = locationBoundsForPlaces(places) ?? undefined;
+    if (locationButton) {
+      locationButton.addEventListener("click", centerOnCurrentLocation);
+      startLocationAvailabilityWatch();
+    }
     mapElement.guideMapFit = () => {
       map.invalidateSize();
       fitPlaces(map, currentPlaces);
@@ -239,6 +543,7 @@ const mapPlaces = places
       const visiblePlaceIds = new Set(event.detail.visiblePlaceIds);
       const visiblePlaces = places.filter((place) => visiblePlaceIds.has(place.id));
       currentPlaces = visiblePlaces;
+      updateMapFrameControls(Boolean(event.detail.mapFrameActive));
 
       markers.forEach((marker, placeId) => {
         if (visiblePlaceIds.has(placeId)) {
@@ -248,7 +553,11 @@ const mapPlaces = places
         }
       });
 
-      fitPlaces(map, currentPlaces);
+      updateActiveMarker(false);
+
+      if (!event.detail.mapFrameActive) {
+        fitPlaces(map, currentPlaces);
+      }
     }) as EventListener);
   };
 

--- a/src/components/PlaceCard.astro
+++ b/src/components/PlaceCard.astro
@@ -15,6 +15,7 @@ const noteHtml = renderRichText(place.note);
 
 <article
   class="place-card"
+  tabindex="0"
   data-place-card
   data-place-id={place.id}
   data-name={place.name.toLowerCase()}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -45,6 +45,8 @@ function summarizeGuide(guide: Guide): GuideManifest {
     description: guide.description,
     country_name: getDisplayCountryName(guide),
     country_code: guide.country_code,
+    center_lat: guide.center_lat ?? null,
+    center_lng: guide.center_lng ?? null,
     city_name: guide.city_name,
     list_tags: guide.list_tags,
     place_count: guide.place_count,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -34,6 +34,8 @@ export interface Guide {
   top_categories: string[];
   generated_at: string;
   place_count: number;
+  center_lat: number | null;
+  center_lng: number | null;
   places: Place[];
 }
 
@@ -43,6 +45,8 @@ export interface GuideManifest {
   description: string | null;
   country_name: string;
   country_code: string | null;
+  center_lat: number | null;
+  center_lng: number | null;
   city_name: string;
   list_tags: string[];
   place_count: number;

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -86,7 +86,7 @@ const guideDescriptionHtml = renderRichText(guide.description);
       <p class="small-copy">Search names, notes, neighborhoods, or address text.</p>
     </div>
 
-    <div class="browse-layout">
+    <div class="browse-layout" data-browse-layout>
       <div class="browse-main">
         <div class="controls-panel">
           <div class="controls-grid" data-guide-controls>
@@ -128,7 +128,11 @@ const guideDescriptionHtml = renderRichText(guide.description);
           </div>
         </div>
 
-        <p class="small-copy" data-results-count>{visiblePlaces.length} places</p>
+        <div class="results-row">
+          <p class="small-copy" data-results-count>{visiblePlaces.length} places</p>
+          <button class="map-filter-reset" type="button" data-map-filter-reset hidden>Reset map</button>
+        </div>
+        <p class="map-filter-status small-copy" data-map-filter-status hidden>Filtered to the visible map area.</p>
         <div class="empty-state" data-empty-state>No matches. Try a broader search or clear the tag filter.</div>
 
         <div class="card-grid" data-kind="places" data-place-list>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -33,6 +33,17 @@ const guidesByCountry = countryEntries.map(([countryName, countryGuides]) => ({
   countryName,
   countryFlag: getCountryFlag(countryGuides),
 }));
+const locationGuideCandidates = guides
+  .filter((guide) => typeof guide.center_lat === "number" && typeof guide.center_lng === "number")
+  .map((guide) => ({
+    slug: guide.slug,
+    title: guide.title,
+    country: guide.country_name.toLowerCase(),
+    countryName: guide.country_name,
+    lat: guide.center_lat,
+    lng: guide.center_lng,
+  }));
+const locationGuideJson = JSON.stringify(locationGuideCandidates).replace(/</g, "\\u003c");
 const countryCount = guidesByCountry.length;
 const placeCount = guides.reduce((count, guide) => count + guide.place_count, 0);
 ---
@@ -94,6 +105,32 @@ const placeCount = guides.reduce((count, guide) => count + guide.place_count, 0)
           </p>
         </div>
 
+        <div class="control-group location-control-group">
+          <span class="control-label">Near me</span>
+          <div class="location-control-row">
+            <button
+              class="location-target-button"
+              type="button"
+              data-location-target
+              aria-label="Show nearby country"
+              title="Show nearby country"
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24" width="20" height="20">
+                <circle cx="12" cy="12" r="6.5" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                <circle cx="12" cy="12" r="2" fill="currentColor"></circle>
+                <path
+                  d="M12 2v3M12 19v3M2 12h3M19 12h3"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-width="2"
+                ></path>
+              </svg>
+            </button>
+            <p class="location-status" data-location-status role="status" aria-live="polite"></p>
+          </div>
+        </div>
+
         <div class="control-group country-filter-group">
           <span class="control-label">Countries</span>
           <div class="country-filter-list" data-country-filter-list>
@@ -144,5 +181,6 @@ const placeCount = guides.reduce((count, guide) => count + guide.place_count, 0)
     ))}
   </section>
 
+  <script is:inline type="application/json" data-location-guide-index set:html={locationGuideJson}></script>
   <script is:inline type="module" src="/scripts/home-browser.js"></script>
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -45,6 +45,10 @@ img {
   display: block;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 .site-header {
   width: min(calc(100% - 1rem), var(--page-width));
   margin: 0 auto;
@@ -211,6 +215,10 @@ img {
   margin-top: 2rem;
 }
 
+.country-block {
+  scroll-margin-top: 8rem;
+}
+
 .country-browser {
   margin-bottom: 1rem;
 }
@@ -270,6 +278,11 @@ img {
   color: var(--surface);
 }
 
+.country-filter[data-location-match="true"] {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(196, 49, 45, 0.18);
+}
+
 .country-filter:disabled {
   cursor: not-allowed;
   opacity: 0.48;
@@ -303,6 +316,10 @@ img {
 .browse-main {
   display: grid;
   gap: 1rem;
+}
+
+.browse-layout {
+  min-width: 0;
 }
 
 .guide-card,
@@ -391,11 +408,32 @@ img {
   padding: 1.1rem;
   display: grid;
   gap: 0.9rem;
+  cursor: pointer;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    box-shadow 160ms ease;
 }
 
 .place-card[data-top-pick="true"] {
   background: #fffafa;
   border-color: rgba(255, 112, 108, 0.4);
+}
+
+.place-card:hover,
+.place-card:focus-visible,
+.place-card[data-map-active="true"] {
+  border-color: var(--accent);
+  background: #fffdfd;
+}
+
+.place-card:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.place-card[data-map-active="true"] {
+  box-shadow: inset 0 0 0 1px var(--accent);
 }
 
 .place-card-title {
@@ -430,6 +468,75 @@ img {
 .controls-grid {
   display: grid;
   gap: 0.9rem;
+}
+
+.location-control-row {
+  min-height: 2.8rem;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.location-target-button {
+  width: 2.8rem;
+  height: 2.8rem;
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--ink);
+  cursor: pointer;
+}
+
+.location-target-button:hover,
+.location-target-button:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.location-target-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.location-target-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
+.location-target-button[data-busy="true"] svg {
+  animation: location-target-spin 900ms linear infinite;
+}
+
+.location-status {
+  min-width: 0;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
+.location-status[data-tone="success"] {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.location-status[data-tone="error"] {
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.country-block[data-location-match="true"] > .section-head {
+  padding-left: 0.85rem;
+  border-left: 4px solid var(--accent);
+}
+
+@keyframes location-target-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .control-group {
@@ -501,6 +608,98 @@ select {
     visibility 160ms ease;
 }
 
+.map-actions {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  z-index: 500;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: end;
+  gap: 0.45rem;
+  max-width: min(24rem, calc(100% - 4rem));
+}
+
+.map-control-button {
+  min-height: 2.2rem;
+  padding: 0 0.65rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--ink);
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.18);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.map-control-button:hover,
+.map-control-button:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.map-control-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.map-control-button:disabled {
+  cursor: progress;
+  opacity: 0.72;
+}
+
+.map-icon-button {
+  width: 2.2rem;
+  height: 2.2rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--ink);
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.18);
+  cursor: pointer;
+}
+
+.map-icon-button svg {
+  width: 1.2rem;
+  height: 1.2rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.map-icon-button:hover,
+.map-icon-button:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.map-icon-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.map-icon-button[aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.44;
+  filter: grayscale(1);
+}
+
+.map-icon-button[data-location-state="checking"] {
+  cursor: progress;
+  opacity: 0.72;
+  filter: none;
+}
+
+.map-icon-button[data-busy="true"] svg {
+  animation: location-target-spin 900ms linear infinite;
+}
+
 .map-toggle {
   position: absolute;
   top: 50%;
@@ -540,7 +739,8 @@ select {
 }
 
 .map-panel[data-collapsed="true"] .guide-map,
-.map-panel[data-collapsed="true"] .map-fallback {
+.map-panel[data-collapsed="true"] .map-fallback,
+.map-panel[data-collapsed="true"] .map-actions {
   visibility: hidden;
   opacity: 0;
   pointer-events: none;
@@ -614,7 +814,48 @@ select {
 }
 
 [data-results-count] {
+  margin: 0;
+}
+
+.results-row {
+  min-height: 2.3rem;
   margin: 1rem 0 0.7rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.map-filter-status {
+  margin: -0.3rem 0 0.7rem;
+  color: var(--accent-strong);
+}
+
+.map-filter-reset {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.2rem;
+  padding: 0 0.72rem;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--accent);
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.map-filter-reset:hover,
+.map-filter-reset:focus-visible {
+  background: var(--accent);
+  color: var(--surface);
+}
+
+.map-filter-reset:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .utility-link {
@@ -636,7 +877,7 @@ select {
   }
 
   .controls-grid {
-    grid-template-columns: minmax(0, 1.7fr) minmax(220px, 0.9fr);
+    grid-template-columns: minmax(0, 1.55fr) minmax(190px, 0.75fr) minmax(230px, 0.8fr);
     align-items: end;
   }
 }
@@ -673,6 +914,11 @@ select {
   .browse-layout {
     grid-template-columns: minmax(0, 1fr) minmax(30rem, 46vw);
     align-items: start;
+    transition: grid-template-columns 180ms ease;
+  }
+
+  .browse-layout[data-map-collapsed="true"] {
+    grid-template-columns: minmax(0, 1fr) 2.75rem;
   }
 
   .map-panel {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -733,6 +733,9 @@ select {
 }
 
 .map-panel[data-collapsed="true"] {
+  border-color: transparent;
+  border-radius: 0;
+  background: transparent;
   height: 3.5rem;
   max-height: 3.5rem;
   min-height: 3.5rem;
@@ -747,12 +750,13 @@ select {
 }
 
 .map-panel[data-collapsed="true"] .map-toggle {
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  border: 0;
+  top: 50%;
+  left: 50%;
+  width: 4.25rem;
+  height: 2.75rem;
+  border: 1px solid var(--line);
   border-radius: var(--radius-lg);
-  transform: none;
+  transform: translate(-50%, -50%);
 }
 
 .map-panel[data-collapsed="true"] .map-toggle-icon {
@@ -932,6 +936,11 @@ select {
     height: calc(100vh - 1rem);
     min-height: 28rem;
     max-height: none;
+  }
+
+  .map-panel[data-collapsed="true"] .map-toggle {
+    width: 2.25rem;
+    height: 4.25rem;
   }
 
   .guide-map {

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -29,6 +29,7 @@ describe("guide map interactions", () => {
     expect(guidePage).toContain("data-map-filter-reset");
     expect(guideMap).toContain("data-map-frame-filter");
     expect(guideMap).toContain("data-map-full-area");
+    expect(guideMap).toContain(">Reset Map</button>");
     expect(guideMap).toContain('new CustomEvent("guide:map-frame-reset-request"');
     expect(guideMap).toContain('new CustomEvent("guide:map-frame-filter"');
     expect(filters).toContain('root.addEventListener("guide:map-frame-filter"');

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -14,6 +14,10 @@ describe("guide map interactions", () => {
     expect(guideMap).toContain("layout.dataset.mapCollapsed");
     expect(css).toContain('.browse-layout[data-map-collapsed="true"]');
     expect(css).toContain("grid-template-columns: minmax(0, 1fr) 2.75rem");
+    expect(css).toContain('.map-panel[data-collapsed="true"] .map-toggle');
+    expect(css).toContain("border-color: transparent");
+    expect(css).toContain("background: transparent");
+    expect(css).not.toContain("inset: 0;\n  width: 100%;\n  height: 100%;");
   });
 
   it("keeps map-frame filtering resettable from both the map and the list", () => {
@@ -24,6 +28,8 @@ describe("guide map interactions", () => {
     expect(guidePage).toContain("data-map-filter-status");
     expect(guidePage).toContain("data-map-filter-reset");
     expect(guideMap).toContain("data-map-frame-filter");
+    expect(guideMap).toContain("data-map-full-area");
+    expect(guideMap).toContain('new CustomEvent("guide:map-frame-reset-request"');
     expect(guideMap).toContain('new CustomEvent("guide:map-frame-filter"');
     expect(filters).toContain('root.addEventListener("guide:map-frame-filter"');
     expect(filters).toContain('root.dispatchEvent(new CustomEvent("guide:map-frame-reset"');

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const readSource = (path) => readFileSync(path, "utf8");
+
+describe("guide map interactions", () => {
+  it("lets the collapsed map panel release width back to the places list", () => {
+    const guidePage = readSource("src/pages/guides/[slug].astro");
+    const guideMap = readSource("src/components/GuideMap.astro");
+    const css = readSource("src/styles/global.css");
+
+    expect(guidePage).toContain('class="browse-layout" data-browse-layout');
+    expect(guideMap).toContain('panel.closest<HTMLElement>("[data-browse-layout]")');
+    expect(guideMap).toContain("layout.dataset.mapCollapsed");
+    expect(css).toContain('.browse-layout[data-map-collapsed="true"]');
+    expect(css).toContain("grid-template-columns: minmax(0, 1fr) 2.75rem");
+  });
+
+  it("keeps map-frame filtering resettable from both the map and the list", () => {
+    const guidePage = readSource("src/pages/guides/[slug].astro");
+    const guideMap = readSource("src/components/GuideMap.astro");
+    const filters = readSource("public/scripts/guide-filters.js");
+
+    expect(guidePage).toContain("data-map-filter-status");
+    expect(guidePage).toContain("data-map-filter-reset");
+    expect(guideMap).toContain("data-map-frame-filter");
+    expect(guideMap).toContain('new CustomEvent("guide:map-frame-filter"');
+    expect(filters).toContain('root.addEventListener("guide:map-frame-filter"');
+    expect(filters).toContain('root.dispatchEvent(new CustomEvent("guide:map-frame-reset"');
+  });
+
+  it("guards the current-location map control with stored guide proximity bounds", () => {
+    const guideMap = readSource("src/components/GuideMap.astro");
+    const css = readSource("src/styles/global.css");
+
+    expect(guideMap).toContain('class="map-icon-button"');
+    expect(guideMap).toContain('data-location-state="checking"');
+    expect(guideMap).toContain('aria-label="Center map on current location"');
+    expect(guideMap).toContain('aria-disabled="true"');
+    expect(guideMap).not.toContain(">Near me</button>");
+    expect(guideMap).toContain("locationBoundsForPlaces");
+    expect(guideMap).toContain("guideLocationBounds");
+    expect(guideMap).toContain("distanceFromGuideCenter <= guideLocationBounds.maxDistanceKm");
+    expect(guideMap).toContain("Current location is too far from this guide");
+    expect(guideMap).toContain("watchPosition");
+    expect(css).toContain(".map-icon-button");
+    expect(css).toContain('.map-icon-button[aria-disabled="true"]');
+    expect(css).toContain('.map-icon-button[data-location-state="checking"]');
+    expect(css).toContain(".map-icon-button[data-busy=\"true\"] svg");
+  });
+});

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -10,7 +10,14 @@ from unittest.mock import patch
 from pydantic import ValidationError
 
 from scripts import build_data
-from scripts.pipeline_models import EnrichmentCacheEntry, EnrichmentPlace, RawPlace, RawSavedList, SourceConfig
+from scripts.pipeline_models import (
+    EnrichmentCacheEntry,
+    EnrichmentPlace,
+    NormalizedPlace,
+    RawPlace,
+    RawSavedList,
+    SourceConfig,
+)
 
 
 class BuildDataTests(unittest.TestCase):
@@ -102,6 +109,8 @@ class BuildDataTests(unittest.TestCase):
                     address="1 Shibuya, Tokyo, Japan",
                     note="Original note",
                     is_favorite=False,
+                    lat=35.65,
+                    lng=139.7,
                     maps_url="https://maps.google.com/?cid=1",
                     cid="111",
                 ),
@@ -110,6 +119,8 @@ class BuildDataTests(unittest.TestCase):
                     address="2 Shinjuku, Tokyo, Japan",
                     note="Best at lunch",
                     is_favorite=True,
+                    lat=35.66,
+                    lng=139.71,
                     maps_url="https://maps.google.com/?cid=2",
                     cid="222",
                 ),
@@ -194,6 +205,8 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(guide.list_tags, ["coffee", "food", "manual-tag"])
         self.assertEqual(guide.place_count, 2)
         self.assertEqual(guide.featured_place_ids, [second_place_id, first_place_id])
+        self.assertAlmostEqual(guide.center_lat or 0, 35.655, places=3)
+        self.assertAlmostEqual(guide.center_lng or 0, 139.705, places=3)
 
         first_place = guide.places[0]
         hidden_place = next(place for place in guide.places if place.id == third_place_id)
@@ -210,6 +223,83 @@ class BuildDataTests(unittest.TestCase):
         self.assertIn("specialty", first_place.tags)
         self.assertIn("tokyo", first_place.tags)
         self.assertTrue(hidden_place.hidden)
+
+    def test_guide_location_center_excludes_far_outliers(self) -> None:
+        places = [
+            NormalizedPlace(
+                id="tokyo-1",
+                name="Tokyo 1",
+                lat=35.66,
+                lng=139.7,
+                maps_url="https://maps.example/tokyo-1",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="tokyo-2",
+                name="Tokyo 2",
+                lat=35.67,
+                lng=139.71,
+                maps_url="https://maps.example/tokyo-2",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="tokyo-3",
+                name="Tokyo 3",
+                lat=35.65,
+                lng=139.69,
+                maps_url="https://maps.example/tokyo-3",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="tokyo-4",
+                name="Tokyo 4",
+                lat=35.68,
+                lng=139.72,
+                maps_url="https://maps.example/tokyo-4",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="bad-import",
+                name="Bad import",
+                lat=48.86,
+                lng=2.35,
+                maps_url="https://maps.example/bad-import",
+                status="active",
+            ),
+        ]
+
+        center_lat, center_lng = build_data.guide_location_center(places)
+
+        self.assertAlmostEqual(center_lat or 0, 35.665, places=3)
+        self.assertAlmostEqual(center_lng or 0, 139.705, places=3)
+
+    def test_warn_far_map_pins_prints_cli_warning_for_distant_places(self) -> None:
+        places = [
+            NormalizedPlace(
+                id="tokyo-1",
+                name="Tokyo 1",
+                lat=35.66,
+                lng=139.7,
+                maps_url="https://maps.example/tokyo-1",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="bad-import",
+                name="Bad import",
+                lat=48.86,
+                lng=2.35,
+                maps_url="https://maps.example/bad-import",
+                status="active",
+            ),
+        ]
+
+        with patch("builtins.print") as print_mock:
+            build_data.warn_far_map_pins("tokyo-japan", places, (35.665, 139.705))
+
+        self.assertEqual(print_mock.call_count, 1)
+        warning = print_mock.call_args.args[0]
+        self.assertIn("WARNING: tokyo-japan:bad-import", warning)
+        self.assertIn("check whether it belongs in this city/country", warning)
 
     def test_country_inference_keeps_monaco_english_with_localized_address_tails(self) -> None:
         raw = RawSavedList(


### PR DESCRIPTION
Adds richer guide map interactions: collapsed map panels now release space back to the list, place cards can highlight/open map pins, and users can filter the list to the current map frame with reset controls.
Adds location-aware guide browsing, including home-page nearby country filtering and a guide-map current-location target that stays disabled when the user is too far from the guide.
Adds generated guide center metadata plus build-time warnings for map pins that are 200km or more from a guide center.
Verification: bun run test, bun run check, and bun run build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Search this area" map-frame filtering, map reset, and location-centering controls; embedded "Near me" location index and geolocation handling.

* **Data / Manifest**
  * Guides now include computed geographic center (center_lat/center_lng) and map-pin distance warnings.

* **Accessibility**
  * Place cards are keyboard-focusable (tabindex).

* **UI/UX Improvements**
  * Cleaner guide titles, results header shows map-filter status/reset, improved map-panel collapse and related styles.

* **Tests**
  * New frontend and Python tests covering map interactions and location logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->