### PR TITLE
feat: add client-side place search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ __pycache__/
 .env
 .DS_Store
 src/data/generated/
+public/data/search-index.json
 .gstack/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ This repo deliberately avoids committing generated build artifacts.
 - `data/raw/` may be committed when you want reproducible scraped snapshots in git.
 - `data/cache/google-places/` may be committed when you want reproducible enrichment snapshots in git.
 - `src/data/generated/` is local-only generated site input data.
+- `public/data/search-index.json` is local-only generated browser search data.
 - `src/data/overrides/` is the source-controlled layer for handwritten curation.
 - `scripts/config/list_sources.json` is safe to commit if it only contains public list URLs you are comfortable sharing.
 - In `scripts/config/list_sources.json`, `slug` is required. `type` is inferred for supported Google Maps `url` sources and local CSV `path` sources; explicit `type` is allowed but must match the configured `url` or `path`. Google My Maps URLs are not supported yet. `google_export_csv` sources still require `title`; `title` is optional for Google Maps URL sources as a fallback if the source data cannot recover the real title.
@@ -65,7 +66,7 @@ Refresh one configured raw source by slug, source URL, or source path:
 bun run sync:source -- tokyo-japan
 ```
 
-Build generated JSON from local raw data:
+Build generated JSON and search index data from local raw data:
 
 ```bash
 bun run build:data
@@ -93,6 +94,7 @@ bun run dev
 - Raw place `note` should flow through as the default place note.
 - Raw place `is_favorite` should flow through as the default top-pick signal.
 - Manual `note` and `top_pick` overrides still win.
+- Manual `vibe_tags` overrides win over rule-derived browser search vibe tags.
 - Google Places cache entries now carry `input_signature` and `refresh_after`; invalidation is not a single global TTL anymore.
 - Raw saved-list snapshots now carry `fetched_at`, `refresh_after`, and `source_signature`; URL sources skip network refreshes until the refresh window expires unless the source config changes, while CSV sources can skip rewrites when the input hash is unchanged.
 - Do not reintroduce tracked generated JSON unless the user explicitly asks for fixture-style examples in git.

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ bun run sync:source -- https://maps.app.goo.gl/your-public-list
 bun run sync:source -- data/imports/taipei-taiwan.csv
 ```
 
-Build generated site data from local raw JSON:
+Build generated site data and the static browser search index from local raw JSON:
 
 ```bash
 bun run build:data
 ```
 
-Use this when `data/raw/` is already up to date and you only want to regenerate site inputs.
+Use this when `data/raw/` is already up to date and you only want to regenerate site inputs and search data.
 Configured local CSV sources are auto-imported before rebuild. Public Google Maps URL sources are not refreshed here.
 
 Fill missing or stale Google Places enrichment cache entries, then rebuild:
@@ -246,7 +246,7 @@ enrichment results.
 bun run build:data
 ```
 
-This writes local generated JSON into `src/data/generated/` from the current contents of `data/raw/`.
+This writes local generated JSON into `src/data/generated/` and the client-side search index into `public/data/search-index.json` from the current contents of `data/raw/`.
 Configured local CSV sources are imported into `data/raw/<slug>.json` first when needed.
 
 7. Run the site:

--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -1,3 +1,5 @@
+import { loadSearchIndex, searchPlaces } from "./place-search.js";
+
 const root = document.querySelector("[data-guide-root]");
 
 if (root) {
@@ -10,9 +12,13 @@ if (root) {
   const emptyState = root.querySelector("[data-empty-state]");
   const mapFilterStatus = root.querySelector("[data-map-filter-status]");
   const mapFilterResetButtons = Array.from(root.querySelectorAll("[data-map-filter-reset]"));
+  const guideSlug = root.dataset.guideSlug || "";
+  const initialParams = new URLSearchParams(window.location.search);
 
   let activeTag = "";
   let mapFramePlaceIds = null;
+  let searchIndex = null;
+  let highlightedPlaceId = initialParams.get("place") || "";
 
   const sorters = {
     curated: (left, right) => {
@@ -28,6 +34,13 @@ if (root) {
       || (left.dataset.name || "").localeCompare(right.dataset.name || ""),
   };
 
+  const fallbackMatches = (card, query) => {
+    const tagText = `${card.dataset.tags || ""} ${card.dataset.vibeTags || ""}`;
+    const matchesQuery = !query || (card.dataset.search || "").includes(query);
+    const matchesTag = !activeTag || tagText.split(" ").includes(activeTag);
+    return matchesQuery && matchesTag;
+  };
+
   const clearMapFrameFilter = () => {
     mapFramePlaceIds = null;
     update("map-reset");
@@ -37,19 +50,43 @@ if (root) {
   };
 
   const update = (source = "list-filter") => {
-    const query = (searchInput?.value || "").trim().toLowerCase();
+    const query = (searchInput?.value || "").trim();
+    const normalizedQuery = query.toLowerCase();
     const sort = sortSelect?.value || "curated";
+    const searchState = searchIndex && guideSlug
+      ? searchPlaces(query, {
+        index: searchIndex,
+        scope: "guide",
+        guideSlug,
+        activeFilters: { tag: activeTag },
+      })
+      : null;
+    const searchResultIds = searchState
+      ? new Set(searchState.results.map((result) => result.entry.id))
+      : null;
+    const searchScores = searchState
+      ? new Map(searchState.results.map((result) => [result.entry.id, result.score]))
+      : new Map();
 
     const visibleCards = cards.filter((card) => {
-      const matchesQuery = !query || (card.dataset.search || "").includes(query);
-      const matchesTag = !activeTag || (card.dataset.tags || "").split(" ").includes(activeTag);
+      const matchesSearch = searchResultIds
+        ? searchResultIds.has(card.dataset.placeId || "")
+        : fallbackMatches(card, normalizedQuery);
       const matchesMapFrame = !mapFramePlaceIds || mapFramePlaceIds.has(card.dataset.placeId || "");
-      const visible = matchesQuery && matchesTag && matchesMapFrame;
+      const visible = matchesSearch && matchesMapFrame;
       card.hidden = !visible;
+      card.dataset.searchHighlight = highlightedPlaceId && card.dataset.placeId === highlightedPlaceId ? "true" : "false";
       return visible;
     });
 
-    visibleCards.sort(sorters[sort] || sorters.curated).forEach((card) => {
+    const sorter = normalizedQuery && sort === "curated" && searchResultIds
+      ? (left, right) =>
+        (searchScores.get(right.dataset.placeId || "") || 0)
+          - (searchScores.get(left.dataset.placeId || "") || 0)
+        || sorters.curated(left, right)
+      : sorters[sort] || sorters.curated;
+
+    visibleCards.sort(sorter).forEach((card) => {
       list?.appendChild(card);
     });
 
@@ -60,6 +97,9 @@ if (root) {
 
     if (emptyState) {
       emptyState.dataset.visible = visibleCards.length === 0 ? "true" : "false";
+      emptyState.textContent = query
+        ? `No places matched "${query}" in this guide. Try a broader search or clear filters.`
+        : "No matches. Try a broader search or clear the tag filter.";
     }
 
     if (mapFilterStatus) {
@@ -104,9 +144,40 @@ if (root) {
     button.addEventListener("click", clearMapFrameFilter);
   });
 
+  const applyDeepLink = () => {
+    const initialQuery = initialParams.get("q") || "";
+    if (initialQuery && searchInput) {
+      searchInput.value = initialQuery;
+    }
+  };
+
+  const scrollToHighlightedPlace = () => {
+    if (!highlightedPlaceId) {
+      return;
+    }
+    const target = cards.find((card) => card.dataset.placeId === highlightedPlaceId);
+    if (!target) {
+      return;
+    }
+    target.scrollIntoView({ behavior: "smooth", block: "center" });
+    target.focus({ preventScroll: true });
+  };
+
   const allButton = tagButtons.find((button) => (button.dataset.tag || "") === "");
   if (allButton) {
     allButton.dataset.active = "true";
   }
+  applyDeepLink();
   update();
+
+  loadSearchIndex()
+    .then((index) => {
+      searchIndex = index;
+      update();
+      requestAnimationFrame(scrollToHighlightedPlace);
+    })
+    .catch(() => {
+      update();
+      requestAnimationFrame(scrollToHighlightedPlace);
+    });
 }

--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -8,6 +8,7 @@ if (root) {
   const searchInput = root.querySelector("[data-search-input]");
   const sortSelect = root.querySelector("[data-sort-select]");
   const tagButtons = Array.from(root.querySelectorAll("[data-tag-filter]"));
+  const areaButtons = Array.from(root.querySelectorAll("[data-area-filter]"));
   const resultsCount = root.querySelector("[data-results-count]");
   const emptyState = root.querySelector("[data-empty-state]");
   const mapFilterStatus = root.querySelector("[data-map-filter-status]");
@@ -16,6 +17,7 @@ if (root) {
   const initialParams = new URLSearchParams(window.location.search);
 
   let activeTag = "";
+  let activeArea = "";
   let mapFramePlaceIds = null;
   let searchIndex = null;
   let highlightedPlaceId = initialParams.get("place") || "";
@@ -72,8 +74,9 @@ if (root) {
       const matchesSearch = searchResultIds
         ? searchResultIds.has(card.dataset.placeId || "")
         : fallbackMatches(card, normalizedQuery);
+      const matchesArea = !activeArea || (card.dataset.neighborhood || "") === activeArea;
       const matchesMapFrame = !mapFramePlaceIds || mapFramePlaceIds.has(card.dataset.placeId || "");
-      const visible = matchesSearch && matchesMapFrame;
+      const visible = matchesSearch && matchesArea && matchesMapFrame;
       card.hidden = !visible;
       card.dataset.searchHighlight = highlightedPlaceId && card.dataset.placeId === highlightedPlaceId ? "true" : "false";
       return visible;
@@ -131,6 +134,15 @@ if (root) {
       update();
     });
   });
+  areaButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      activeArea = button.dataset.area || "";
+      areaButtons.forEach((candidate) => {
+        candidate.dataset.active = candidate === button ? "true" : "false";
+      });
+      update();
+    });
+  });
 
   root.addEventListener("guide:map-frame-filter", (event) => {
     const visiblePlaceIds = Array.isArray(event.detail?.visiblePlaceIds) ? event.detail.visiblePlaceIds : [];
@@ -166,6 +178,10 @@ if (root) {
   const allButton = tagButtons.find((button) => (button.dataset.tag || "") === "");
   if (allButton) {
     allButton.dataset.active = "true";
+  }
+  const allAreaButton = areaButtons.find((button) => (button.dataset.area || "") === "");
+  if (allAreaButton) {
+    allAreaButton.dataset.active = "true";
   }
   applyDeepLink();
   update();

--- a/public/scripts/home-browser.js
+++ b/public/scripts/home-browser.js
@@ -1,3 +1,5 @@
+import { loadSearchIndex, searchGuides, searchPlaces } from "./place-search.js";
+
 const root = document.querySelector("[data-home-browser-root]");
 
 if (root) {
@@ -9,9 +11,16 @@ if (root) {
   const locationButton = root.querySelector("[data-location-target]");
   const locationStatus = root.querySelector("[data-location-status]");
   const locationGuideIndex = document.querySelector("[data-location-guide-index]");
+  const globalResults = root.querySelector("[data-global-search-results]");
+  const globalResultsTitle = root.querySelector("[data-global-search-title]");
+  const globalResultsSummary = root.querySelector("[data-global-search-summary]");
+  const globalResultsList = root.querySelector("[data-global-search-list]");
+  const globalResultsEmpty = root.querySelector("[data-global-search-empty]");
 
   let activeCountry = "";
   let locationMatchCountry = "";
+  let searchIndex = null;
+  let searchIndexUnavailable = false;
 
   const pluralize = (count, singular, plural = `${singular}s`) =>
     `${count} ${count === 1 ? singular : plural}`;
@@ -120,6 +129,9 @@ if (root) {
 
   const update = () => {
     const query = (searchInput?.value || "").trim().toLowerCase();
+    const guideMatches = searchIndex && query ? new Set(
+      searchGuides(query, { index: searchIndex }).map((result) => result.guide.slug),
+    ) : null;
     const matchingGuidesByCountry = new Map();
     let visibleGuideCount = 0;
     let visibleCountryCount = 0;
@@ -128,7 +140,12 @@ if (root) {
     countryBlocks.forEach((block) => {
       const country = block.dataset.country || "";
       const cards = Array.from(block.querySelectorAll("[data-guide-card]"));
-      const matchingCards = cards.filter((card) => !query || (card.dataset.search || "").includes(query));
+      const matchingCards = cards.filter((card) => {
+        if (!query) {
+          return true;
+        }
+        return (card.dataset.search || "").includes(query) || guideMatches?.has(card.dataset.guideSlug || "");
+      });
       const matchingCardSet = new Set(matchingCards);
 
       block.dataset.locationMatch = country && country === locationMatchCountry ? "true" : "false";
@@ -168,6 +185,108 @@ if (root) {
       emptyState.dataset.visible = visibleGuideCount === 0 ? "true" : "false";
     }
 
+    renderGlobalSearch(query);
+  };
+
+  const renderGlobalSearch = (query) => {
+    if (!globalResults || !globalResultsList || !globalResultsEmpty) {
+      return;
+    }
+
+    globalResults.hidden = !query;
+    if (!query) {
+      globalResultsList.replaceChildren();
+      globalResultsEmpty.dataset.visible = "false";
+      if (globalResultsSummary) {
+        globalResultsSummary.textContent = "";
+      }
+      return;
+    }
+
+    if (searchIndexUnavailable) {
+      globalResultsList.replaceChildren();
+      globalResultsEmpty.dataset.visible = "true";
+      globalResultsEmpty.textContent = "Place search is unavailable. Guide browsing still works.";
+      return;
+    }
+
+    if (!searchIndex) {
+      globalResultsList.replaceChildren();
+      globalResultsEmpty.dataset.visible = "false";
+      if (globalResultsSummary) {
+        globalResultsSummary.textContent = "Loading index...";
+      }
+      return;
+    }
+
+    const state = searchPlaces(query, { index: searchIndex, scope: "all" });
+    const results = state.results.slice(0, 24);
+    globalResultsList.replaceChildren(...results.map((result) => createSearchResultCard(result, query)));
+
+    if (globalResultsTitle) {
+      globalResultsTitle.textContent = `${state.count} matching place${state.count === 1 ? "" : "s"}`;
+    }
+    if (globalResultsSummary) {
+      const parsed = [
+        ...state.parsed.vibes.map((vibe) => vibe.replaceAll("-", " ")),
+        ...state.parsed.categories,
+      ];
+      globalResultsSummary.textContent = parsed.length > 0 ? parsed.join(" · ") : "All guides";
+    }
+    globalResultsEmpty.dataset.visible = state.count === 0 ? "true" : "false";
+    globalResultsEmpty.textContent = "No matching places. Try a broader search.";
+  };
+
+  const createSearchResultCard = (result, query) => {
+    const entry = result.entry;
+    const card = document.createElement("article");
+    card.className = "search-result-card";
+
+    const title = document.createElement("h4");
+    title.textContent = entry.name || "Saved place";
+
+    const meta = document.createElement("p");
+    meta.className = "meta-copy";
+    meta.textContent = [
+      entry.guide_title,
+      [entry.category, entry.neighborhood].filter(Boolean).join(" · "),
+      [entry.city, entry.country].filter(Boolean).join(", "),
+    ].filter(Boolean).join(" · ");
+
+    const copy = document.createElement("p");
+    copy.className = "small-copy";
+    copy.textContent = truncateText(entry.why_recommended || entry.note || "", 180);
+    copy.hidden = !copy.textContent;
+
+    const tags = document.createElement("div");
+    tags.className = "tag-row";
+    [...(entry.vibe_tags || []), ...(entry.tags || [])].slice(0, 5).forEach((tag) => {
+      const pill = document.createElement("span");
+      pill.className = "tag-pill";
+      pill.textContent = tag.includes("-") ? tag.replaceAll("-", " ") : `#${tag}`;
+      tags.appendChild(pill);
+    });
+    tags.hidden = tags.childElementCount === 0;
+
+    const link = document.createElement("a");
+    link.className = "action-pill";
+    const params = new URLSearchParams();
+    params.set("place", entry.id);
+    if (query) {
+      params.set("q", query);
+    }
+    link.href = `/guides/${entry.guide_slug}/?${params.toString()}`;
+    link.textContent = "Open in guide";
+
+    card.append(title, meta, copy, tags, link);
+    return card;
+  };
+
+  const truncateText = (value, maxLength) => {
+    if (!value || value.length <= maxLength) {
+      return value || "";
+    }
+    return `${value.slice(0, maxLength - 1).trim()}...`;
   };
 
   searchInput?.addEventListener("input", update);
@@ -230,4 +349,14 @@ if (root) {
   }
 
   update();
+
+  loadSearchIndex()
+    .then((index) => {
+      searchIndex = index;
+      update();
+    })
+    .catch(() => {
+      searchIndexUnavailable = true;
+      update();
+    });
 }

--- a/public/scripts/home-browser.js
+++ b/public/scripts/home-browser.js
@@ -194,9 +194,13 @@ if (root) {
     }
 
     globalResults.hidden = !query;
+    globalResults.setAttribute("aria-hidden", query ? "false" : "true");
     if (!query) {
       globalResultsList.replaceChildren();
       globalResultsEmpty.dataset.visible = "false";
+      if (globalResultsTitle) {
+        globalResultsTitle.textContent = "Matching places";
+      }
       if (globalResultsSummary) {
         globalResultsSummary.textContent = "";
       }
@@ -207,12 +211,21 @@ if (root) {
       globalResultsList.replaceChildren();
       globalResultsEmpty.dataset.visible = "true";
       globalResultsEmpty.textContent = "Place search is unavailable. Guide browsing still works.";
+      if (globalResultsTitle) {
+        globalResultsTitle.textContent = "Place search unavailable";
+      }
+      if (globalResultsSummary) {
+        globalResultsSummary.textContent = "";
+      }
       return;
     }
 
     if (!searchIndex) {
       globalResultsList.replaceChildren();
       globalResultsEmpty.dataset.visible = "false";
+      if (globalResultsTitle) {
+        globalResultsTitle.textContent = "Loading matching places";
+      }
       if (globalResultsSummary) {
         globalResultsSummary.textContent = "Loading index...";
       }

--- a/public/scripts/place-search.js
+++ b/public/scripts/place-search.js
@@ -70,7 +70,11 @@ export async function loadSearchIndex(url = "/data/search-index.json") {
       }
       return response.json();
     })
-    .then(prepareSearchIndex);
+    .then(prepareSearchIndex)
+    .catch((error) => {
+      cachedIndexPromise = undefined;
+      throw error;
+    });
 
   return cachedIndexPromise;
 }
@@ -111,7 +115,11 @@ export function searchPlaces(query, options = {}) {
     if (options.scope === "guide" && options.guideSlug && entry.guide_slug !== options.guideSlug) {
       return false;
     }
-    if (parsed.guideSlugs.size > 0 && !parsed.guideSlugs.has(entry.guide_slug)) {
+    if (
+      options.scope !== "guide" &&
+      parsed.guideSlugs.size > 0 &&
+      !parsed.guideSlugs.has(entry.guide_slug)
+    ) {
       return false;
     }
     if (
@@ -217,8 +225,8 @@ function parseQuery(query, index, options) {
     }
   }
 
-  if (options.scope === "guide" && options.guideSlug) {
-    guideSlugs.delete(options.guideSlug);
+  if (options.scope === "guide") {
+    guideSlugs.clear();
   }
 
   const unmatchedTerms = tokens.filter((token) => !STOP_WORDS.has(token) && !consumedTokens.has(token));

--- a/public/scripts/place-search.js
+++ b/public/scripts/place-search.js
@@ -60,23 +60,28 @@ const LOCATION_ALIASES = new Map([
   ["tokyo-japan", ["tokyo"]],
 ]);
 
-let cachedIndexPromise;
+const cachedIndexPromises = new Map();
 
 export async function loadSearchIndex(url = "/data/search-index.json") {
-  cachedIndexPromise ??= fetch(url)
-    .then((response) => {
-      if (!response.ok) {
-        throw new Error(`Search index request failed: ${response.status}`);
-      }
-      return response.json();
-    })
-    .then(prepareSearchIndex)
-    .catch((error) => {
-      cachedIndexPromise = undefined;
-      throw error;
-    });
+  if (!cachedIndexPromises.has(url)) {
+    cachedIndexPromises.set(
+      url,
+      fetch(url)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`Search index request failed: ${response.status}`);
+          }
+          return response.json();
+        })
+        .then(prepareSearchIndex)
+        .catch((error) => {
+          cachedIndexPromises.delete(url);
+          throw error;
+        }),
+    );
+  }
 
-  return cachedIndexPromise;
+  return cachedIndexPromises.get(url);
 }
 
 export function prepareSearchIndex(index) {
@@ -141,7 +146,7 @@ export function searchPlaces(query, options = {}) {
   });
 
   const results = scopedEntries
-    .map((entry) => scoreEntry(entry, parsed, options))
+    .map((entry) => scoreEntry(entry, parsed))
     .filter((result) => parsed.tokens.length === 0 || result.score > 0)
     .sort((left, right) => right.score - left.score || curatedSort(left.entry, right.entry));
 
@@ -241,21 +246,13 @@ function parseQuery(query, index, options) {
   };
 }
 
-function scoreEntry(entry, parsed, options) {
+function scoreEntry(entry, parsed) {
   const matchedSignals = [];
   let score = 0;
   const entryTags = normalizedList(entry.tags);
   const entryVibes = normalizedList(entry.vibe_tags);
   const categoryText = normalizeText([entry.category, ...entryTags].join(" "));
-
-  if (options.scope === "guide") {
-    score += 4;
-  }
-
-  if (parsed.guideSlugs.has(entry.guide_slug)) {
-    score += 80;
-    matchedSignals.push("location");
-  }
+  const locationMatched = parsed.guideSlugs.has(entry.guide_slug);
 
   for (const category of parsed.categories) {
     const matchTerms = CATEGORY_MATCH_TERMS.get(category) || [category];
@@ -307,11 +304,20 @@ function scoreEntry(entry, parsed, options) {
     score = 1;
   }
 
-  if (entry.top_pick) {
+  const hasNonLocationIntent =
+    parsed.categories.size > 0 || parsed.vibes.size > 0 || parsed.unmatchedTerms.length > 0;
+  const hasNonLocationMatch = matchedSignals.length > 0;
+  if (locationMatched && (!hasNonLocationIntent || hasNonLocationMatch)) {
+    score += 80;
+    matchedSignals.push("location");
+  }
+
+  const hasMatch = parsed.tokens.length === 0 || matchedSignals.length > 0;
+  if (hasMatch && entry.top_pick) {
     score += 8;
     matchedSignals.push("top-pick");
   }
-  if (Number(entry.manual_rank) > 0) {
+  if (hasMatch && Number(entry.manual_rank) > 0) {
     score += Math.min(8, Number(entry.manual_rank));
   }
 

--- a/public/scripts/place-search.js
+++ b/public/scripts/place-search.js
@@ -1,0 +1,385 @@
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "around",
+  "at",
+  "best",
+  "for",
+  "in",
+  "near",
+  "of",
+  "on",
+  "the",
+  "to",
+  "with",
+]);
+
+const CATEGORY_ALIASES = new Map([
+  ["bar", ["bar", "pub", "cocktail"]],
+  ["cafe", ["cafe", "cafes", "coffee", "coffee shop", "coffee shops", "espresso"]],
+  ["museum", ["museum", "museums", "gallery", "galleries"]],
+  ["restaurant", ["restaurant", "restaurants", "dinner", "lunch", "food", "eat", "eats"]],
+  ["shop", ["shop", "shops", "store", "stores", "shopping"]],
+]);
+
+const CATEGORY_MATCH_TERMS = new Map([
+  ["bar", ["bar", "pub", "cocktail"]],
+  ["cafe", ["cafe", "coffee", "coffee-shop", "coffee shop", "bakery", "tea"]],
+  ["museum", ["museum", "gallery", "art-gallery", "art gallery"]],
+  ["restaurant", ["restaurant", "food", "dining", "eatery"]],
+  ["shop", ["shop", "store", "market"]],
+]);
+
+const VIBE_ALIASES = new Map([
+  ["cheap-eats", ["cheap", "affordable", "budget", "inexpensive", "cheap eats"]],
+  ["cozy", ["cozy", "cosy", "good vibes", "warm", "homey"]],
+  ["date-night", ["date night", "date", "romantic", "special occasion"]],
+  ["design-forward", ["design", "stylish", "beautiful", "aesthetic", "good vibes"]],
+  ["family-friendly", ["family", "kids", "children"]],
+  ["group-friendly", ["group", "friends", "share", "shared"]],
+  ["hidden-gem", ["hidden", "hidden gem", "underrated"]],
+  ["laptop-friendly", ["laptop", "work", "wifi", "wi fi", "outlets"]],
+  ["late-night", ["late night", "late", "nightlife"]],
+  ["lively", ["lively", "buzzy", "fun", "good vibes"]],
+  ["local-favorite", ["local", "local favorite", "regulars", "good vibes"]],
+  ["outdoor-seating", ["outdoor", "patio", "terrace", "outside"]],
+  ["quiet", ["quiet", "calm", "peaceful", "chill"]],
+  ["rainy-day", ["rainy", "rainy day", "indoor", "indoors"]],
+  ["scenic", ["scenic", "view", "views", "waterfront", "rooftop"]],
+  ["slow-afternoon", ["slow", "afternoon", "linger"]],
+  ["solo-friendly", ["solo", "alone", "counter"]],
+  ["splurge", ["splurge", "expensive", "fine dining", "michelin"]],
+  ["touristy-but-worth-it", ["touristy", "worth it", "iconic", "landmark"]],
+]);
+
+const LOCATION_ALIASES = new Map([
+  ["new-york-new-york-usa", ["nyc", "new york city"]],
+  ["san-francisco-california-usa", ["sf", "san fran", "san francisco"]],
+  ["los-angeles-california-usa", ["la", "los angeles"]],
+  ["tokyo-japan", ["tokyo"]],
+]);
+
+let cachedIndexPromise;
+
+export async function loadSearchIndex(url = "/data/search-index.json") {
+  cachedIndexPromise ??= fetch(url)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Search index request failed: ${response.status}`);
+      }
+      return response.json();
+    })
+    .then(prepareSearchIndex);
+
+  return cachedIndexPromise;
+}
+
+export function prepareSearchIndex(index) {
+  const guides = Array.isArray(index?.guides) ? index.guides : [];
+  const entries = Array.isArray(index?.entries) ? index.entries : Array.isArray(index) ? index : [];
+  const normalizedGuides = guides.map((guide) => ({
+    ...guide,
+    _searchText: normalizeText(guide.search_text || guide.title || ""),
+    _aliases: guideAliases(guide),
+  }));
+  const guideBySlug = new Map(normalizedGuides.map((guide) => [guide.slug, guide]));
+  const normalizedEntries = entries.map((entry) => ({
+    ...entry,
+    tags: Array.isArray(entry.tags) ? entry.tags : [],
+    vibe_tags: Array.isArray(entry.vibe_tags) ? entry.vibe_tags : [],
+    _searchText: normalizeText(entry.search_text || ""),
+    _name: normalizeText(entry.name || ""),
+    _category: normalizeText(entry.category || ""),
+    _neighborhood: normalizeText(entry.neighborhood || ""),
+    _guide: guideBySlug.get(entry.guide_slug),
+  }));
+
+  return {
+    ...index,
+    guides: normalizedGuides,
+    entries: normalizedEntries,
+    guideBySlug,
+  };
+}
+
+export function searchPlaces(query, options = {}) {
+  const index = options.index ? prepareSearchIndexOnce(options.index) : prepareSearchIndex({ entries: [] });
+  const parsed = parseQuery(query, index, options);
+  const activeFilters = options.activeFilters || {};
+  const scopedEntries = index.entries.filter((entry) => {
+    if (options.scope === "guide" && options.guideSlug && entry.guide_slug !== options.guideSlug) {
+      return false;
+    }
+    if (parsed.guideSlugs.size > 0 && !parsed.guideSlugs.has(entry.guide_slug)) {
+      return false;
+    }
+    if (
+      activeFilters.tag &&
+      !normalizedList([...entry.tags, ...entry.vibe_tags]).includes(normalizeToken(activeFilters.tag))
+    ) {
+      return false;
+    }
+    if (
+      activeFilters.neighborhood &&
+      normalizeToken(entry.neighborhood || "") !== normalizeToken(activeFilters.neighborhood)
+    ) {
+      return false;
+    }
+    if (activeFilters.topPicksOnly && !entry.top_pick) {
+      return false;
+    }
+    return true;
+  });
+
+  const results = scopedEntries
+    .map((entry) => scoreEntry(entry, parsed, options))
+    .filter((result) => parsed.tokens.length === 0 || result.score > 0)
+    .sort((left, right) => right.score - left.score || curatedSort(left.entry, right.entry));
+
+  return {
+    query,
+    count: results.length,
+    parsed: {
+      categories: [...parsed.categories],
+      guideSlugs: [...parsed.guideSlugs],
+      unmatchedTerms: parsed.unmatchedTerms,
+      vibes: [...parsed.vibes],
+    },
+    results,
+  };
+}
+
+export function searchGuides(query, options = {}) {
+  const index = options.index ? prepareSearchIndexOnce(options.index) : prepareSearchIndex({ guides: [] });
+  const normalizedQuery = normalizeText(query);
+  const tokens = tokenize(normalizedQuery);
+  if (tokens.length === 0) {
+    return [];
+  }
+
+  return index.guides
+    .map((guide) => {
+      let score = 0;
+      const matchedSignals = [];
+      for (const alias of guide._aliases) {
+        if (containsPhrase(normalizedQuery, alias)) {
+          score += alias === normalizeText(guide.title) ? 40 : 28;
+          matchedSignals.push("guide");
+        }
+      }
+      for (const token of tokens) {
+        if (guide._searchText.includes(token)) {
+          score += 3;
+        }
+      }
+      return { guide, matchedSignals: [...new Set(matchedSignals)], score };
+    })
+    .filter((result) => result.score > 0)
+    .sort((left, right) => right.score - left.score || left.guide.title.localeCompare(right.guide.title));
+}
+
+export function normalizeText(value) {
+  return String(value || "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/&/g, " and ")
+    .replace(/['']/g, "")
+    .replace(/[^a-z0-9]+/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function parseQuery(query, index, options) {
+  const normalizedQuery = normalizeText(query);
+  const tokens = tokenize(normalizedQuery);
+  const consumedTokens = new Set();
+  const categories = new Set();
+  const vibes = new Set();
+  const guideSlugs = new Set();
+
+  for (const [category, aliases] of CATEGORY_ALIASES) {
+    if (aliases.some((alias) => consumePhrase(normalizedQuery, alias, consumedTokens))) {
+      categories.add(category);
+    }
+  }
+
+  for (const [vibe, aliases] of VIBE_ALIASES) {
+    if (aliases.some((alias) => consumePhrase(normalizedQuery, alias, consumedTokens))) {
+      vibes.add(vibe);
+    }
+  }
+
+  for (const guide of index.guides) {
+    if (guide._aliases.some((alias) => consumePhrase(normalizedQuery, alias, consumedTokens))) {
+      guideSlugs.add(guide.slug);
+    }
+  }
+
+  if (options.scope === "guide" && options.guideSlug) {
+    guideSlugs.delete(options.guideSlug);
+  }
+
+  const unmatchedTerms = tokens.filter((token) => !STOP_WORDS.has(token) && !consumedTokens.has(token));
+
+  return {
+    categories,
+    guideSlugs,
+    normalizedQuery,
+    tokens,
+    unmatchedTerms,
+    vibes,
+  };
+}
+
+function scoreEntry(entry, parsed, options) {
+  const matchedSignals = [];
+  let score = 0;
+  const entryTags = normalizedList(entry.tags);
+  const entryVibes = normalizedList(entry.vibe_tags);
+  const categoryText = normalizeText([entry.category, ...entryTags].join(" "));
+
+  if (options.scope === "guide") {
+    score += 4;
+  }
+
+  if (parsed.guideSlugs.has(entry.guide_slug)) {
+    score += 80;
+    matchedSignals.push("location");
+  }
+
+  for (const category of parsed.categories) {
+    const matchTerms = CATEGORY_MATCH_TERMS.get(category) || [category];
+    if (matchTerms.some((term) => categoryText.includes(normalizeText(term)))) {
+      score += 38;
+      matchedSignals.push("category");
+    }
+  }
+
+  for (const vibe of parsed.vibes) {
+    if (entryVibes.includes(vibe) || entryTags.includes(vibe)) {
+      score += 34;
+      matchedSignals.push("vibe");
+    }
+  }
+
+  if (parsed.normalizedQuery && entry._name === parsed.normalizedQuery) {
+    score += 55;
+    matchedSignals.push("name");
+  } else if (parsed.normalizedQuery && entry._name.includes(parsed.normalizedQuery)) {
+    score += 30;
+    matchedSignals.push("name");
+  }
+
+  if (parsed.normalizedQuery && entry._neighborhood.includes(parsed.normalizedQuery)) {
+    score += 22;
+    matchedSignals.push("neighborhood");
+  }
+
+  if (parsed.normalizedQuery && entry._searchText.includes(parsed.normalizedQuery)) {
+    score += 18;
+    matchedSignals.push("text");
+  }
+
+  for (const term of parsed.unmatchedTerms) {
+    if (entry._name.includes(term)) {
+      score += 12;
+      matchedSignals.push("name");
+    } else if (entryTags.includes(term) || entryVibes.includes(term) || entry._category.includes(term)) {
+      score += 8;
+      matchedSignals.push("tag");
+    } else if (entry._searchText.includes(term)) {
+      score += 3;
+      matchedSignals.push("text");
+    }
+  }
+
+  if (parsed.tokens.length === 0) {
+    score = 1;
+  }
+
+  if (entry.top_pick) {
+    score += 8;
+    matchedSignals.push("top-pick");
+  }
+  if (Number(entry.manual_rank) > 0) {
+    score += Math.min(8, Number(entry.manual_rank));
+  }
+
+  return {
+    entry,
+    matchedSignals: [...new Set(matchedSignals)],
+    score,
+  };
+}
+
+function guideAliases(guide) {
+  const aliases = new Set([
+    guide.slug,
+    String(guide.slug || "").replaceAll("-", " "),
+    guide.title,
+    guide.city,
+    guide.country,
+    guide.country_code,
+    [guide.city, guide.country].filter(Boolean).join(" "),
+  ]);
+  for (const alias of LOCATION_ALIASES.get(guide.slug) || []) {
+    aliases.add(alias);
+  }
+  return [...aliases].map(normalizeText).filter(Boolean);
+}
+
+function tokenize(value) {
+  return normalizeText(value)
+    .split(" ")
+    .filter((token) => token.length > 0);
+}
+
+function consumePhrase(query, phrase, consumedTokens) {
+  const normalizedPhrase = normalizeText(phrase);
+  if (!containsPhrase(query, normalizedPhrase)) {
+    return false;
+  }
+  for (const token of tokenize(normalizedPhrase)) {
+    consumedTokens.add(token);
+  }
+  return true;
+}
+
+function containsPhrase(query, phrase) {
+  if (!phrase) {
+    return false;
+  }
+  if (phrase.length <= 2) {
+    return new RegExp(`(^|\\s)${escapeRegExp(phrase)}($|\\s)`).test(query);
+  }
+  return new RegExp(`(^|\\s)${escapeRegExp(phrase)}($|\\s)`).test(query);
+}
+
+function normalizedList(values) {
+  return values.map(normalizeToken).filter(Boolean);
+}
+
+function normalizeToken(value) {
+  return normalizeText(value).replaceAll(" ", "-");
+}
+
+function curatedSort(left, right) {
+  const topPickDelta = Number(Boolean(right.top_pick)) - Number(Boolean(left.top_pick));
+  if (topPickDelta !== 0) {
+    return topPickDelta;
+  }
+  return Number(right.manual_rank || 0) - Number(left.manual_rank || 0) || left.name.localeCompare(right.name);
+}
+
+function prepareSearchIndexOnce(index) {
+  if (index?.guideBySlug instanceof Map) {
+    return index;
+  }
+  return prepareSearchIndex(index);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -29,6 +29,7 @@ RAW_DIR = ROOT / "data" / "raw"
 PLACES_CACHE_DIR = ROOT / "data" / "cache" / "google-places"
 GENERATED_DIR = ROOT / "src" / "data" / "generated"
 GENERATED_LISTS_DIR = GENERATED_DIR / "lists"
+PUBLIC_DATA_DIR = ROOT / "public" / "data"
 LIST_OVERRIDES_DIR = ROOT / "src" / "data" / "overrides" / "lists"
 PLACE_OVERRIDES_DIR = ROOT / "src" / "data" / "overrides" / "places"
 DEFAULT_REFRESH_WORKERS = 4
@@ -76,6 +77,213 @@ PLACES_FIELD_MASK = ",".join(
         "places.businessStatus",
     ]
 )
+VIBE_TAG_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "cozy": (
+        "cozy",
+        "cosy",
+        "warm",
+        "intimate",
+        "comfort",
+        "homey",
+        "home-y",
+        "fireside",
+    ),
+    "quiet": (
+        "quiet",
+        "calm",
+        "peaceful",
+        "serene",
+        "relaxing",
+        "chill",
+        "low-key",
+        "low key",
+        "library",
+    ),
+    "lively": (
+        "lively",
+        "buzzy",
+        "busy",
+        "fun",
+        "energetic",
+        "scene",
+        "nightlife",
+        "live music",
+    ),
+    "date-night": (
+        "date night",
+        "romantic",
+        "intimate",
+        "cocktail",
+        "wine bar",
+        "special occasion",
+    ),
+    "solo-friendly": (
+        "solo",
+        "counter",
+        "bar seating",
+        "quick bite",
+        "book",
+        "people watching",
+    ),
+    "group-friendly": (
+        "group",
+        "friends",
+        "share",
+        "shared",
+        "family style",
+        "large table",
+    ),
+    "laptop-friendly": (
+        "laptop",
+        "wifi",
+        "wi-fi",
+        "work",
+        "cowork",
+        "outlet",
+        "outlets",
+    ),
+    "scenic": (
+        "view",
+        "views",
+        "scenic",
+        "waterfront",
+        "beach",
+        "mountain",
+        "sunset",
+        "rooftop",
+        "garden",
+        "park",
+    ),
+    "design-forward": (
+        "design",
+        "beautiful",
+        "stylish",
+        "interior",
+        "architecture",
+        "gallery",
+        "aesthetic",
+    ),
+    "local-favorite": (
+        "local favorite",
+        "favorite",
+        "institution",
+        "neighborhood",
+        "beloved",
+        "regulars",
+    ),
+    "classic": (
+        "classic",
+        "old-school",
+        "old school",
+        "historic",
+        "traditional",
+        "since ",
+        "heritage",
+    ),
+    "hidden-gem": (
+        "hidden gem",
+        "hidden",
+        "underrated",
+        "hole in the wall",
+        "off the beaten",
+        "tucked",
+    ),
+    "cheap-eats": (
+        "cheap",
+        "inexpensive",
+        "affordable",
+        "budget",
+        "value",
+        "cash only",
+    ),
+    "splurge": (
+        "splurge",
+        "expensive",
+        "fine dining",
+        "michelin",
+        "omakase",
+        "tasting menu",
+        "luxury",
+    ),
+    "quick-stop": (
+        "quick",
+        "grab",
+        "takeout",
+        "take away",
+        "snack",
+        "bakery",
+        "stand",
+        "stall",
+    ),
+    "slow-afternoon": (
+        "afternoon",
+        "linger",
+        "slow",
+        "tea",
+        "cafe",
+        "coffee",
+        "bookstore",
+    ),
+    "late-night": (
+        "late night",
+        "late-night",
+        "24 hour",
+        "24-hour",
+        "bar",
+        "pub",
+        "izakaya",
+        "night market",
+    ),
+    "outdoor-seating": (
+        "outdoor",
+        "patio",
+        "terrace",
+        "sidewalk",
+        "courtyard",
+        "garden",
+    ),
+    "rainy-day": (
+        "rainy",
+        "rain",
+        "museum",
+        "gallery",
+        "bookstore",
+        "indoor",
+        "indoors",
+    ),
+    "family-friendly": (
+        "family",
+        "kids",
+        "children",
+        "playground",
+        "stroller",
+    ),
+    "touristy-but-worth-it": (
+        "touristy",
+        "worth it",
+        "iconic",
+        "famous",
+        "landmark",
+        "must",
+    ),
+}
+VIBE_CATEGORY_RULES: dict[str, tuple[str, ...]] = {
+    "cafe": ("cozy", "solo-friendly", "slow-afternoon"),
+    "coffee": ("cozy", "solo-friendly", "slow-afternoon"),
+    "coffee_shop": ("cozy", "solo-friendly", "slow-afternoon"),
+    "tea_house": ("quiet", "slow-afternoon"),
+    "bakery": ("quick-stop", "slow-afternoon"),
+    "bar": ("date-night", "late-night", "lively"),
+    "pub": ("group-friendly", "late-night", "lively"),
+    "night_club": ("late-night", "lively"),
+    "restaurant": ("date-night", "group-friendly"),
+    "fine_dining_restaurant": ("date-night", "splurge"),
+    "museum": ("rainy-day", "solo-friendly"),
+    "art_gallery": ("design-forward", "rainy-day"),
+    "book_store": ("quiet", "rainy-day", "solo-friendly"),
+    "park": ("scenic", "family-friendly"),
+    "tourist_attraction": ("touristy-but-worth-it", "scenic"),
+}
 
 try:
     from pipeline_models import (
@@ -418,8 +626,8 @@ def refresh_google_export_csv(
 def rebuild_generated_data() -> None:
     sync_local_csv_sources()
     GENERATED_LISTS_DIR.mkdir(parents=True, exist_ok=True)
+    PUBLIC_DATA_DIR.mkdir(parents=True, exist_ok=True)
     guides: list[Guide] = []
-    search_index: list[dict[str, Any]] = []
 
     for raw_path in sorted(RAW_DIR.glob("*.json")):
         raw = RawSavedList.model_validate_json(raw_path.read_text(encoding="utf-8"))
@@ -428,39 +636,12 @@ def rebuild_generated_data() -> None:
         guides.append(guide)
         write_json(GENERATED_LISTS_DIR / f"{guide.slug}.json", guide)
 
-        for place in guide.places:
-            if place.hidden:
-                continue
-            search_index.append(
-                {
-                    "id": place.id,
-                    "list_slug": guide.slug,
-                    "list_title": guide.title,
-                    "name": place.name,
-                    "tags": place.tags,
-                    "category": place.primary_category,
-                    "neighborhood": place.neighborhood,
-                    "search_text": " ".join(
-                        filter(
-                            None,
-                            [
-                                place.name,
-                                place.address,
-                                place.note,
-                                place.why_recommended,
-                                place.primary_category,
-                                place.neighborhood,
-                                " ".join(place.tags),
-                            ],
-                        )
-                    ).lower(),
-                }
-            )
-
     guides.sort(key=lambda guide: (guide.country_name, guide.city_name, guide.title))
     manifests = [summarize_guide(guide) for guide in guides]
+    search_index = build_search_index(guides)
     write_json(GENERATED_DIR / "manifests.json", manifests)
     write_json(GENERATED_DIR / "search-index.json", search_index)
+    write_json(PUBLIC_DATA_DIR / "search-index.json", search_index, compact=True)
 
 
 def sync_local_csv_sources() -> None:
@@ -627,6 +808,20 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
         top_pick = top_pick_override if top_pick_override is not None else place.is_favorite
         note = as_string(override.get("note")) or place.note
         why_recommended = as_string(override.get("why_recommended"))
+        override_vibe_tags = coerce_string_list(override.get("vibe_tags"))
+        vibe_tags = (
+            sorted({slugify(tag) for tag in override_vibe_tags if slugify(tag)})
+            if override_vibe_tags
+            else derive_vibe_tags(
+                place,
+                enrichment=enrichment,
+                category=primary_category,
+                tags=tags,
+                note=note,
+                why_recommended=why_recommended,
+                top_pick=top_pick,
+            )
+        )
         manual_rank = as_int(override.get("manual_rank")) or 0
         status = (
             as_string(override.get("status"))
@@ -650,6 +845,7 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
             google_place_resource_name=enrichment.google_place_resource_name,
             primary_category=primary_category,
             tags=tags,
+            vibe_tags=vibe_tags,
             neighborhood=neighborhood,
             note=note,
             why_recommended=why_recommended,
@@ -893,6 +1089,157 @@ def derive_place_tags(
     for place_type in enrichment.types[:4]:
         tags.add(slugify(place_type.replace("_", "-")))
     return sorted(tag for tag in tags if tag)
+
+
+def derive_vibe_tags(
+    place: RawPlace,
+    *,
+    enrichment: EnrichmentPlace,
+    category: str | None,
+    tags: list[str],
+    note: str | None,
+    why_recommended: str | None,
+    top_pick: bool,
+) -> list[str]:
+    vibes: set[str] = set()
+    category_terms = [
+        category,
+        enrichment.primary_type,
+        enrichment.primary_type_display_name,
+        *enrichment.types,
+        *tags,
+    ]
+    category_slugs = {slugify(term.replace("_", "-")) for term in category_terms if term}
+
+    for category_slug in category_slugs:
+        if category_slug in VIBE_CATEGORY_RULES:
+            vibes.update(VIBE_CATEGORY_RULES[category_slug])
+
+    lookup_text = normalize_vibe_lookup_text(
+        " ".join(
+            filter(
+                None,
+                [
+                    place.name,
+                    place.address,
+                    place.note,
+                    note,
+                    why_recommended,
+                    category,
+                    enrichment.primary_type,
+                    enrichment.primary_type_display_name,
+                    " ".join(enrichment.types),
+                    " ".join(tags),
+                ],
+            )
+        )
+    )
+    for vibe_tag, keywords in VIBE_TAG_KEYWORDS.items():
+        if any(keyword in lookup_text for keyword in keywords):
+            vibes.add(vibe_tag)
+
+    if top_pick:
+        vibes.add("local-favorite")
+
+    return sorted(vibes)
+
+
+def normalize_vibe_lookup_text(value: str) -> str:
+    return re.sub(r"\s+", " ", value.replace("_", " ").replace("-", " ").lower()).strip()
+
+
+def build_search_index(guides: list[Guide]) -> dict[str, Any]:
+    generated_at = datetime.now(UTC).isoformat()
+    return {
+        "version": 1,
+        "generated_at": generated_at,
+        "guides": [search_index_guide_entry(guide) for guide in guides],
+        "entries": [
+            search_index_place_entry(guide, place)
+            for guide in guides
+            for place in guide.places
+            if not place.hidden
+        ],
+    }
+
+
+def search_index_guide_entry(guide: Guide) -> dict[str, Any]:
+    return {
+        "slug": guide.slug,
+        "title": guide.title,
+        "description": guide.description,
+        "city": guide.city_name,
+        "country": guide.country_name,
+        "country_code": guide.country_code,
+        "tags": guide.list_tags,
+        "place_count": guide.place_count,
+        "top_categories": guide.top_categories,
+        "featured_names": [
+            place.name
+            for place in guide.places
+            if place.id in set(guide.featured_place_ids) and not place.hidden
+        ][:3],
+        "url": f"/guides/{guide.slug}/",
+        "search_text": compact_search_text(
+            [
+                guide.title,
+                guide.description,
+                guide.city_name,
+                guide.country_name,
+                guide.country_code,
+                " ".join(guide.list_tags),
+                " ".join(guide.top_categories),
+            ]
+        ),
+    }
+
+
+def search_index_place_entry(guide: Guide, place: NormalizedPlace) -> dict[str, Any]:
+    return {
+        "id": place.id,
+        "guide_slug": guide.slug,
+        "guide_title": guide.title,
+        "city": guide.city_name,
+        "country": guide.country_name,
+        "country_code": guide.country_code,
+        "name": place.name,
+        "category": place.primary_category,
+        "neighborhood": place.neighborhood,
+        "tags": place.tags,
+        "vibe_tags": place.vibe_tags,
+        "note": place.note,
+        "why_recommended": place.why_recommended,
+        "top_pick": place.top_pick,
+        "manual_rank": place.manual_rank,
+        "maps_url": place.maps_url,
+        "url": f"/guides/{guide.slug}/?place={quote_query_value(place.id)}",
+        "search_text": compact_search_text(
+            [
+                place.name,
+                place.address,
+                place.note,
+                place.why_recommended,
+                place.primary_category,
+                place.neighborhood,
+                " ".join(place.tags),
+                " ".join(place.vibe_tags),
+                guide.title,
+                guide.city_name,
+                guide.country_name,
+                guide.country_code,
+            ]
+        ),
+    }
+
+
+def compact_search_text(parts: list[str | None]) -> str:
+    return re.sub(r"\s+", " ", " ".join(part for part in parts if part).lower()).strip()
+
+
+def quote_query_value(value: str) -> str:
+    from urllib.parse import quote
+
+    return quote(value, safe="")
 
 
 def infer_city_name(title: str) -> str | None:
@@ -1195,14 +1542,18 @@ def load_raw_saved_list(path: Path) -> RawSavedList | None:
     return RawSavedList.model_validate_json(path.read_text(encoding="utf-8"))
 
 
-def write_json(path: Path, payload: Any) -> None:
+def write_json(path: Path, payload: Any, *, compact: bool = False) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     if hasattr(payload, "model_dump"):
         payload = payload.model_dump(mode="json")
     elif isinstance(payload, list):
         payload = [item.model_dump(mode="json") if hasattr(item, "model_dump") else item for item in payload]
     tmp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    tmp_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    if compact:
+        text = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    else:
+        text = json.dumps(payload, indent=2, ensure_ascii=False)
+    tmp_path.write_text(f"{text}\n", encoding="utf-8")
     tmp_path.replace(path)
 
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -270,19 +270,19 @@ VIBE_TAG_KEYWORDS: dict[str, tuple[str, ...]] = {
 VIBE_CATEGORY_RULES: dict[str, tuple[str, ...]] = {
     "cafe": ("cozy", "solo-friendly", "slow-afternoon"),
     "coffee": ("cozy", "solo-friendly", "slow-afternoon"),
-    "coffee_shop": ("cozy", "solo-friendly", "slow-afternoon"),
-    "tea_house": ("quiet", "slow-afternoon"),
+    "coffee-shop": ("cozy", "solo-friendly", "slow-afternoon"),
+    "tea-house": ("quiet", "slow-afternoon"),
     "bakery": ("quick-stop", "slow-afternoon"),
     "bar": ("date-night", "late-night", "lively"),
     "pub": ("group-friendly", "late-night", "lively"),
-    "night_club": ("late-night", "lively"),
+    "night-club": ("late-night", "lively"),
     "restaurant": ("date-night", "group-friendly"),
-    "fine_dining_restaurant": ("date-night", "splurge"),
+    "fine-dining-restaurant": ("date-night", "splurge"),
     "museum": ("rainy-day", "solo-friendly"),
-    "art_gallery": ("design-forward", "rainy-day"),
-    "book_store": ("quiet", "rainy-day", "solo-friendly"),
+    "art-gallery": ("design-forward", "rainy-day"),
+    "book-store": ("quiet", "rainy-day", "solo-friendly"),
     "park": ("scenic", "family-friendly"),
-    "tourist_attraction": ("touristy-but-worth-it", "scenic"),
+    "tourist-attraction": ("touristy-but-worth-it", "scenic"),
 }
 
 try:
@@ -808,11 +808,11 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
         top_pick = top_pick_override if top_pick_override is not None else place.is_favorite
         note = as_string(override.get("note")) or place.note
         why_recommended = as_string(override.get("why_recommended"))
-        override_vibe_tags = coerce_string_list(override.get("vibe_tags"))
-        vibe_tags = (
-            sorted({slugify(tag) for tag in override_vibe_tags if slugify(tag)})
-            if override_vibe_tags
-            else derive_vibe_tags(
+        if "vibe_tags" in override:
+            override_vibe_tags = coerce_string_list(override.get("vibe_tags"))
+            vibe_tags = sorted({slugify(tag) for tag in override_vibe_tags if slugify(tag)})
+        else:
+            vibe_tags = derive_vibe_tags(
                 place,
                 enrichment=enrichment,
                 category=primary_category,
@@ -821,7 +821,6 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
                 why_recommended=why_recommended,
                 top_pick=top_pick,
             )
-        )
         manual_rank = as_int(override.get("manual_rank")) or 0
         status = (
             as_string(override.get("status"))
@@ -1135,7 +1134,7 @@ def derive_vibe_tags(
         )
     )
     for vibe_tag, keywords in VIBE_TAG_KEYWORDS.items():
-        if any(keyword in lookup_text for keyword in keywords):
+        if any(vibe_keyword_matches(lookup_text, keyword) for keyword in keywords):
             vibes.add(vibe_tag)
 
     if top_pick:
@@ -1146,6 +1145,14 @@ def derive_vibe_tags(
 
 def normalize_vibe_lookup_text(value: str) -> str:
     return re.sub(r"\s+", " ", value.replace("_", " ").replace("-", " ").lower()).strip()
+
+
+def vibe_keyword_matches(lookup_text: str, keyword: str) -> bool:
+    normalized_keyword = normalize_vibe_lookup_text(keyword)
+    if not normalized_keyword:
+        return False
+    pattern = r"(?<![a-z0-9])" + re.escape(normalized_keyword).replace(r"\ ", r"\s+") + r"(?![a-z0-9])"
+    return re.search(pattern, lookup_text) is not None
 
 
 def build_search_index(guides: list[Guide]) -> dict[str, Any]:
@@ -1164,6 +1171,7 @@ def build_search_index(guides: list[Guide]) -> dict[str, Any]:
 
 
 def search_index_guide_entry(guide: Guide) -> dict[str, Any]:
+    featured_ids = set(guide.featured_place_ids)
     return {
         "slug": guide.slug,
         "title": guide.title,
@@ -1177,7 +1185,7 @@ def search_index_guide_entry(guide: Guide) -> dict[str, Any]:
         "featured_names": [
             place.name
             for place in guide.places
-            if place.id in set(guide.featured_place_ids) and not place.hidden
+            if place.id in featured_ids and not place.hidden
         ][:3],
         "url": f"/guides/{guide.slug}/",
         "search_text": compact_search_text(

--- a/scripts/pipeline_models.py
+++ b/scripts/pipeline_models.py
@@ -167,6 +167,7 @@ class NormalizedPlace(PipelineModel):
     google_place_resource_name: str | None = None
     primary_category: str | None = None
     tags: list[str] = Field(default_factory=list)
+    vibe_tags: list[str] = Field(default_factory=list)
     neighborhood: str | None = None
     note: str | None = None
     why_recommended: str | None = None

--- a/src/components/GuideCard.astro
+++ b/src/components/GuideCard.astro
@@ -57,7 +57,7 @@ const trimCountryFromTitle = (title: string) => {
 const guideDisplayTitle = trimCountryFromTitle(guide.title);
 ---
 
-<article class="guide-card" data-guide-card data-search={guideSearchText}>
+<article class="guide-card" data-guide-card data-guide-slug={guide.slug} data-search={guideSearchText}>
   <a class="guide-card-link" href={`/guides/${guide.slug}/`} aria-label={`Open ${guideDisplayTitle}`}></a>
 
   <div class="section-stack">

--- a/src/components/PlaceCard.astro
+++ b/src/components/PlaceCard.astro
@@ -9,6 +9,7 @@ interface Props {
 
 const { place } = Astro.props;
 const displayTags = getDisplayPlaceTags(place.tags);
+const displayVibeTags = getDisplayPlaceTags(place.vibe_tags);
 const whyRecommendedHtml = renderRichText(place.why_recommended);
 const noteHtml = renderRichText(place.note);
 ---
@@ -20,6 +21,7 @@ const noteHtml = renderRichText(place.note);
   data-place-id={place.id}
   data-name={place.name.toLowerCase()}
   data-tags={displayTags.join(" ").toLowerCase()}
+  data-vibe-tags={displayVibeTags.join(" ").toLowerCase()}
   data-category={(place.primary_category ?? "").toLowerCase()}
   data-neighborhood={(place.neighborhood ?? "").toLowerCase()}
   data-top-pick={place.top_pick ? "true" : "false"}
@@ -32,6 +34,7 @@ const noteHtml = renderRichText(place.note);
     place.primary_category ?? "",
     place.neighborhood ?? "",
     place.tags.join(" "),
+    place.vibe_tags.join(" "),
   ].join(" ").toLowerCase()}
 >
   <div class="place-card-title">

--- a/src/lib/placeTags.ts
+++ b/src/lib/placeTags.ts
@@ -6,6 +6,28 @@ const ADDRESS_TAG_PATTERNS = [
   /(^|-)(bldg|building|tower|plaza|terrace|floor|mansion|palace|gems|gratteciel)($|-)/,
 ];
 
+const STREET_AREA_PATTERN =
+  /^(p\.|d\.|ng\.|c\/|c\.|carrer\b|rda\.|calle\b|av\b|av\.|jl\.|jalan\b|ngo\b|duong\b)/;
+const DEFAULT_AREA_FILTER_LIMIT = 12;
+
+interface AreaFilterPlace {
+  neighborhood: string | null;
+}
+
+export interface AreaFilter {
+  label: string;
+  value: string;
+  count: number;
+}
+
+function normalizeAreaText(area: string): string {
+  return area
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .toLowerCase();
+}
+
 export function isDisplayPlaceTag(tag: string): boolean {
   const normalizedTag = tag.toLowerCase();
   return !ADDRESS_TAG_PATTERNS.some((pattern) => pattern.test(normalizedTag));
@@ -13,4 +35,35 @@ export function isDisplayPlaceTag(tag: string): boolean {
 
 export function getDisplayPlaceTags(tags: string[]): string[] {
   return tags.filter(isDisplayPlaceTag);
+}
+
+export function getGuideAreaFilters(
+  places: AreaFilterPlace[],
+  { limit = DEFAULT_AREA_FILTER_LIMIT }: { limit?: number } = {},
+): AreaFilter[] {
+  const totalPlaces = places.length;
+  const minimumCount = totalPlaces >= 20 ? 3 : 2;
+  const areaCounts = new Map<string, AreaFilter>();
+
+  places.forEach((place) => {
+    const label = place.neighborhood?.trim();
+    if (!label) return;
+
+    const normalizedValue = normalizeAreaText(label);
+    if (!normalizedValue || STREET_AREA_PATTERN.test(normalizedValue)) return;
+
+    const value = label.toLowerCase();
+    const current = areaCounts.get(value);
+    if (current) {
+      current.count += 1;
+      return;
+    }
+
+    areaCounts.set(value, { label, value, count: 1 });
+  });
+
+  return [...areaCounts.values()]
+    .filter((area) => area.count >= minimumCount && area.count < totalPlaces)
+    .sort((left, right) => right.count - left.count || left.label.localeCompare(right.label))
+    .slice(0, limit);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,7 @@ export interface Place {
   google_place_resource_name: string | null;
   primary_category: string | null;
   tags: string[];
+  vibe_tags: string[];
   neighborhood: string | null;
   note: string | null;
   why_recommended: string | null;

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -4,7 +4,7 @@ import { siteConfig } from "../../data/site";
 import GuideMap from "../../components/GuideMap.astro";
 import PlaceCard from "../../components/PlaceCard.astro";
 import { getGuides } from "../../lib/data";
-import { getDisplayPlaceTags } from "../../lib/placeTags";
+import { getDisplayPlaceTags, getGuideAreaFilters } from "../../lib/placeTags";
 import { renderRichText } from "../../lib/renderRichText";
 
 export function getStaticPaths() {
@@ -18,9 +18,7 @@ const { guide } = Astro.props;
 
 const visiblePlaces = guide.places.filter((place) => !place.hidden);
 const topPicks = visiblePlaces.filter((place) => guide.featured_place_ids.includes(place.id)).slice(0, 3);
-const allTags = [...new Set(visiblePlaces.flatMap((place) => getDisplayPlaceTags(place.tags)))].sort((a, b) =>
-  a.localeCompare(b),
-);
+const areaFilters = getGuideAreaFilters(visiblePlaces);
 const guideVibeFilters = [
   ...new Set(
     visiblePlaces.flatMap((place) =>
@@ -130,16 +128,16 @@ const formatVibeLabel = (tag: string) => tag.replaceAll("-", " ");
               </select>
             </div>
 
-            {allTags.length > 0 && (
+            {areaFilters.length > 0 && (
               <div class="control-group" style="grid-column: 1 / -1;">
-                <span class="control-label">Filter by tag</span>
+                <span class="control-label">Area</span>
                 <div class="tag-row">
-                  <button class="tag-pill" type="button" data-tag-filter data-tag="">
+                  <button class="tag-pill" type="button" data-area-filter data-area="">
                     All
                   </button>
-                  {allTags.map((tag) => (
-                    <button class="tag-pill" type="button" data-tag-filter data-tag={tag.toLowerCase()}>
-                      #{tag}
+                  {areaFilters.map((area) => (
+                    <button class="tag-pill" type="button" data-area-filter data-area={area.value}>
+                      {area.label} ({area.count})
                     </button>
                   ))}
                 </div>
@@ -150,6 +148,9 @@ const formatVibeLabel = (tag: string) => tag.replaceAll("-", " ");
               <div class="control-group" style="grid-column: 1 / -1;">
                 <span class="control-label">Vibe</span>
                 <div class="tag-row">
+                  <button class="tag-pill" type="button" data-tag-filter data-tag="">
+                    All
+                  </button>
                   {guideVibeFilters.map((tag) => (
                     <button class="tag-pill" type="button" data-tag-filter data-tag={tag}>
                       {formatVibeLabel(tag)}

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -21,7 +21,28 @@ const topPicks = visiblePlaces.filter((place) => guide.featured_place_ids.includ
 const allTags = [...new Set(visiblePlaces.flatMap((place) => getDisplayPlaceTags(place.tags)))].sort((a, b) =>
   a.localeCompare(b),
 );
+const guideVibeFilters = [
+  ...new Set(
+    visiblePlaces.flatMap((place) =>
+      getDisplayPlaceTags(place.vibe_tags).filter((tag) =>
+        [
+          "cozy",
+          "quiet",
+          "lively",
+          "date-night",
+          "laptop-friendly",
+          "scenic",
+          "hidden-gem",
+          "cheap-eats",
+          "splurge",
+          "rainy-day",
+        ].includes(tag),
+      ),
+    ),
+  ),
+].sort((a, b) => a.localeCompare(b));
 const guideDescriptionHtml = renderRichText(guide.description);
+const formatVibeLabel = (tag: string) => tag.replaceAll("-", " ");
 ---
 
 <Layout title={`${guide.title} · ${siteConfig.siteName}`} description={guide.description ?? undefined}>
@@ -77,13 +98,12 @@ const guideDescriptionHtml = renderRichText(guide.description);
     </section>
   )}
 
-  <section class="section browse-section" data-guide-root>
+  <section class="section browse-section" data-guide-root data-guide-slug={guide.slug}>
     <div class="section-head">
       <div>
         <p class="eyebrow">Browse</p>
         <h2 class="section-title">Places</h2>
       </div>
-      <p class="small-copy">Search names, notes, neighborhoods, or address text.</p>
     </div>
 
     <div class="browse-layout" data-browse-layout>
@@ -120,6 +140,19 @@ const guideDescriptionHtml = renderRichText(guide.description);
                   {allTags.map((tag) => (
                     <button class="tag-pill" type="button" data-tag-filter data-tag={tag.toLowerCase()}>
                       #{tag}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {guideVibeFilters.length > 0 && (
+              <div class="control-group" style="grid-column: 1 / -1;">
+                <span class="control-label">Vibe</span>
+                <div class="tag-row">
+                  {guideVibeFilters.map((tag) => (
+                    <button class="tag-pill" type="button" data-tag-filter data-tag={tag}>
+                      {formatVibeLabel(tag)}
                     </button>
                   ))}
                 </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -163,7 +163,15 @@ const placeCount = guides.reduce((count, guide) => count + guide.place_count, 0)
 
     <div class="empty-state" data-home-empty-state>No matching guides. Try a broader search or choose all countries.</div>
 
-    <div class="global-search-results" data-global-search-results hidden>
+    <div
+      class="global-search-results"
+      data-global-search-results
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      aria-hidden="true"
+      hidden
+    >
       <div class="section-head">
         <div>
           <p class="eyebrow">Search results</p>
@@ -171,8 +179,10 @@ const placeCount = guides.reduce((count, guide) => count + guide.place_count, 0)
         </div>
         <p class="small-copy" data-global-search-summary></p>
       </div>
-      <div class="search-result-grid" data-global-search-list></div>
-      <div class="empty-state" data-global-search-empty>No matching places. Try a broader search.</div>
+      <div class="search-result-grid" data-global-search-list aria-live="polite"></div>
+      <div class="empty-state" data-global-search-empty role="status" aria-live="polite">
+        No matching places. Try a broader search.
+      </div>
     </div>
 
     {guidesByCountry.map(({ countryName, countryGuides, countryFlag }) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -93,7 +93,7 @@ const placeCount = guides.reduce((count, guide) => count + guide.place_count, 0)
             id="country-search"
             name="country-search"
             type="search"
-            placeholder="Search countries, cities, guide names, tags"
+            placeholder="Search quiet coffee, date night, rainy day museums"
             data-home-search-input
           />
         </div>
@@ -162,6 +162,18 @@ const placeCount = guides.reduce((count, guide) => count + guide.place_count, 0)
     </div>
 
     <div class="empty-state" data-home-empty-state>No matching guides. Try a broader search or choose all countries.</div>
+
+    <div class="global-search-results" data-global-search-results hidden>
+      <div class="section-head">
+        <div>
+          <p class="eyebrow">Search results</p>
+          <h3 class="section-title" data-global-search-title>Matching places</h3>
+        </div>
+        <p class="small-copy" data-global-search-summary></p>
+      </div>
+      <div class="search-result-grid" data-global-search-list></div>
+      <div class="empty-state" data-global-search-empty>No matching places. Try a broader search.</div>
+    </div>
 
     {guidesByCountry.map(({ countryName, countryGuides, countryFlag }) => (
       <div class="country-block" data-country-block data-country={countryName.toLowerCase()}>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -221,6 +221,9 @@ img {
 
 .country-browser {
   margin-bottom: 1rem;
+  position: sticky;
+  top: 0.5rem;
+  z-index: 5;
 }
 
 .global-search-results {
@@ -492,9 +495,6 @@ img {
 
 .controls-panel {
   padding: 1rem;
-  position: sticky;
-  top: 0.5rem;
-  z-index: 5;
   background: var(--surface-strong);
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -223,6 +223,34 @@ img {
   margin-bottom: 1rem;
 }
 
+.global-search-results {
+  margin: 1rem 0 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--line);
+}
+
+.search-result-grid {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.search-result-card {
+  min-width: 0;
+  padding: 1rem;
+  display: grid;
+  gap: 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+}
+
+.search-result-card h4 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 1.14rem;
+  line-height: 1.25;
+}
+
 .browse-count {
   min-height: 2.8rem;
   margin: 0;
@@ -425,6 +453,11 @@ img {
 .place-card[data-map-active="true"] {
   border-color: var(--accent);
   background: #fffdfd;
+}
+
+.place-card[data-search-highlight="true"] {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(196, 49, 45, 0.18);
 }
 
 .place-card:focus-visible {
@@ -873,6 +906,10 @@ select {
   }
 
   .card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .search-result-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -2,8 +2,21 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const readSource = (path) => readFileSync(path, "utf8");
+const cssBlocks = (css, selector) => {
+  return [...css.matchAll(/([^{}]+){([^}]*)}/g)]
+    .filter((match) => match[1].split(",").map((part) => part.trim()).includes(selector))
+    .map((match) => match[2]);
+};
 
 describe("guide map interactions", () => {
+  it("keeps guide search controls in normal document flow while the map remains sticky", () => {
+    const css = readSource("src/styles/global.css");
+
+    expect(cssBlocks(css, ".controls-panel").join("\n")).not.toContain("position: sticky");
+    expect(cssBlocks(css, ".country-browser").join("\n")).toContain("position: sticky");
+    expect(cssBlocks(css, ".map-panel").join("\n")).toContain("position: sticky");
+  });
+
   it("lets the collapsed map panel release width back to the places list", () => {
     const guidePage = readSource("src/pages/guides/[slug].astro");
     const guideMap = readSource("src/components/GuideMap.astro");

--- a/tests/frontend/placeSearch.test.mjs
+++ b/tests/frontend/placeSearch.test.mjs
@@ -134,6 +134,16 @@ describe("place search", () => {
     expect(state.results.map((result) => result.entry.id)).toEqual(["tokyo-coffee"]);
   });
 
+  it("filters unmatched guide-local queries after the index loads", () => {
+    const state = searchPlaces("volcanic bookstore", {
+      index,
+      scope: "guide",
+      guideSlug: "tokyo-japan",
+    });
+
+    expect(state.results).toEqual([]);
+  });
+
   it("ignores cross-guide location aliases in guide-scoped searches", () => {
     const state = searchPlaces("quiet coffee in united states", {
       index,
@@ -149,21 +159,42 @@ describe("place search", () => {
     expect(searchGuides("sf restaurants", { index })[0].guide.slug).toBe("san-francisco-california-usa");
   });
 
-  it("allows a failed index fetch to retry", async () => {
+  it("does not return curated places for unrelated global searches", () => {
+    const state = searchPlaces("volcanic bookstore in sf", { index, scope: "all" });
+
+    expect(state.results).toEqual([]);
+  });
+
+  it("caches index fetches per URL and allows failed URLs to retry", async () => {
     const fetchMock = vi
       .fn()
       .mockRejectedValueOnce(new Error("offline"))
       .mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ version: 1, guides: [], entries: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            version: 1,
+            guides: [{ slug: "tokyo-japan", title: "Tokyo", city: "Tokyo" }],
+            entries: [],
+          }),
       });
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(loadSearchIndex("/data/search-index.json")).rejects.toThrow("offline");
-    await expect(loadSearchIndex("/data/search-index.json")).resolves.toMatchObject({
+    await expect(loadSearchIndex("/data/search-index-failed.json")).rejects.toThrow("offline");
+    await expect(loadSearchIndex("/data/search-index-failed.json")).resolves.toMatchObject({
       entries: [],
       guides: [],
     });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await expect(loadSearchIndex("/data/search-index-other.json")).resolves.toMatchObject({
+      guides: [expect.objectContaining({ slug: "tokyo-japan" })],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/data/search-index-failed.json");
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/data/search-index-failed.json");
+    expect(fetchMock).toHaveBeenNthCalledWith(3, "/data/search-index-other.json");
   });
 });

--- a/tests/frontend/placeSearch.test.mjs
+++ b/tests/frontend/placeSearch.test.mjs
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { prepareSearchIndex, searchGuides, searchPlaces } from "../../public/scripts/place-search.js";
+import { loadSearchIndex, prepareSearchIndex, searchGuides, searchPlaces } from "../../public/scripts/place-search.js";
 
 const index = prepareSearchIndex({
   version: 1,
@@ -30,6 +30,19 @@ const index = prepareSearchIndex({
       featured_names: ["Buzzy Dinner"],
       url: "/guides/san-francisco-california-usa/",
       search_text: "san francisco california sf restaurants",
+    },
+    {
+      slug: "new-york-new-york-usa",
+      title: "New York, New York, USA",
+      city: "New York",
+      country: "United States",
+      country_code: "US",
+      tags: ["coffee"],
+      place_count: 1,
+      top_categories: ["Coffee shop"],
+      featured_names: ["NY Coffee"],
+      url: "/guides/new-york-new-york-usa/",
+      search_text: "new york nyc united states us coffee",
     },
   ],
   entries: [
@@ -69,10 +82,32 @@ const index = prepareSearchIndex({
       url: "/guides/san-francisco-california-usa/?place=sf-dinner",
       search_text: "date night restaurant mission san francisco sf",
     },
+    {
+      id: "ny-coffee",
+      guide_slug: "new-york-new-york-usa",
+      guide_title: "New York, New York, USA",
+      city: "New York",
+      country: "United States",
+      name: "NY Coffee",
+      category: "Coffee shop",
+      neighborhood: "SoHo",
+      tags: ["coffee-shop", "soho"],
+      vibe_tags: ["quiet"],
+      note: "Quiet coffee shop.",
+      top_pick: false,
+      manual_rank: 0,
+      maps_url: "https://maps.example/ny-coffee",
+      url: "/guides/new-york-new-york-usa/?place=ny-coffee",
+      search_text: "quiet coffee shop soho new york united states us",
+    },
   ],
 });
 
 describe("place search", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("parses natural global queries into location, category, and vibe constraints", () => {
     const state = searchPlaces("quiet coffee in tokyo", { index, scope: "all" });
 
@@ -99,7 +134,36 @@ describe("place search", () => {
     expect(state.results.map((result) => result.entry.id)).toEqual(["tokyo-coffee"]);
   });
 
+  it("ignores cross-guide location aliases in guide-scoped searches", () => {
+    const state = searchPlaces("quiet coffee in united states", {
+      index,
+      scope: "guide",
+      guideSlug: "tokyo-japan",
+    });
+
+    expect(state.results.map((result) => result.entry.id)).toEqual(["tokyo-coffee"]);
+    expect(state.parsed.guideSlugs).toEqual([]);
+  });
+
   it("returns guide matches for broad home-page discovery", () => {
     expect(searchGuides("sf restaurants", { index })[0].guide.slug).toBe("san-francisco-california-usa");
+  });
+
+  it("allows a failed index fetch to retry", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ version: 1, guides: [], entries: [] }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadSearchIndex("/data/search-index.json")).rejects.toThrow("offline");
+    await expect(loadSearchIndex("/data/search-index.json")).resolves.toMatchObject({
+      entries: [],
+      guides: [],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/frontend/placeSearch.test.mjs
+++ b/tests/frontend/placeSearch.test.mjs
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { prepareSearchIndex, searchGuides, searchPlaces } from "../../public/scripts/place-search.js";
+
+const index = prepareSearchIndex({
+  version: 1,
+  guides: [
+    {
+      slug: "tokyo-japan",
+      title: "Tokyo, Japan",
+      city: "Tokyo",
+      country: "Japan",
+      country_code: "JP",
+      tags: ["coffee"],
+      place_count: 2,
+      top_categories: ["Coffee shop"],
+      featured_names: ["Quiet Coffee"],
+      url: "/guides/tokyo-japan/",
+      search_text: "tokyo japan coffee",
+    },
+    {
+      slug: "san-francisco-california-usa",
+      title: "San Francisco, California, USA",
+      city: "San Francisco",
+      country: "United States",
+      country_code: "US",
+      tags: ["restaurants"],
+      place_count: 1,
+      top_categories: ["Restaurant"],
+      featured_names: ["Buzzy Dinner"],
+      url: "/guides/san-francisco-california-usa/",
+      search_text: "san francisco california sf restaurants",
+    },
+  ],
+  entries: [
+    {
+      id: "tokyo-coffee",
+      guide_slug: "tokyo-japan",
+      guide_title: "Tokyo, Japan",
+      city: "Tokyo",
+      country: "Japan",
+      name: "Quiet Coffee",
+      category: "Coffee shop",
+      neighborhood: "Shibuya",
+      tags: ["coffee-shop", "shibuya"],
+      vibe_tags: ["quiet", "laptop-friendly", "cozy"],
+      note: "Quiet coffee shop with wifi.",
+      top_pick: true,
+      manual_rank: 2,
+      maps_url: "https://maps.example/tokyo-coffee",
+      url: "/guides/tokyo-japan/?place=tokyo-coffee",
+      search_text: "quiet coffee shop wifi shibuya tokyo japan",
+    },
+    {
+      id: "sf-dinner",
+      guide_slug: "san-francisco-california-usa",
+      guide_title: "San Francisco, California, USA",
+      city: "San Francisco",
+      country: "United States",
+      name: "Buzzy Dinner",
+      category: "Restaurant",
+      neighborhood: "Mission",
+      tags: ["restaurant", "mission"],
+      vibe_tags: ["date-night", "lively"],
+      note: "Date night restaurant.",
+      top_pick: false,
+      manual_rank: 0,
+      maps_url: "https://maps.example/sf-dinner",
+      url: "/guides/san-francisco-california-usa/?place=sf-dinner",
+      search_text: "date night restaurant mission san francisco sf",
+    },
+  ],
+});
+
+describe("place search", () => {
+  it("parses natural global queries into location, category, and vibe constraints", () => {
+    const state = searchPlaces("quiet coffee in tokyo", { index, scope: "all" });
+
+    expect(state.results.map((result) => result.entry.id)).toEqual(["tokyo-coffee"]);
+    expect(state.parsed.guideSlugs).toEqual(["tokyo-japan"]);
+    expect(state.parsed.categories).toEqual(["cafe"]);
+    expect(state.parsed.vibes).toContain("quiet");
+  });
+
+  it("keeps explicit location matches above unrelated cities", () => {
+    const state = searchPlaces("date night restaurants in sf", { index, scope: "all" });
+
+    expect(state.results[0].entry.id).toBe("sf-dinner");
+    expect(state.results.every((result) => result.entry.guide_slug === "san-francisco-california-usa")).toBe(true);
+  });
+
+  it("supports guide-local queries without repeating the city name", () => {
+    const state = searchPlaces("laptop friendly coffee", {
+      index,
+      scope: "guide",
+      guideSlug: "tokyo-japan",
+    });
+
+    expect(state.results.map((result) => result.entry.id)).toEqual(["tokyo-coffee"]);
+  });
+
+  it("returns guide matches for broad home-page discovery", () => {
+    expect(searchGuides("sf restaurants", { index })[0].guide.slug).toBe("san-francisco-california-usa");
+  });
+});

--- a/tests/frontend/placeTags.test.ts
+++ b/tests/frontend/placeTags.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getDisplayPlaceTags } from "../../src/lib/placeTags";
+import { getDisplayPlaceTags, getGuideAreaFilters } from "../../src/lib/placeTags";
 
 describe("getDisplayPlaceTags", () => {
   it("keeps useful tags and hides address fragments", () => {
@@ -29,5 +29,44 @@ describe("getDisplayPlaceTags", () => {
       "street-food",
       "st-kilda",
     ]);
+  });
+});
+
+describe("getGuideAreaFilters", () => {
+  it("keeps repeated area filters and drops one-off or street-like labels", () => {
+    expect(
+      getGuideAreaFilters(
+        [
+          { neighborhood: "Ginza" },
+          { neighborhood: "Ginza" },
+          { neighborhood: "Ginza" },
+          { neighborhood: "Shibuya" },
+          { neighborhood: "Shibuya" },
+          { neighborhood: "Shibuya" },
+          { neighborhood: "Juárez" },
+          { neighborhood: "Juárez" },
+          { neighborhood: "Juárez" },
+          { neighborhood: "C/ d'Aribau" },
+          { neighborhood: "C/ d'Aribau" },
+          { neighborhood: "C/ d'Aribau" },
+          { neighborhood: "One-off" },
+        ],
+        { limit: 3 },
+      ),
+    ).toEqual([
+      { label: "Ginza", value: "ginza", count: 3 },
+      { label: "Juárez", value: "juárez", count: 3 },
+      { label: "Shibuya", value: "shibuya", count: 3 },
+    ]);
+  });
+
+  it("drops no-op areas that would match every place", () => {
+    expect(
+      getGuideAreaFilters([
+        { neighborhood: "Tokyo" },
+        { neighborhood: "Tokyo" },
+        { neighborhood: "Tokyo" },
+      ]),
+    ).toEqual([]);
   });
 });

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -236,12 +236,81 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(first_place.maps_url, "https://maps.google.com/?cid=override")
         self.assertEqual(first_place.neighborhood, "Shibuya")
         self.assertTrue(first_place.top_pick)
+        self.assertIn("local-favorite", first_place.vibe_tags)
+        self.assertIn("quick-stop", first_place.vibe_tags)
         self.assertEqual(first_place.status, "active")
         self.assertIn("bakery", first_place.tags)
         self.assertIn("shibuya", first_place.tags)
         self.assertIn("specialty", first_place.tags)
         self.assertIn("tokyo", first_place.tags)
         self.assertTrue(hidden_place.hidden)
+
+    def test_place_vibe_tags_can_be_manually_overridden(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo, Japan",
+            places=[
+                RawPlace(
+                    name="Quiet Coffee",
+                    address="1 Shibuya, Tokyo, Japan",
+                    note="Quiet cafe with wifi and outlets.",
+                    maps_url="https://maps.google.com/?cid=1",
+                    cid="111",
+                ),
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0])
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+            (place_overrides_dir / "tokyo-japan.json").write_text(
+                json.dumps({place_id: {"vibe_tags": ["date-night"]}}),
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+            ):
+                guide = build_data.normalize_guide(
+                    "tokyo-japan",
+                    raw,
+                    enrichment_cache={},
+                )
+
+        self.assertEqual(guide.places[0].vibe_tags, ["date-night"])
+
+    def test_build_search_index_contains_compact_place_context(self) -> None:
+        guide = build_data.normalize_guide(
+            "tokyo-japan",
+            RawSavedList(
+                title="Tokyo, Japan",
+                places=[
+                    RawPlace(
+                        name="Quiet Coffee",
+                        address="1 Shibuya, Tokyo, Japan",
+                        note="Quiet cafe with wifi.",
+                        is_favorite=True,
+                        maps_url="https://maps.google.com/?cid=1",
+                        cid="111",
+                    ),
+                ],
+            ),
+            enrichment_cache={},
+        )
+
+        index = build_data.build_search_index([guide])
+
+        self.assertEqual(index["version"], 1)
+        self.assertEqual(index["guides"][0]["slug"], "tokyo-japan")
+        self.assertEqual(index["entries"][0]["guide_slug"], "tokyo-japan")
+        self.assertEqual(index["entries"][0]["name"], "Quiet Coffee")
+        self.assertIn("quiet", index["entries"][0]["vibe_tags"])
+        self.assertIn("laptop-friendly", index["entries"][0]["vibe_tags"])
+        self.assertIn("tokyo", index["entries"][0]["search_text"])
 
     def test_guide_location_center_excludes_far_outliers(self) -> None:
         places = [

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -283,6 +283,67 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertEqual(guide.places[0].vibe_tags, ["date-night"])
 
+    def test_place_vibe_tags_can_be_manually_cleared(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo, Japan",
+            places=[
+                RawPlace(
+                    name="Quiet Coffee",
+                    address="1 Shibuya, Tokyo, Japan",
+                    note="Quiet cafe with wifi and outlets.",
+                    maps_url="https://maps.google.com/?cid=1",
+                    cid="111",
+                ),
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0])
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+            (place_overrides_dir / "tokyo-japan.json").write_text(
+                json.dumps({place_id: {"vibe_tags": []}}),
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+            ):
+                guide = build_data.normalize_guide(
+                    "tokyo-japan",
+                    raw,
+                    enrichment_cache={},
+                )
+
+        self.assertEqual(guide.places[0].vibe_tags, [])
+
+    def test_vibe_tags_match_snake_case_enrichment_types(self) -> None:
+        vibes = build_data.derive_vibe_tags(
+            RawPlace(
+                name="Plain Place",
+                address="1 Shibuya, Tokyo, Japan",
+                maps_url="https://maps.google.com/?cid=1",
+            ),
+            enrichment=EnrichmentPlace(primary_type="coffee_shop", types=["coffee_shop"]),
+            category="coffee_shop",
+            tags=[],
+            note=None,
+            why_recommended=None,
+            top_pick=False,
+        )
+
+        self.assertIn("cozy", vibes)
+        self.assertIn("slow-afternoon", vibes)
+        self.assertIn("solo-friendly", vibes)
+
+    def test_vibe_keyword_matching_uses_token_boundaries(self) -> None:
+        self.assertFalse(build_data.vibe_keyword_matches("barcelona cafe", "bar"))
+        self.assertTrue(build_data.vibe_keyword_matches("quiet bar seating", "bar"))
+
     def test_build_search_index_contains_compact_place_context(self) -> None:
         guide = build_data.normalize_guide(
             "tokyo-japan",


### PR DESCRIPTION
Adds a static client-side search foundation that builds a compact index with derived/manual vibe tags and serves it from `public/data/search-index.json` without committing generated data.
Wires the home page to show place-level global search results with guide context, natural query aliases, empty/error handling, and deep links into guides.
Upgrades guide pages to use the shared scoped search while preserving tag filters, sorting, result counts, and map update events, plus focused vibe chips and deep-link highlighting.
Documents the generated search index in `README.md` and `AGENTS.md`, including manual `vibe_tags` override behavior for future agents.
Tests: `bun run build:data`, `bun run test:frontend`, `bun run test:python`, `bun run check`, `bun run build`; closes #20, #24, #25.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global client-side place & guide search with a dedicated results panel and deep-linking (q/place).
  * Vibe-based filters on guide pages and per-card search highlighting.

* **Improvements**
  * Search placeholder updated with example queries.
  * Place cards now show vibe tags and ranking can use search scores for curated sorting.

* **Documentation**
  * Updated docs and README to describe the search-index generation and data-practices; build-data command guidance clarified.

* **Tests**
  * Added frontend and Python tests covering search behavior and index generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->