### PR TITLE
Track place provenance and add map provider toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
 
 ## Environment Variables
 
-- `GOOGLE_MAPS_JS_API_KEY` is the browser Google Maps display key. It is expected to be visible in the client, so production usage should be on a separate key restricted by HTTP referrer and limited to `Maps JavaScript API`.
+- `GOOGLE_MAPS_JS_API_KEY` is read by Astro during render/build and emitted into the page only when the Google map provider is active. Treat it as the browser Google Maps display key: production usage should be on a separate key restricted by HTTP referrer and limited to `Maps JavaScript API`.
 - `GOOGLE_PLACES_API_KEY` is the server/build-time Places enrichment key. Do not expose it to the browser.
 - `PUBLIC_MAP_PROVIDER=leaflet` forces the Leaflet/OpenStreetMap fallback even when `GOOGLE_MAPS_JS_API_KEY` is present.
 
@@ -93,7 +93,7 @@ Run the site:
 bun run dev
 ```
 
-Guide pages default to Google Maps when `GOOGLE_MAPS_JS_API_KEY` is present. Without that key, or when `PUBLIC_MAP_PROVIDER=leaflet`, they fall back to Leaflet.
+Guide pages default to Google Maps when `GOOGLE_MAPS_JS_API_KEY` is present at build/render time. Without that key, or when `PUBLIC_MAP_PROVIDER=leaflet`, they fall back to Leaflet.
 
 ## Notes For Future Agents
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,12 @@
 - Use `bun run check` and `bun run build` before closing out frontend changes.
 - Use `.venv/bin/python` if `uv run` hits sandbox cache issues in Codex.
 
+## Environment Variables
+
+- `GOOGLE_MAPS_JS_API_KEY` is the browser Google Maps display key. It is expected to be visible in the client, so production usage should be on a separate key restricted by HTTP referrer and limited to `Maps JavaScript API`.
+- `GOOGLE_PLACES_API_KEY` is the server/build-time Places enrichment key. Do not expose it to the browser.
+- `PUBLIC_MAP_PROVIDER=leaflet` forces the Leaflet/OpenStreetMap fallback even when `GOOGLE_MAPS_JS_API_KEY` is present.
+
 ## Data Practices
 
 This repo deliberately avoids committing generated build artifacts.
@@ -86,6 +92,8 @@ Run the site:
 ```bash
 bun run dev
 ```
+
+Guide pages default to Google Maps when `GOOGLE_MAPS_JS_API_KEY` is present. Without that key, or when `PUBLIC_MAP_PROVIDER=leaflet`, they fall back to Leaflet.
 
 ## Notes For Future Agents
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,29 @@ uv sync
 
 The repo pins Python via [`.python-version`](.python-version) so local `uv` usage and Cloudflare Pages builds both resolve the intended `3.14` runtime instead of Cloudflare's default `3.13.x`.
 
-Optional local Google Places API key:
+## Environment Variables
+
+Put local secrets in `.env`.
+
+Recommended split:
 
 ```bash
-cp .env.example .env
+# Browser Google Maps display only.
+GOOGLE_MAPS_JS_API_KEY=...
+
+# Server/build-time Google Places enrichment only.
+GOOGLE_PLACES_API_KEY=...
+
+# Optional: force the old non-Google map path.
+PUBLIC_MAP_PROVIDER=leaflet
 ```
+
+Notes:
+
+- `GOOGLE_MAPS_JS_API_KEY` is expected to be public in the browser. Restrict the production key by HTTP referrer and allow only `Maps JavaScript API`.
+- `GOOGLE_PLACES_API_KEY` should never be exposed to the browser. Use it only for local/build/server enrichment flows.
+- Use a separate production browser key instead of reusing a local dev key.
+- `PUBLIC_MAP_PROVIDER=leaflet` is an escape hatch if you need to force the Leaflet fallback while keeping the Google Maps codepath in the repo.
 
 Populate local raw data from public Google Maps lists:
 
@@ -89,6 +107,8 @@ Start the site:
 ```bash
 bun run dev
 ```
+
+Guide pages use Google Maps by default when `GOOGLE_MAPS_JS_API_KEY` is set. If it is missing, or if `PUBLIC_MAP_PROVIDER=leaflet`, the site falls back to Leaflet/OpenStreetMap.
 
 Verify the site:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ PUBLIC_MAP_PROVIDER=leaflet
 
 Notes:
 
-- `GOOGLE_MAPS_JS_API_KEY` is expected to be public in the browser. Restrict the production key by HTTP referrer and allow only `Maps JavaScript API`.
+- `GOOGLE_MAPS_JS_API_KEY` is read by Astro during render/build and embedded into the page only when the Google map provider is active. Treat it as a browser key: restrict the production key by HTTP referrer and allow only `Maps JavaScript API`.
 - `GOOGLE_PLACES_API_KEY` should never be exposed to the browser. Use it only for local/build/server enrichment flows.
 - Use a separate production browser key instead of reusing a local dev key.
 - `PUBLIC_MAP_PROVIDER=leaflet` is an escape hatch if you need to force the Leaflet fallback while keeping the Google Maps codepath in the repo.
@@ -108,7 +108,7 @@ Start the site:
 bun run dev
 ```
 
-Guide pages use Google Maps by default when `GOOGLE_MAPS_JS_API_KEY` is set. If it is missing, or if `PUBLIC_MAP_PROVIDER=leaflet`, the site falls back to Leaflet/OpenStreetMap.
+Guide pages use Google Maps by default when `GOOGLE_MAPS_JS_API_KEY` is set at build/render time. If it is missing, or if `PUBLIC_MAP_PROVIDER=leaflet`, the site falls back to Leaflet/OpenStreetMap.
 
 Verify the site:
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -88,6 +88,8 @@ try:
         RawPlace,
         RawSavedList,
         SourceConfig,
+        PlaceField,
+        PlaceProvenance,
     )
 except ModuleNotFoundError:
     from scripts.pipeline_models import (
@@ -100,6 +102,8 @@ except ModuleNotFoundError:
         RawPlace,
         RawSavedList,
         SourceConfig,
+        PlaceField,
+        PlaceProvenance,
     )
 
 try:
@@ -606,7 +610,8 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
     for place in raw.places:
         place_id = stable_place_id(place, source_type=raw.configured_source_type)
         override = place_override_map.get(place_id, {})
-        enrichment = coerce_enrichment_place(enrichment_cache.get(place_id))
+        enrichment_cache_entry = enrichment_cache.get(place_id)
+        enrichment = coerce_enrichment_place(enrichment_cache_entry)
         primary_category = (
             as_string(override.get("primary_category"))
             or enrichment.primary_type_display_name
@@ -658,6 +663,20 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
             manual_rank=manual_rank,
             status=status,
         )
+        normalized.provenance = build_place_provenance(
+            raw=raw,
+            raw_place=place,
+            override=override,
+            normalized=normalized,
+            enrichment_cache_entry=enrichment_cache_entry,
+            enrichment=enrichment,
+            primary_category=primary_category,
+            tags=tags,
+            city_name=city_name,
+            top_pick_override=top_pick_override,
+            status=status,
+            prefer_enrichment_names=prefer_enrichment_names,
+        )
         normalized_places.append(normalized)
         if primary_category:
             category_counter[primary_category] += 1
@@ -705,6 +724,186 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
         center_lat=guide_center[0],
         center_lng=guide_center[1],
         places=normalized_places,
+    )
+
+
+def build_place_provenance(
+    *,
+    raw: RawSavedList,
+    raw_place: RawPlace,
+    override: dict[str, Any],
+    normalized: NormalizedPlace,
+    enrichment_cache_entry: EnrichmentCacheEntry | None,
+    enrichment: EnrichmentPlace,
+    primary_category: str | None,
+    tags: list[str],
+    city_name: str | None,
+    top_pick_override: bool | None,
+    status: str,
+    prefer_enrichment_names: bool,
+) -> PlaceProvenance:
+    manual_name = as_string(override.get("name"))
+    manual_category = as_string(override.get("primary_category"))
+    manual_note = as_string(override.get("note"))
+    manual_neighborhood = as_string(override.get("neighborhood"))
+    manual_why_recommended = as_string(override.get("why_recommended"))
+    manual_status = as_string(override.get("status"))
+
+    provenance = PlaceProvenance()
+    provenance.name = (
+        manual_place_field(normalized.name)
+        if manual_name
+        else google_places_field(normalized.name, enrichment_cache_entry)
+        if prefer_enrichment_names and enrichment.display_name
+        else google_list_field(normalized.name, raw)
+    )
+    if normalized.address:
+        provenance.address = (
+            google_list_field(normalized.address, raw)
+            if raw_place.address
+            else google_places_field(normalized.address, enrichment_cache_entry)
+        )
+    if normalized.lat is not None:
+        provenance.lat = google_list_field(normalized.lat, raw)
+    if normalized.lng is not None:
+        provenance.lng = google_list_field(normalized.lng, raw)
+    provenance.maps_url = (
+        google_places_field(normalized.maps_url, enrichment_cache_entry)
+        if enrichment.google_maps_uri
+        else google_list_field(normalized.maps_url, raw)
+    )
+    if normalized.cid:
+        provenance.cid = google_list_field(normalized.cid, raw)
+    if normalized.google_id:
+        provenance.google_id = google_list_field(normalized.google_id, raw)
+    if normalized.google_place_id:
+        provenance.google_place_id = google_places_field(normalized.google_place_id, enrichment_cache_entry)
+    if normalized.google_place_resource_name:
+        provenance.google_place_resource_name = google_places_field(
+            normalized.google_place_resource_name,
+            enrichment_cache_entry,
+        )
+    if primary_category:
+        provenance.primary_category = (
+            manual_place_field(primary_category)
+            if manual_category
+            else google_places_field(primary_category, enrichment_cache_entry)
+        )
+    provenance.tags = build_tag_provenance(
+        raw=raw,
+        raw_place=raw_place,
+        override=override,
+        enrichment_cache_entry=enrichment_cache_entry,
+        enrichment=enrichment,
+        primary_category=primary_category,
+        primary_category_field=provenance.primary_category,
+        city_name=city_name,
+        tags=tags,
+    )
+    if normalized.neighborhood:
+        provenance.neighborhood = (
+            manual_place_field(normalized.neighborhood)
+            if manual_neighborhood
+            else google_list_field(normalized.neighborhood, raw)
+        )
+    if normalized.note:
+        provenance.note = manual_place_field(normalized.note) if manual_note else google_list_field(normalized.note, raw)
+    if normalized.why_recommended:
+        provenance.why_recommended = (
+            manual_place_field(normalized.why_recommended)
+            if manual_why_recommended
+            else None
+        )
+    provenance.top_pick = (
+        manual_place_field(normalized.top_pick)
+        if top_pick_override is not None
+        else google_list_field(normalized.top_pick, raw)
+    )
+    if "hidden" in override:
+        provenance.hidden = manual_place_field(normalized.hidden)
+    if "manual_rank" in override:
+        provenance.manual_rank = manual_place_field(normalized.manual_rank)
+    if manual_status:
+        provenance.status = manual_place_field(status)
+    elif enrichment.business_status:
+        provenance.status = google_places_field(status, enrichment_cache_entry)
+    return provenance
+
+
+def build_tag_provenance(
+    *,
+    raw: RawSavedList,
+    raw_place: RawPlace,
+    override: dict[str, Any],
+    enrichment_cache_entry: EnrichmentCacheEntry | None,
+    enrichment: EnrichmentPlace,
+    primary_category: str | None,
+    primary_category_field: PlaceField | None,
+    city_name: str | None,
+    tags: list[str],
+) -> list[PlaceField]:
+    ranked_fields: dict[str, tuple[int, PlaceField]] = {}
+
+    def put_tag(value: str | None, field: PlaceField | None, *, priority: int) -> None:
+        tag = as_string(value)
+        if tag is None or field is None:
+            return
+        existing = ranked_fields.get(tag)
+        if existing is None or existing[0] < priority:
+            ranked_fields[tag] = (priority, field)
+
+    for tag in coerce_string_list(override.get("tags")):
+        put_tag(tag, manual_place_field(tag), priority=30)
+    if city_name:
+        tag = slugify(city_name)
+        put_tag(tag, google_list_field(tag, raw), priority=10)
+    for locality in infer_address_localities(raw_place.address, city_name=city_name):
+        tag = slugify(locality)
+        put_tag(tag, google_list_field(tag, raw), priority=10)
+    if primary_category:
+        tag = slugify(primary_category)
+        put_tag(
+            tag,
+            source_place_field(tag, primary_category_field),
+            priority=30 if primary_category_field and primary_category_field.source == "manual" else 20,
+        )
+    for place_type in enrichment.types[:4]:
+        tag = slugify(place_type.replace("_", "-"))
+        put_tag(tag, google_places_field(tag, enrichment_cache_entry), priority=20)
+
+    return [ranked_fields[tag][1] for tag in tags if tag in ranked_fields]
+
+
+def source_place_field(value: Any, source_field: PlaceField | None) -> PlaceField | None:
+    if source_field is None:
+        return None
+    return PlaceField(
+        value=value,
+        source=source_field.source,
+        fetched_at=source_field.fetched_at,
+        expires_at=source_field.expires_at,
+    )
+
+
+def manual_place_field(value: Any) -> PlaceField:
+    return PlaceField(value=value, source="manual")
+
+
+def google_list_field(value: Any, raw: RawSavedList) -> PlaceField:
+    return PlaceField(
+        value=value,
+        source="google_list",
+        fetched_at=raw.fetched_at,
+        expires_at=raw.refresh_after,
+    )
+
+
+def google_places_field(value: Any, cache_entry: EnrichmentCacheEntry | None) -> PlaceField:
+    return PlaceField(
+        value=value,
+        source="google_places",
+        fetched_at=cache_entry.fetched_at if cache_entry else None,
+        expires_at=cache_entry.refresh_after if cache_entry else None,
     )
 
 

--- a/scripts/pipeline_models.py
+++ b/scripts/pipeline_models.py
@@ -154,6 +154,37 @@ class EnrichmentCacheEntry(PipelineModel):
     place: EnrichmentPlace | None = None
 
 
+FieldSource = Literal["manual", "google_list", "google_places", "osm", "wikidata", "website"]
+
+
+class PlaceField(PipelineModel):
+    value: Any
+    source: FieldSource
+    fetched_at: str | None = None
+    expires_at: str | None = None
+
+
+class PlaceProvenance(PipelineModel):
+    name: PlaceField | None = None
+    address: PlaceField | None = None
+    lat: PlaceField | None = None
+    lng: PlaceField | None = None
+    maps_url: PlaceField | None = None
+    cid: PlaceField | None = None
+    google_id: PlaceField | None = None
+    google_place_id: PlaceField | None = None
+    google_place_resource_name: PlaceField | None = None
+    primary_category: PlaceField | None = None
+    tags: list[PlaceField] = Field(default_factory=list)
+    neighborhood: PlaceField | None = None
+    note: PlaceField | None = None
+    why_recommended: PlaceField | None = None
+    top_pick: PlaceField | None = None
+    hidden: PlaceField | None = None
+    manual_rank: PlaceField | None = None
+    status: PlaceField | None = None
+
+
 class NormalizedPlace(PipelineModel):
     id: str
     name: str
@@ -174,6 +205,7 @@ class NormalizedPlace(PipelineModel):
     hidden: bool = False
     manual_rank: int = 0
     status: str
+    provenance: PlaceProvenance = Field(default_factory=PlaceProvenance)
 
 
 class Guide(PipelineModel):

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -6,9 +6,10 @@ interface Props {
 }
 
 const { places } = Astro.props;
-const googleMapsApiKey = import.meta.env.GOOGLE_MAPS_JS_API_KEY || "";
+const configuredGoogleMapsApiKey = import.meta.env.GOOGLE_MAPS_JS_API_KEY || "";
 const requestedMapProvider = (import.meta.env.PUBLIC_MAP_PROVIDER || "").toLowerCase();
-const mapProvider = requestedMapProvider === "leaflet" ? "leaflet" : googleMapsApiKey ? "google" : "leaflet";
+const mapProvider = requestedMapProvider === "leaflet" ? "leaflet" : configuredGoogleMapsApiKey ? "google" : "leaflet";
+const googleMapsApiKey = mapProvider === "google" ? configuredGoogleMapsApiKey : "";
 const mapPlaces = places
   .filter((place) => place.lat !== null && place.lng !== null)
   .map((place) => ({
@@ -189,7 +190,7 @@ const mapPlaces = places
   const popupHtml = (place: MapPlace) => {
     const meta = [place.category, place.neighborhood].filter(Boolean).join(" · ");
     return `
-      <div class="guide-map-popup">
+      <div class="guide-map-popup-content">
         <strong>${escapeHtml(place.name)}</strong>
         <span>${escapeHtml(meta)}</span>
         <a href="${escapeHtml(place.mapsUrl)}" target="_blank" rel="noreferrer">Open in Google Maps</a>
@@ -208,7 +209,7 @@ const mapPlaces = places
 
   const placeCircle = (place: MapPlace) =>
     L.circleMarker([place.lat, place.lng], markerStyle(place)).bindPopup(popupHtml(place), {
-      className: "guide-map-popup",
+      className: "guide-map-popup-shell",
       closeButton: false,
     });
 
@@ -411,8 +412,24 @@ const mapPlaces = places
     window.__favoritePlacesGoogleMapsLoader = new Promise((resolve, reject) => {
       const existingScript = document.querySelector<HTMLScriptElement>('script[data-google-maps-loader="favorite-places"]');
       if (existingScript) {
+        if (window.google?.maps) {
+          resolve(window.google);
+          return;
+        }
+        if (existingScript.dataset.googleMapsStatus === "loaded") {
+          reject(new Error("Google Maps loaded without the Maps API namespace"));
+          return;
+        }
+        if (existingScript.dataset.googleMapsStatus === "error") {
+          reject(new Error("Google Maps failed to load"));
+          return;
+        }
         existingScript.addEventListener("load", () => {
-          if (window.google?.maps) resolve(window.google);
+          if (window.google?.maps) {
+            resolve(window.google);
+            return;
+          }
+          reject(new Error("Google Maps loaded without the Maps API namespace"));
         });
         existingScript.addEventListener("error", () => reject(new Error("Google Maps failed to load")));
         return;
@@ -421,16 +438,19 @@ const mapPlaces = places
       const callbackName = "__favoritePlacesGoogleMapsInit";
       window[callbackName] = () => {
         if (window.google?.maps) {
+          script.dataset.googleMapsStatus = "loaded";
           resolve(window.google);
           return;
         }
 
+        script.dataset.googleMapsStatus = "loaded";
         reject(new Error("Google Maps loaded without the Maps API namespace"));
       };
 
       const script = document.createElement("script");
       script.async = true;
       script.dataset.googleMapsLoader = "favorite-places";
+      script.dataset.googleMapsStatus = "loading";
       script.src =
         "https://maps.googleapis.com/maps/api/js?" +
         new URLSearchParams({
@@ -440,7 +460,10 @@ const mapPlaces = places
           v: "weekly",
           auth_referrer_policy: "origin",
         }).toString();
-      script.addEventListener("error", () => reject(new Error("Google Maps failed to load")));
+      script.addEventListener("error", () => {
+        script.dataset.googleMapsStatus = "error";
+        reject(new Error("Google Maps failed to load"));
+      });
       document.head.append(script);
     });
 
@@ -617,16 +640,20 @@ const mapPlaces = places
     const requestedProvider = element.dataset.mapProvider === "google" ? "google" : "leaflet";
     const apiKey = element.dataset.googleMapsApiKey || "";
     const handleMarkerSelect = (placeId: string) => selectPlace(placeId);
-    const runtime =
-      requestedProvider === "google" && apiKey
-        ? await initGoogleRuntime(mapElement, places, apiKey, handleMarkerSelect).catch(() =>
-            initLeafletRuntime(mapElement, places, handleMarkerSelect),
-          )
-        : initLeafletRuntime(mapElement, places, handleMarkerSelect);
+    let runtime: MapRuntime;
+    try {
+      runtime =
+        requestedProvider === "google" && apiKey
+          ? await initGoogleRuntime(mapElement, places, apiKey, handleMarkerSelect).catch(() =>
+              initLeafletRuntime(mapElement, places, handleMarkerSelect),
+            )
+          : initLeafletRuntime(mapElement, places, handleMarkerSelect);
 
-    mapElement.guideMap = runtime.rawMap;
-    element.dataset.initialized = "true";
-    delete element.dataset.initializing;
+      mapElement.guideMap = runtime.rawMap;
+      element.dataset.initialized = "true";
+    } finally {
+      delete element.dataset.initializing;
+    }
 
     const activePlaceId = () => hoveredPlaceId || selectedPlaceId;
 

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -426,23 +426,29 @@ const mapPlaces = places
           resolve(window.google);
           return;
         }
-        if (existingScript.dataset.googleMapsStatus === "loaded") {
-          reject(new Error("Google Maps loaded without the Maps API namespace"));
+        if (
+          existingScript.dataset.googleMapsStatus === "loaded" ||
+          existingScript.dataset.googleMapsStatus === "error"
+        ) {
+          existingScript.remove();
+          delete window.__favoritePlacesGoogleMapsInit;
+        } else {
+          existingScript.addEventListener(
+            "load",
+            () => {
+              if (window.google?.maps) {
+                resolve(window.google);
+                return;
+              }
+              reject(new Error("Google Maps loaded without the Maps API namespace"));
+            },
+            { once: true },
+          );
+          existingScript.addEventListener("error", () => reject(new Error("Google Maps failed to load")), {
+            once: true,
+          });
           return;
         }
-        if (existingScript.dataset.googleMapsStatus === "error") {
-          reject(new Error("Google Maps failed to load"));
-          return;
-        }
-        existingScript.addEventListener("load", () => {
-          if (window.google?.maps) {
-            resolve(window.google);
-            return;
-          }
-          reject(new Error("Google Maps loaded without the Maps API namespace"));
-        });
-        existingScript.addEventListener("error", () => reject(new Error("Google Maps failed to load")));
-        return;
       }
 
       const callbackName = "__favoritePlacesGoogleMapsInit";

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -187,13 +187,23 @@ const mapPlaces = places
       .replaceAll('"', "&quot;")
       .replaceAll("'", "&#39;");
 
+  const safeMapsUrl = (value: string) => {
+    try {
+      const url = new URL(value);
+      return url.protocol === "https:" || url.protocol === "http:" ? url.toString() : null;
+    } catch {
+      return null;
+    }
+  };
+
   const popupHtml = (place: MapPlace) => {
     const meta = [place.category, place.neighborhood].filter(Boolean).join(" · ");
+    const mapsUrl = safeMapsUrl(place.mapsUrl);
     return `
       <div class="guide-map-popup-content">
         <strong>${escapeHtml(place.name)}</strong>
         <span>${escapeHtml(meta)}</span>
-        <a href="${escapeHtml(place.mapsUrl)}" target="_blank" rel="noreferrer">Open in Google Maps</a>
+        ${mapsUrl ? `<a href="${escapeHtml(mapsUrl)}" target="_blank" rel="noreferrer">Open in Google Maps</a>` : ""}
       </div>
     `;
   };
@@ -409,7 +419,7 @@ const mapPlaces = places
       return window.__favoritePlacesGoogleMapsLoader;
     }
 
-    window.__favoritePlacesGoogleMapsLoader = new Promise((resolve, reject) => {
+    window.__favoritePlacesGoogleMapsLoader = new Promise<GoogleMapsApi>((resolve, reject) => {
       const existingScript = document.querySelector<HTMLScriptElement>('script[data-google-maps-loader="favorite-places"]');
       if (existingScript) {
         if (window.google?.maps) {
@@ -439,11 +449,13 @@ const mapPlaces = places
       window[callbackName] = () => {
         if (window.google?.maps) {
           script.dataset.googleMapsStatus = "loaded";
+          delete window.__favoritePlacesGoogleMapsInit;
           resolve(window.google);
           return;
         }
 
         script.dataset.googleMapsStatus = "loaded";
+        delete window.__favoritePlacesGoogleMapsInit;
         reject(new Error("Google Maps loaded without the Maps API namespace"));
       };
 
@@ -462,9 +474,13 @@ const mapPlaces = places
         }).toString();
       script.addEventListener("error", () => {
         script.dataset.googleMapsStatus = "error";
+        delete window.__favoritePlacesGoogleMapsInit;
         reject(new Error("Google Maps failed to load"));
       });
       document.head.append(script);
+    }).catch((error) => {
+      delete window.__favoritePlacesGoogleMapsLoader;
+      throw error;
     });
 
     return window.__favoritePlacesGoogleMapsLoader;

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -613,7 +613,7 @@ const mapPlaces = places
         visiblePlaces.forEach((place) => bounds.extend({ lat: place.lat, lng: place.lng }));
         map.fitBounds(bounds, 28);
       },
-      getBoundsContains: (place) => map.getBounds()?.contains({ lat: place.lat, lng: place.lng }) ?? false,
+      getBoundsContains: (place) => map.getBounds()?.contains({ lat: place.lat, lng: place.lng }) ?? true,
       getZoom: () => map.getZoom() ?? 0,
       hasVisiblePlace: (placeId) => Boolean(markers.get(placeId)?.getMap()),
       highlightPlace: (place, active) => {

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -6,6 +6,13 @@ interface Props {
 }
 
 const { places } = Astro.props;
+const googleMapsApiKey =
+  import.meta.env.GOOGLE_MAPS_JS_API_KEY ||
+  import.meta.env.PUBLIC_GOOGLE_MAPS_API_KEY ||
+  import.meta.env.GOOGLE_MAPS_API_KEY ||
+  "";
+const requestedMapProvider = (import.meta.env.PUBLIC_MAP_PROVIDER || "").toLowerCase();
+const mapProvider = requestedMapProvider === "leaflet" ? "leaflet" : googleMapsApiKey ? "google" : "leaflet";
 const mapPlaces = places
   .filter((place) => place.lat !== null && place.lng !== null)
   .map((place) => ({
@@ -48,7 +55,13 @@ const mapPlaces = places
         </button>
       </div>
 
-      <div class="guide-map" data-guide-map data-places={JSON.stringify(mapPlaces)} />
+      <div
+        class="guide-map"
+        data-guide-map
+        data-map-provider={mapProvider}
+        data-google-maps-api-key={googleMapsApiKey}
+        data-places={JSON.stringify(mapPlaces)}
+      />
 
       <noscript>
         <div class="map-fallback">
@@ -86,16 +99,78 @@ const mapPlaces = places
     };
   }
 
+  interface Coordinates {
+    lat: number;
+    lng: number;
+  }
+
   interface GuideLocationBounds {
-    center: L.LatLng;
+    center: Coordinates;
     radiusKm: number;
     maxDistanceKm: number;
   }
 
   interface GuideMapElement extends HTMLElement {
-    guideMap?: L.Map;
+    guideMap?: unknown;
     guideMapFit?: () => void;
     guideLocationBounds?: GuideLocationBounds;
+  }
+
+  interface MapRuntime {
+    rawMap: unknown;
+    closePopup: () => void;
+    fitPlaces: (places: MapPlace[]) => void;
+    getBoundsContains: (place: MapPlace) => boolean;
+    getZoom: () => number;
+    hasVisiblePlace: (placeId: string) => boolean;
+    highlightPlace: (place: MapPlace, active: boolean) => void;
+    invalidateSize?: () => void;
+    openPlace: (place: MapPlace) => void;
+    setView: (coordinates: Coordinates, zoom: number) => void;
+    setVisiblePlaces: (visiblePlaceIds: Set<string>) => void;
+  }
+
+  interface GoogleMapsApi {
+    maps: {
+      InfoWindow: new (options?: { content?: string }) => {
+        close: () => void;
+        open: (options: { anchor: unknown; map: unknown; shouldFocus?: boolean }) => void;
+        setContent: (content: string) => void;
+      };
+      LatLngBounds: new () => {
+        contains: (coordinates: Coordinates) => boolean;
+        extend: (coordinates: Coordinates) => void;
+      };
+      Map: new (
+        element: HTMLElement,
+        options: Record<string, unknown>,
+      ) => {
+        fitBounds: (bounds: unknown, padding?: number | { top: number; right: number; bottom: number; left: number }) => void;
+        getBounds: () => { contains: (coordinates: Coordinates) => boolean } | undefined;
+        getZoom: () => number | undefined;
+        panTo: (coordinates: Coordinates) => void;
+        setCenter: (coordinates: Coordinates) => void;
+        setZoom: (zoom: number) => void;
+      };
+      Marker: new (options: Record<string, unknown>) => {
+        addListener: (eventName: string, handler: () => void) => void;
+        getMap: () => unknown;
+        setIcon: (icon: Record<string, unknown>) => void;
+        setMap: (map: unknown | null) => void;
+        setZIndex: (zIndex: number) => void;
+      };
+      SymbolPath: {
+        CIRCLE: unknown;
+      };
+    };
+  }
+
+  declare global {
+    interface Window {
+      __favoritePlacesGoogleMapsInit?: () => void;
+      __favoritePlacesGoogleMapsLoader?: Promise<GoogleMapsApi>;
+      google?: GoogleMapsApi;
+    }
   }
 
   const MAP_COLLAPSED_KEY = "favoritePlacesMapCollapsed";
@@ -118,9 +193,11 @@ const mapPlaces = places
   const popupHtml = (place: MapPlace) => {
     const meta = [place.category, place.neighborhood].filter(Boolean).join(" · ");
     return `
-      <strong>${escapeHtml(place.name)}</strong>
-      <span>${escapeHtml(meta)}</span>
-      <a href="${escapeHtml(place.mapsUrl)}" target="_blank" rel="noreferrer">Open in Google Maps</a>
+      <div class="guide-map-popup">
+        <strong>${escapeHtml(place.name)}</strong>
+        <span>${escapeHtml(meta)}</span>
+        <a href="${escapeHtml(place.mapsUrl)}" target="_blank" rel="noreferrer">Open in Google Maps</a>
+      </div>
     `;
   };
 
@@ -227,10 +304,10 @@ const mapPlaces = places
     if (places.length === 0) return null;
 
     const inlierPlaces = guideLocationInliers(places);
-    const center = L.latLng(
-      median(inlierPlaces.map((place) => place.lat)),
-      median(inlierPlaces.map((place) => place.lng)),
-    );
+    const center = {
+      lat: median(inlierPlaces.map((place) => place.lat)),
+      lng: median(inlierPlaces.map((place) => place.lng)),
+    };
     const distances = inlierPlaces.map((place) => distanceInKm(center.lat, center.lng, place.lat, place.lng));
     const radiusKm = percentile(distances, 0.95);
 
@@ -326,21 +403,59 @@ const mapPlaces = places
     });
   };
 
-  const initMap = (element: HTMLElement) => {
-    const places = JSON.parse(element.dataset.places || "[]") as MapPlace[];
-    if (places.length === 0 || element.dataset.initialized === "true") return;
+  const loadGoogleMapsApi = (apiKey: string) => {
+    if (window.google?.maps) {
+      return Promise.resolve(window.google);
+    }
 
-    element.dataset.initialized = "true";
+    if (window.__favoritePlacesGoogleMapsLoader) {
+      return window.__favoritePlacesGoogleMapsLoader;
+    }
 
-    const root = element.closest<HTMLElement>("[data-guide-root]");
-    const panel = element.closest<HTMLElement>("[data-map-panel]");
-    const cards = root ? Array.from(root.querySelectorAll<HTMLElement>("[data-place-card][data-place-id]")) : [];
-    const mapFrameButton = panel?.querySelector<HTMLButtonElement>("[data-map-frame-filter]");
-    const mapFullAreaButton = panel?.querySelector<HTMLButtonElement>("[data-map-full-area]");
-    const locationButton = panel?.querySelector<HTMLButtonElement>("[data-map-location]");
-    const mapResetButtons = root ? Array.from(root.querySelectorAll<HTMLButtonElement>("[data-map-filter-reset]")) : [];
-    let currentPlaces = places;
-    const mapElement = element as GuideMapElement;
+    window.__favoritePlacesGoogleMapsLoader = new Promise((resolve, reject) => {
+      const existingScript = document.querySelector<HTMLScriptElement>('script[data-google-maps-loader="favorite-places"]');
+      if (existingScript) {
+        existingScript.addEventListener("load", () => {
+          if (window.google?.maps) resolve(window.google);
+        });
+        existingScript.addEventListener("error", () => reject(new Error("Google Maps failed to load")));
+        return;
+      }
+
+      const callbackName = "__favoritePlacesGoogleMapsInit";
+      window[callbackName] = () => {
+        if (window.google?.maps) {
+          resolve(window.google);
+          return;
+        }
+
+        reject(new Error("Google Maps loaded without the Maps API namespace"));
+      };
+
+      const script = document.createElement("script");
+      script.async = true;
+      script.dataset.googleMapsLoader = "favorite-places";
+      script.src =
+        "https://maps.googleapis.com/maps/api/js?" +
+        new URLSearchParams({
+          key: apiKey,
+          loading: "async",
+          callback: callbackName,
+          v: "weekly",
+          auth_referrer_policy: "origin",
+        }).toString();
+      script.addEventListener("error", () => reject(new Error("Google Maps failed to load")));
+      document.head.append(script);
+    });
+
+    return window.__favoritePlacesGoogleMapsLoader;
+  };
+
+  const initLeafletRuntime = (
+    mapElement: HTMLElement,
+    places: MapPlace[],
+    onSelectPlace: (placeId: string) => void,
+  ): MapRuntime => {
     const map = L.map(mapElement, {
       dragging: true,
       maxZoom: 19,
@@ -358,10 +473,164 @@ const mapPlaces = places
     }).addTo(map);
 
     const markers = new Map<string, L.CircleMarker>();
+    places.forEach((place) => {
+      const marker = placeCircle(place).addTo(map);
+      marker.on("click", () => onSelectPlace(place.id));
+      markers.set(place.id, marker);
+    });
+
+    return {
+      rawMap: map,
+      closePopup: () => map.closePopup(),
+      fitPlaces: (visiblePlaces) => fitPlaces(map, visiblePlaces),
+      getBoundsContains: (place) => map.getBounds().contains(L.latLng(place.lat, place.lng)),
+      getZoom: () => map.getZoom(),
+      hasVisiblePlace: (placeId) => Boolean(markers.get(placeId) && map.hasLayer(markers.get(placeId)!)),
+      highlightPlace: (place, active) => {
+        const marker = markers.get(place.id);
+        if (!marker) return;
+        marker.setStyle(markerStyle(place, active));
+        if (active && map.hasLayer(marker)) {
+          marker.bringToFront();
+        }
+      },
+      invalidateSize: () => map.invalidateSize(),
+      openPlace: (place) => {
+        const marker = markers.get(place.id);
+        if (marker && map.hasLayer(marker)) {
+          marker.openPopup();
+        }
+      },
+      setView: (coordinates, zoom) => {
+        map.setView([coordinates.lat, coordinates.lng], zoom, { animate: true });
+      },
+      setVisiblePlaces: (visiblePlaceIds) => {
+        markers.forEach((marker, placeId) => {
+          if (visiblePlaceIds.has(placeId)) {
+            marker.addTo(map);
+          } else {
+            marker.removeFrom(map);
+          }
+        });
+      },
+    };
+  };
+
+  const initGoogleRuntime = async (
+    mapElement: HTMLElement,
+    places: MapPlace[],
+    apiKey: string,
+    onSelectPlace: (placeId: string) => void,
+  ): Promise<MapRuntime> => {
+    const google = await loadGoogleMapsApi(apiKey);
+    const map = new google.maps.Map(mapElement, {
+      center: { lat: places[0].lat, lng: places[0].lng },
+      clickableIcons: false,
+      disableDefaultUI: true,
+      gestureHandling: "greedy",
+      keyboardShortcuts: true,
+      mapTypeControl: false,
+      streetViewControl: false,
+      zoom: 13,
+    });
+    const infoWindow = new google.maps.InfoWindow();
+    const markers = new Map<string, any>();
+
+    const markerIcon = (place: MapPlace, active = false) => ({
+      fillColor: active ? ACTIVE_MARKER_COLOR : place.topPick ? TOP_PICK_MARKER_COLOR : "#fffaf1",
+      fillOpacity: active ? 0.96 : place.topPick ? 0.92 : 0.86,
+      path: google.maps.SymbolPath.CIRCLE,
+      scale: active ? (place.topPick ? 11 : 9) : place.topPick ? 8 : 6,
+      strokeColor: active ? ACTIVE_MARKER_COLOR : place.topPick ? TOP_PICK_MARKER_COLOR : DEFAULT_MARKER_COLOR,
+      strokeOpacity: 0.95,
+      strokeWeight: active ? 3 : 2,
+    });
+
+    places.forEach((place) => {
+      const marker = new google.maps.Marker({
+        icon: markerIcon(place),
+        map,
+        position: { lat: place.lat, lng: place.lng },
+        title: place.name,
+      });
+      marker.addListener("click", () => onSelectPlace(place.id));
+      markers.set(place.id, marker);
+    });
+
+    return {
+      rawMap: map,
+      closePopup: () => infoWindow.close(),
+      fitPlaces: (visiblePlaces) => {
+        if (visiblePlaces.length === 0) return;
+        if (visiblePlaces.length === 1) {
+          map.setCenter({ lat: visiblePlaces[0].lat, lng: visiblePlaces[0].lng });
+          map.setZoom(14);
+          return;
+        }
+
+        const bounds = new google.maps.LatLngBounds();
+        visiblePlaces.forEach((place) => bounds.extend({ lat: place.lat, lng: place.lng }));
+        map.fitBounds(bounds, 28);
+      },
+      getBoundsContains: (place) => map.getBounds()?.contains({ lat: place.lat, lng: place.lng }) ?? false,
+      getZoom: () => map.getZoom() ?? 0,
+      hasVisiblePlace: (placeId) => Boolean(markers.get(placeId)?.getMap()),
+      highlightPlace: (place, active) => {
+        const marker = markers.get(place.id);
+        if (!marker) return;
+        marker.setIcon(markerIcon(place, active));
+        marker.setZIndex(active ? 1000 : place.topPick ? 10 : 1);
+      },
+      openPlace: (place) => {
+        const marker = markers.get(place.id);
+        if (!marker || !marker.getMap()) return;
+        infoWindow.setContent(popupHtml(place));
+        infoWindow.open({ anchor: marker, map, shouldFocus: false });
+      },
+      setView: (coordinates, zoom) => {
+        map.panTo(coordinates);
+        map.setZoom(zoom);
+      },
+      setVisiblePlaces: (visiblePlaceIds) => {
+        markers.forEach((marker, placeId) => marker.setMap(visiblePlaceIds.has(placeId) ? map : null));
+      },
+    };
+  };
+
+  const initMap = async (element: HTMLElement) => {
+    const places = JSON.parse(element.dataset.places || "[]") as MapPlace[];
+    if (places.length === 0 || element.dataset.initialized === "true" || element.dataset.initializing === "true") {
+      return;
+    }
+
+    element.dataset.initializing = "true";
+
+    const root = element.closest<HTMLElement>("[data-guide-root]");
+    const panel = element.closest<HTMLElement>("[data-map-panel]");
+    const cards = root ? Array.from(root.querySelectorAll<HTMLElement>("[data-place-card][data-place-id]")) : [];
+    const mapFrameButton = panel?.querySelector<HTMLButtonElement>("[data-map-frame-filter]");
+    const mapFullAreaButton = panel?.querySelector<HTMLButtonElement>("[data-map-full-area]");
+    const locationButton = panel?.querySelector<HTMLButtonElement>("[data-map-location]");
+    const mapResetButtons = root ? Array.from(root.querySelectorAll<HTMLButtonElement>("[data-map-filter-reset]")) : [];
+    let currentPlaces = places;
+    const mapElement = element as GuideMapElement;
     const placeById = new Map(places.map((place) => [place.id, place]));
     let selectedPlaceId = "";
     let hoveredPlaceId = "";
-    let currentLocation: L.LatLng | null = null;
+    let currentLocation: Coordinates | null = null;
+    const requestedProvider = element.dataset.mapProvider === "google" ? "google" : "leaflet";
+    const apiKey = element.dataset.googleMapsApiKey || "";
+    const handleMarkerSelect = (placeId: string) => selectPlace(placeId);
+    const runtime =
+      requestedProvider === "google" && apiKey
+        ? await initGoogleRuntime(mapElement, places, apiKey, handleMarkerSelect).catch(() =>
+            initLeafletRuntime(mapElement, places, handleMarkerSelect),
+          )
+        : initLeafletRuntime(mapElement, places, handleMarkerSelect);
+
+    mapElement.guideMap = runtime.rawMap;
+    element.dataset.initialized = "true";
+    delete element.dataset.initializing;
 
     const activePlaceId = () => hoveredPlaceId || selectedPlaceId;
 
@@ -375,27 +644,23 @@ const mapPlaces = places
       const placeId = activePlaceId();
       setCardsActive(placeId);
 
-      markers.forEach((marker, markerPlaceId) => {
-        const place = placeById.get(markerPlaceId);
-        if (!place) return;
-
-        marker.setStyle(markerStyle(place, markerPlaceId === placeId));
-        if (markerPlaceId === placeId && map.hasLayer(marker)) {
-          marker.bringToFront();
-          if (openPopup) {
-            marker.openPopup();
-          }
-        }
+      places.forEach((place) => {
+        runtime.highlightPlace(place, place.id === placeId);
       });
 
       if (!placeId) {
-        map.closePopup();
+        runtime.closePopup();
+      } else if (openPopup) {
+        const place = placeById.get(placeId);
+        if (place && runtime.hasVisiblePlace(place.id)) {
+          runtime.openPlace(place);
+        }
       }
     };
 
     const placeIsInSaneView = (place: MapPlace) => {
-      const zoom = map.getZoom();
-      return map.getBounds().pad(-0.08).contains(L.latLng(place.lat, place.lng)) && zoom >= 13 && zoom <= 17;
+      const zoom = runtime.getZoom();
+      return runtime.getBoundsContains(place) && zoom >= 13 && zoom <= 17;
     };
 
     const showPlace = (
@@ -403,8 +668,7 @@ const mapPlaces = places
       { ensureVisible = false, expandCollapsed = false, openPopup = true } = {},
     ) => {
       const place = placeById.get(placeId);
-      const marker = markers.get(placeId);
-      if (!place || !marker) return;
+      if (!place) return;
 
       if (expandCollapsed && panel?.dataset.collapsed === "true") {
         setPanelCollapsed(panel, false);
@@ -417,17 +681,17 @@ const mapPlaces = places
       updateActiveMarker(false);
 
       if (ensureVisible && !placeIsInSaneView(place)) {
-        const zoom = map.getZoom();
+        const zoom = runtime.getZoom();
         const nextZoom = zoom < 13 ? 15 : Math.min(zoom, 17);
-        map.setView([place.lat, place.lng], nextZoom, { animate: true });
+        runtime.setView({ lat: place.lat, lng: place.lng }, nextZoom);
         window.setTimeout(() => {
-          if (map.hasLayer(marker) && openPopup) marker.openPopup();
+          if (runtime.hasVisiblePlace(place.id) && openPopup) runtime.openPlace(place);
         }, 180);
         return;
       }
 
-      if (map.hasLayer(marker) && openPopup) {
-        marker.openPopup();
+      if (runtime.hasVisiblePlace(place.id) && openPopup) {
+        runtime.openPlace(place);
       }
     };
 
@@ -457,10 +721,7 @@ const mapPlaces = places
     const applyMapFrameFilter = () => {
       if (!root) return;
 
-      const bounds = map.getBounds();
-      const visiblePlaceIds = currentPlaces
-        .filter((place) => bounds.contains(L.latLng(place.lat, place.lng)))
-        .map((place) => place.id);
+      const visiblePlaceIds = currentPlaces.filter((place) => runtime.getBoundsContains(place)).map((place) => place.id);
 
       root.dispatchEvent(
         new CustomEvent("guide:map-frame-filter", {
@@ -484,7 +745,7 @@ const mapPlaces = places
       locationButton.setAttribute("aria-busy", state === "checking" ? "true" : "false");
     };
 
-    const locationIsNearGuide = (location: L.LatLng) => {
+    const locationIsNearGuide = (location: Coordinates) => {
       const guideLocationBounds = mapElement.guideLocationBounds;
       if (!guideLocationBounds) return false;
 
@@ -499,7 +760,7 @@ const mapPlaces = places
     };
 
     const updateLocationFromPosition = (position: GeolocationPosition) => {
-      currentLocation = L.latLng(position.coords.latitude, position.coords.longitude);
+      currentLocation = { lat: position.coords.latitude, lng: position.coords.longitude };
 
       if (locationIsNearGuide(currentLocation)) {
         setLocationButtonState("near", "Center map on current location");
@@ -530,7 +791,7 @@ const mapPlaces = places
 
     const centerOnCurrentLocation = () => {
       if (!currentLocation || !locationIsNearGuide(currentLocation)) return;
-      map.setView([currentLocation.lat, currentLocation.lng], 15, { animate: true });
+      runtime.setView(currentLocation, 15);
     };
 
     const resetToFullArea = () => {
@@ -545,16 +806,10 @@ const mapPlaces = places
         );
       } else {
         currentPlaces = places;
-        markers.forEach((marker) => marker.addTo(map));
-        fitPlaces(map, places);
+        runtime.setVisiblePlaces(new Set(places.map((place) => place.id)));
+        runtime.fitPlaces(places);
       }
     };
-
-    places.forEach((place) => {
-      const marker = placeCircle(place).addTo(map);
-      marker.on("click", () => selectPlace(place.id));
-      markers.set(place.id, marker);
-    });
 
     cards.forEach((card) => {
       if (card.dataset.mapInteractionInitialized === "true") return;
@@ -582,18 +837,17 @@ const mapPlaces = places
     mapFrameButton?.addEventListener("click", applyMapFrameFilter);
     mapFullAreaButton?.addEventListener("click", resetToFullArea);
 
-    mapElement.guideMap = map;
     mapElement.guideLocationBounds = locationBoundsForPlaces(places) ?? undefined;
     if (locationButton) {
       locationButton.addEventListener("click", centerOnCurrentLocation);
       startLocationAvailabilityWatch();
     }
     mapElement.guideMapFit = () => {
-      map.invalidateSize();
-      fitPlaces(map, currentPlaces);
+      runtime.invalidateSize?.();
+      runtime.fitPlaces(currentPlaces);
     };
 
-    fitPlaces(map, currentPlaces);
+    runtime.fitPlaces(currentPlaces);
     window.setTimeout(() => mapElement.guideMapFit?.(), 0);
 
     document.addEventListener("guide:places-updated", ((event: PlacesUpdatedEvent) => {
@@ -601,26 +855,21 @@ const mapPlaces = places
       const visiblePlaces = places.filter((place) => visiblePlaceIds.has(place.id));
       currentPlaces = visiblePlaces;
       updateMapFrameControls(Boolean(event.detail.mapFrameActive));
-
-      markers.forEach((marker, placeId) => {
-        if (visiblePlaceIds.has(placeId)) {
-          marker.addTo(map);
-        } else {
-          marker.removeFrom(map);
-        }
-      });
+      runtime.setVisiblePlaces(visiblePlaceIds);
 
       updateActiveMarker(false);
 
       if (!event.detail.mapFrameActive) {
-        fitPlaces(map, currentPlaces);
+        runtime.fitPlaces(currentPlaces);
       }
     }) as EventListener);
   };
 
   const initMaps = () => {
     initPanels();
-    document.querySelectorAll<HTMLElement>("[data-guide-map]").forEach(initMap);
+    document.querySelectorAll<HTMLElement>("[data-guide-map]").forEach((element) => {
+      void initMap(element);
+    });
   };
 
   if (document.readyState === "loading") {

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -6,7 +6,7 @@ interface Props {
 }
 
 const { places } = Astro.props;
-const configuredGoogleMapsApiKey = import.meta.env.GOOGLE_MAPS_JS_API_KEY || "";
+const configuredGoogleMapsApiKey = process.env.GOOGLE_MAPS_JS_API_KEY || "";
 const requestedMapProvider = (import.meta.env.PUBLIC_MAP_PROVIDER || "").toLowerCase();
 const mapProvider = requestedMapProvider === "leaflet" ? "leaflet" : configuredGoogleMapsApiKey ? "google" : "leaflet";
 const googleMapsApiKey = mapProvider === "google" ? configuredGoogleMapsApiKey : "";
@@ -647,7 +647,18 @@ const mapPlaces = places
     const mapFullAreaButton = panel?.querySelector<HTMLButtonElement>("[data-map-full-area]");
     const locationButton = panel?.querySelector<HTMLButtonElement>("[data-map-location]");
     const mapResetButtons = root ? Array.from(root.querySelectorAll<HTMLButtonElement>("[data-map-filter-reset]")) : [];
-    let currentPlaces = places;
+    const visiblePlaceIdsFromCards = () =>
+      cards.length === 0
+        ? new Set(places.map((place) => place.id))
+        : new Set(
+            cards
+              .filter((card) => !card.hidden)
+              .map((card) => card.dataset.placeId)
+              .filter((placeId): placeId is string => Boolean(placeId)),
+          );
+    let currentVisiblePlaceIds = visiblePlaceIdsFromCards();
+    let currentPlaces = places.filter((place) => currentVisiblePlaceIds.has(place.id));
+    const mapFrameActive = () => mapResetButtons.some((button) => !button.hidden);
     const mapElement = element as GuideMapElement;
     const placeById = new Map(places.map((place) => [place.id, place]));
     let selectedPlaceId = "";
@@ -656,7 +667,34 @@ const mapPlaces = places
     const requestedProvider = element.dataset.mapProvider === "google" ? "google" : "leaflet";
     const apiKey = element.dataset.googleMapsApiKey || "";
     const handleMarkerSelect = (placeId: string) => selectPlace(placeId);
-    let runtime: MapRuntime;
+    let runtime: MapRuntime | null = null;
+
+    const updateMapFrameControls = (active: boolean) => {
+      mapResetButtons.forEach((button) => {
+        button.hidden = !active;
+      });
+    };
+
+    const syncVisiblePlaces = (detail: PlacesUpdatedEvent["detail"]) => {
+      currentVisiblePlaceIds = new Set(detail.visiblePlaceIds);
+      currentPlaces = places.filter((place) => currentVisiblePlaceIds.has(place.id));
+      updateMapFrameControls(Boolean(detail.mapFrameActive));
+      if (!runtime) return;
+
+      runtime.setVisiblePlaces(currentVisiblePlaceIds);
+      updateActiveMarker(false);
+
+      if (!detail.mapFrameActive) {
+        runtime.fitPlaces(currentPlaces);
+      }
+    };
+
+    const handlePlacesUpdated = ((event: PlacesUpdatedEvent) => {
+      syncVisiblePlaces(event.detail);
+    }) as EventListener;
+
+    updateMapFrameControls(mapFrameActive());
+    document.addEventListener("guide:places-updated", handlePlacesUpdated);
     try {
       runtime =
         requestedProvider === "google" && apiKey
@@ -665,8 +703,12 @@ const mapPlaces = places
             )
           : initLeafletRuntime(mapElement, places, handleMarkerSelect);
 
+      runtime.setVisiblePlaces(currentVisiblePlaceIds);
       mapElement.guideMap = runtime.rawMap;
       element.dataset.initialized = "true";
+    } catch (error) {
+      document.removeEventListener("guide:places-updated", handlePlacesUpdated);
+      throw error;
     } finally {
       delete element.dataset.initializing;
     }
@@ -751,16 +793,10 @@ const mapPlaces = places
       updateActiveMarker(Boolean(selectedPlaceId));
     };
 
-    const updateMapFrameControls = (active: boolean) => {
-      mapResetButtons.forEach((button) => {
-        button.hidden = !active;
-      });
-    };
-
     const applyMapFrameFilter = () => {
       if (!root) return;
 
-      const visiblePlaceIds = currentPlaces.filter((place) => runtime.getBoundsContains(place)).map((place) => place.id);
+      const visiblePlaceIds = currentPlaces.filter((place) => runtime?.getBoundsContains(place)).map((place) => place.id);
 
       root.dispatchEvent(
         new CustomEvent("guide:map-frame-filter", {
@@ -882,26 +918,12 @@ const mapPlaces = places
       startLocationAvailabilityWatch();
     }
     mapElement.guideMapFit = () => {
-      runtime.invalidateSize?.();
-      runtime.fitPlaces(currentPlaces);
+      runtime?.invalidateSize?.();
+      runtime?.fitPlaces(currentPlaces);
     };
 
     runtime.fitPlaces(currentPlaces);
     window.setTimeout(() => mapElement.guideMapFit?.(), 0);
-
-    document.addEventListener("guide:places-updated", ((event: PlacesUpdatedEvent) => {
-      const visiblePlaceIds = new Set(event.detail.visiblePlaceIds);
-      const visiblePlaces = places.filter((place) => visiblePlaceIds.has(place.id));
-      currentPlaces = visiblePlaces;
-      updateMapFrameControls(Boolean(event.detail.mapFrameActive));
-      runtime.setVisiblePlaces(visiblePlaceIds);
-
-      updateActiveMarker(false);
-
-      if (!event.detail.mapFrameActive) {
-        runtime.fitPlaces(currentPlaces);
-      }
-    }) as EventListener);
   };
 
   const initMaps = () => {

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -6,11 +6,7 @@ interface Props {
 }
 
 const { places } = Astro.props;
-const googleMapsApiKey =
-  import.meta.env.GOOGLE_MAPS_JS_API_KEY ||
-  import.meta.env.PUBLIC_GOOGLE_MAPS_API_KEY ||
-  import.meta.env.GOOGLE_MAPS_API_KEY ||
-  "";
+const googleMapsApiKey = import.meta.env.GOOGLE_MAPS_JS_API_KEY || "";
 const requestedMapProvider = (import.meta.env.PUBLIC_MAP_PROVIDER || "").toLowerCase();
 const mapProvider = requestedMapProvider === "leaflet" ? "leaflet" : googleMapsApiKey ? "google" : "leaflet";
 const mapPlaces = places

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="astro/client" />
+
+interface ImportMetaEnv {
+  readonly GOOGLE_MAPS_API_KEY?: string;
+  readonly GOOGLE_MAPS_JS_API_KEY?: string;
+  readonly PUBLIC_GOOGLE_MAPS_API_KEY?: string;
+  readonly PUBLIC_MAP_PROVIDER?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,9 +1,16 @@
 /// <reference types="astro/client" />
 
 interface ImportMetaEnv {
-  readonly GOOGLE_MAPS_JS_API_KEY?: string;
   readonly PUBLIC_MAP_PROVIDER?: string;
 }
+
+interface ProcessEnv {
+  GOOGLE_MAPS_JS_API_KEY?: string;
+}
+
+declare const process: {
+  env: ProcessEnv;
+};
 
 interface ImportMeta {
   readonly env: ImportMetaEnv;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,9 +1,7 @@
 /// <reference types="astro/client" />
 
 interface ImportMetaEnv {
-  readonly GOOGLE_MAPS_API_KEY?: string;
   readonly GOOGLE_MAPS_JS_API_KEY?: string;
-  readonly PUBLIC_GOOGLE_MAPS_API_KEY?: string;
   readonly PUBLIC_MAP_PROVIDER?: string;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,33 @@
+export type FieldSource = "manual" | "google_list" | "google_places" | "osm" | "wikidata" | "website";
+
+export interface PlaceField<T> {
+  value: T;
+  source: FieldSource;
+  fetched_at?: string | null;
+  expires_at?: string | null;
+}
+
+export interface PlaceProvenance {
+  name?: PlaceField<string> | null;
+  address?: PlaceField<string> | null;
+  lat?: PlaceField<number> | null;
+  lng?: PlaceField<number> | null;
+  maps_url?: PlaceField<string> | null;
+  cid?: PlaceField<string> | null;
+  google_id?: PlaceField<string> | null;
+  google_place_id?: PlaceField<string> | null;
+  google_place_resource_name?: PlaceField<string> | null;
+  primary_category?: PlaceField<string> | null;
+  tags: PlaceField<string>[];
+  neighborhood?: PlaceField<string> | null;
+  note?: PlaceField<string> | null;
+  why_recommended?: PlaceField<string> | null;
+  top_pick?: PlaceField<boolean> | null;
+  hidden?: PlaceField<boolean> | null;
+  manual_rank?: PlaceField<number> | null;
+  status?: PlaceField<string> | null;
+}
+
 export interface Place {
   id: string;
   name: string;
@@ -18,6 +48,7 @@ export interface Place {
   hidden: boolean;
   manual_rank: number;
   status: string;
+  provenance: PlaceProvenance;
 }
 
 export interface Guide {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -786,7 +786,19 @@ select {
   font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
+.guide-map-popup {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 12rem;
+  font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
 .guide-map .leaflet-popup-content strong {
+  font-size: 1.1rem;
+  font-weight: 900;
+}
+
+.guide-map-popup strong {
   font-size: 1.1rem;
   font-weight: 900;
 }
@@ -795,7 +807,17 @@ select {
   color: var(--muted);
 }
 
+.guide-map-popup span {
+  color: var(--muted);
+}
+
 .guide-map .leaflet-popup-content a {
+  margin-top: 0.35rem;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.guide-map-popup a {
   margin-top: 0.35rem;
   color: var(--accent);
   font-weight: 700;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -786,7 +786,7 @@ select {
   font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
-.guide-map-popup {
+.guide-map-popup-content {
   display: grid;
   gap: 0.25rem;
   min-width: 12rem;
@@ -798,7 +798,7 @@ select {
   font-weight: 900;
 }
 
-.guide-map-popup strong {
+.guide-map-popup-content strong {
   font-size: 1.1rem;
   font-weight: 900;
 }
@@ -807,7 +807,7 @@ select {
   color: var(--muted);
 }
 
-.guide-map-popup span {
+.guide-map-popup-content span {
   color: var(--muted);
 }
 
@@ -817,7 +817,7 @@ select {
   font-weight: 700;
 }
 
-.guide-map-popup a {
+.guide-map-popup-content a {
   margin-top: 0.35rem;
   color: var(--accent);
   font-weight: 700;

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -241,6 +241,24 @@ class BuildDataTests(unittest.TestCase):
         self.assertIn("shibuya", first_place.tags)
         self.assertIn("specialty", first_place.tags)
         self.assertIn("tokyo", first_place.tags)
+        self.assertEqual(first_place.provenance.name.source, "google_list")
+        self.assertEqual(first_place.provenance.address.source, "google_list")
+        self.assertEqual(first_place.provenance.maps_url.source, "google_places")
+        self.assertEqual(first_place.provenance.primary_category.source, "manual")
+        self.assertEqual(first_place.provenance.note.source, "manual")
+        self.assertEqual(first_place.provenance.top_pick.source, "manual")
+        self.assertEqual(first_place.provenance.status.source, "google_places")
+        self.assertEqual(
+            {field.value: field.source for field in first_place.provenance.tags},
+            {
+                "specialty": "manual",
+                "tokyo": "google_list",
+                "shibuya": "google_list",
+                "bakery": "manual",
+                "cafe": "google_places",
+                "food": "google_places",
+            },
+        )
         self.assertTrue(hidden_place.hidden)
 
     def test_guide_location_center_excludes_far_outliers(self) -> None:
@@ -484,6 +502,73 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(second_place.name, "Fallback Name")
         self.assertTrue(
             build_data.stable_place_id(second_place, source_type="google_export_csv").startswith("url:")
+        )
+
+    def test_normalize_guide_prefers_enrichment_name_for_csv_sources_and_tracks_provenance(self) -> None:
+        raw = RawSavedList(
+            title="Taipei, Taiwan",
+            configured_source_type="google_export_csv",
+            fetched_at="2026-04-15T00:00:00+00:00",
+            refresh_after="2026-04-29T00:00:00+00:00",
+            places=[
+                RawPlace(
+                    name="Legacy Tea Stop",
+                    address=None,
+                    maps_url="https://maps.google.com/?cid=1",
+                    maps_place_token="0xabc123:0xdef456",
+                )
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0], source_type=raw.configured_source_type)
+        enrichment_cache = {
+            place_id: EnrichmentCacheEntry(
+                fetched_at="2026-04-16T00:00:00+00:00",
+                refresh_after="2026-04-23T00:00:00+00:00",
+                query="Legacy Tea Stop",
+                matched=True,
+                score=80,
+                place=EnrichmentPlace(
+                    display_name="Modern Tea House",
+                    formatted_address="1 Songshan, Taipei, Taiwan",
+                    google_maps_uri="https://maps.google.com/?cid=override",
+                    primary_type_display_name="Tea house",
+                    types=["tea_house"],
+                ),
+            )
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+
+            with (
+                patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+            ):
+                guide = build_data.normalize_guide(
+                    "taipei-taiwan",
+                    raw,
+                    enrichment_cache=enrichment_cache,
+                )
+
+        place = guide.places[0]
+        self.assertEqual(place.name, "Modern Tea House")
+        self.assertEqual(place.address, "1 Songshan, Taipei, Taiwan")
+        self.assertEqual(place.maps_url, "https://maps.google.com/?cid=override")
+        self.assertEqual(place.provenance.name.source, "google_places")
+        self.assertEqual(place.provenance.name.fetched_at, "2026-04-16T00:00:00+00:00")
+        self.assertEqual(place.provenance.address.source, "google_places")
+        self.assertEqual(place.provenance.maps_url.source, "google_places")
+        self.assertEqual(place.provenance.primary_category.source, "google_places")
+        self.assertEqual(
+            {field.value: field.source for field in place.provenance.tags},
+            {
+                "taipei": "google_list",
+                "tea-house": "google_places",
+            },
         )
 
     def test_resolve_refresh_sources_matches_csv_path_selector(self) -> None:


### PR DESCRIPTION
## Summary
- add `FieldSource`, `PlaceField`, and `PlaceProvenance` models to normalized place data and populate per-field provenance during guide normalization
- switch guide pages to prefer Google Maps when `GOOGLE_MAPS_JS_API_KEY` is configured, while preserving a Leaflet fallback via `PUBLIC_MAP_PROVIDER=leaflet`
- tighten the Google Maps loader, popup styling, and key exposure behavior, and document the browser/server API key split

## Validation
- `uv run python3 -m unittest tests.python.test_build_data`
- `bun run test:frontend`
- `bun run check`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guide maps now support Google Maps with a Leaflet/OpenStreetMap fallback, respect PUBLIC_MAP_PROVIDER override, and select provider based on build/render-time API key presence; "Open in Google Maps" links are shown only for safe URLs.
  * Place records now include per-field provenance metadata.

* **Documentation**
  * Added Environment Variables section documenting GOOGLE_MAPS_JS_API_KEY, GOOGLE_PLACES_API_KEY, PUBLIC_MAP_PROVIDER, and guide-page provider selection behavior.

* **Style**
  * Improved map popup layout and typography.

* **Tests**
  * Added tests validating provenance attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->