### PR TITLE
Improve guide tag filtering and pin warnings

### DIFF
--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -1,6 +1,62 @@
 import { loadSearchIndex, searchPlaces } from "./place-search.js";
 
-const root = document.querySelector("[data-guide-root]");
+export function cardHasTag(card, tag) {
+  const normalizedTag = String(tag || "").trim().toLowerCase();
+  if (!normalizedTag) {
+    return true;
+  }
+
+  return `${card.dataset.tags || ""} ${card.dataset.vibeTags || ""}`
+    .split(/\s+/)
+    .includes(normalizedTag);
+}
+
+export function matchesCardSearch(card, { normalizedQuery = "", searchResultIds = null } = {}) {
+  return searchResultIds
+    ? searchResultIds.has(card.dataset.placeId || "")
+    : !normalizedQuery || (card.dataset.search || "").includes(normalizedQuery);
+}
+
+export function countMatchingCards(cards, {
+  activeArea = "",
+  mapFramePlaceIds = null,
+  normalizedQuery = "",
+  searchResultIds = null,
+  tag = "",
+} = {}) {
+  return cards.filter((card) => {
+    const matchesSearch = matchesCardSearch(card, { normalizedQuery, searchResultIds });
+    const matchesArea = !activeArea || (card.dataset.neighborhood || "") === activeArea;
+    const matchesMapFrame = !mapFramePlaceIds || mapFramePlaceIds.has(card.dataset.placeId || "");
+    return matchesSearch && matchesArea && matchesMapFrame && cardHasTag(card, tag);
+  }).length;
+}
+
+export function buildAreaFilterStatusMessage({ activeAreaLabel, visibleCount, overflowCount }) {
+  if (!activeAreaLabel || overflowCount <= 0) {
+    return "";
+  }
+
+  return `Showing ${visibleCount} place${visibleCount === 1 ? "" : "s"} in ${activeAreaLabel}. ${overflowCount} more match elsewhere in this guide.`;
+}
+
+export function buildEmptyStateMessage({ activeAreaLabel = "", overflowCount = 0, query = "" }) {
+  if (query && activeAreaLabel && overflowCount > 0) {
+    return `No places matched "${query}" in ${activeAreaLabel}. ${overflowCount} more match elsewhere in this guide. Try another area or clear the area filter.`;
+  }
+  if (activeAreaLabel && overflowCount > 0) {
+    return `No matches in ${activeAreaLabel}. ${overflowCount} more match elsewhere in this guide. Try another area or clear the area filter.`;
+  }
+  if (query) {
+    return `No places matched "${query}" in this guide. Try a broader search or clear filters.`;
+  }
+  if (activeAreaLabel) {
+    return `No matches in ${activeAreaLabel}. Try another area or clear the area filter.`;
+  }
+  return "No matches. Try a broader search or clear the tag filter.";
+}
+
+const root = typeof document === "undefined" ? null : document.querySelector("[data-guide-root]");
 
 if (root) {
   const cards = Array.from(root.querySelectorAll("[data-place-card]"));
@@ -11,6 +67,7 @@ if (root) {
   const areaButtons = Array.from(root.querySelectorAll("[data-area-filter]"));
   const resultsCount = root.querySelector("[data-results-count]");
   const emptyState = root.querySelector("[data-empty-state]");
+  const areaFilterStatus = root.querySelector("[data-area-filter-status]");
   const mapFilterStatus = root.querySelector("[data-map-filter-status]");
   const mapFilterResetButtons = Array.from(root.querySelectorAll("[data-map-filter-reset]"));
   const guideSlug = root.dataset.guideSlug || "";
@@ -36,13 +93,6 @@ if (root) {
       || (left.dataset.name || "").localeCompare(right.dataset.name || ""),
   };
 
-  const fallbackMatches = (card, query) => {
-    const tagText = `${card.dataset.tags || ""} ${card.dataset.vibeTags || ""}`;
-    const matchesQuery = !query || (card.dataset.search || "").includes(query);
-    const matchesTag = !activeTag || tagText.split(" ").includes(activeTag);
-    return matchesQuery && matchesTag;
-  };
-
   const clearMapFrameFilter = () => {
     mapFramePlaceIds = null;
     update("map-reset");
@@ -60,7 +110,6 @@ if (root) {
         index: searchIndex,
         scope: "guide",
         guideSlug,
-        activeFilters: { tag: activeTag },
       })
       : null;
     const searchResultIds = searchState
@@ -70,16 +119,41 @@ if (root) {
       ? new Map(searchState.results.map((result) => [result.entry.id, result.score]))
       : new Map();
 
+    const activeAreaLabel = areaButtons.find((button) => (button.dataset.area || "") === activeArea)?.dataset.areaLabel || "";
     const visibleCards = cards.filter((card) => {
-      const matchesSearch = searchResultIds
-        ? searchResultIds.has(card.dataset.placeId || "")
-        : fallbackMatches(card, normalizedQuery);
+      const matchesSearch = matchesCardSearch(card, { normalizedQuery, searchResultIds });
+      const matchesTag = cardHasTag(card, activeTag);
       const matchesArea = !activeArea || (card.dataset.neighborhood || "") === activeArea;
       const matchesMapFrame = !mapFramePlaceIds || mapFramePlaceIds.has(card.dataset.placeId || "");
-      const visible = matchesSearch && matchesArea && matchesMapFrame;
+      const visible = matchesSearch && matchesTag && matchesArea && matchesMapFrame;
       card.hidden = !visible;
       card.dataset.searchHighlight = highlightedPlaceId && card.dataset.placeId === highlightedPlaceId ? "true" : "false";
       return visible;
+    });
+    const broaderAreaCount = activeArea
+      ? countMatchingCards(cards, {
+        mapFramePlaceIds,
+        normalizedQuery,
+        searchResultIds,
+        tag: activeTag,
+      })
+      : visibleCards.length;
+    const areaOverflowCount = activeArea ? Math.max(0, broaderAreaCount - visibleCards.length) : 0;
+
+    tagButtons.forEach((button) => {
+      const tag = button.dataset.tag || "";
+      const count = countMatchingCards(cards, {
+        activeArea,
+        mapFramePlaceIds,
+        normalizedQuery,
+        searchResultIds,
+        tag,
+      });
+      button.dataset.tagCount = String(count);
+      const countText = button.querySelector("[data-tag-count-text]");
+      if (countText) {
+        countText.textContent = String(count);
+      }
     });
 
     const sorter = normalizedQuery && sort === "curated" && searchResultIds
@@ -100,9 +174,21 @@ if (root) {
 
     if (emptyState) {
       emptyState.dataset.visible = visibleCards.length === 0 ? "true" : "false";
-      emptyState.textContent = query
-        ? `No places matched "${query}" in this guide. Try a broader search or clear filters.`
-        : "No matches. Try a broader search or clear the tag filter.";
+      emptyState.textContent = buildEmptyStateMessage({
+        activeAreaLabel,
+        overflowCount: areaOverflowCount,
+        query,
+      });
+    }
+
+    if (areaFilterStatus) {
+      const message = buildAreaFilterStatusMessage({
+        activeAreaLabel,
+        visibleCount: visibleCards.length,
+        overflowCount: areaOverflowCount,
+      });
+      areaFilterStatus.hidden = !message;
+      areaFilterStatus.textContent = message;
     }
 
     if (mapFilterStatus) {

--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -136,7 +136,6 @@ if (root) {
     });
     const broaderAreaCount = activeArea
       ? countMatchingCards(cards, {
-        mapFramePlaceIds,
         normalizedQuery,
         searchResultIds,
         tag: activeTag,

--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -1,14 +1,45 @@
 import { loadSearchIndex, searchPlaces } from "./place-search.js";
 
+function getTagComparisonValue(value) {
+  const normalizedText = String(value || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+  const slug = normalizedText
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return slug || normalizedText;
+}
+
+function parseCardTagValues(value) {
+  if (!value) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.map((item) => getTagComparisonValue(item)).filter(Boolean) : [];
+  } catch {
+    return String(value)
+      .split(/\s+/)
+      .map((item) => getTagComparisonValue(item))
+      .filter(Boolean);
+  }
+}
+
 export function cardHasTag(card, tag) {
-  const normalizedTag = String(tag || "").trim().toLowerCase();
+  const normalizedTag = getTagComparisonValue(tag);
   if (!normalizedTag) {
     return true;
   }
 
-  return `${card.dataset.tags || ""} ${card.dataset.vibeTags || ""}`
-    .split(/\s+/)
-    .includes(normalizedTag);
+  return [
+    ...parseCardTagValues(card.dataset.tags),
+    ...parseCardTagValues(card.dataset.vibeTags),
+  ].includes(normalizedTag);
 }
 
 export function matchesCardSearch(card, { normalizedQuery = "", searchResultIds = null } = {}) {
@@ -33,7 +64,7 @@ export function countMatchingCards(cards, {
 }
 
 export function buildAreaFilterStatusMessage({ activeAreaLabel, visibleCount, overflowCount }) {
-  if (!activeAreaLabel || overflowCount <= 0) {
+  if (!activeAreaLabel || overflowCount <= 0 || visibleCount <= 0) {
     return "";
   }
 
@@ -45,6 +76,9 @@ export function buildEmptyStateMessage({ activeAreaLabel = "", overflowCount = 0
 
   if (query && activeAreaLabel && overflowCount > 0) {
     return `No places matched "${query}" in ${activeAreaLabel}. ${overflowCount} more ${matchWord} elsewhere in this guide. Try another area or clear the area filter.`;
+  }
+  if (query && activeAreaLabel) {
+    return `No places matched "${query}" in ${activeAreaLabel}. Try another area or clear the area filter.`;
   }
   if (activeAreaLabel && overflowCount > 0) {
     return `No matches in ${activeAreaLabel}. ${overflowCount} more ${matchWord} elsewhere in this guide. Try another area or clear the area filter.`;

--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -37,15 +37,17 @@ export function buildAreaFilterStatusMessage({ activeAreaLabel, visibleCount, ov
     return "";
   }
 
-  return `Showing ${visibleCount} place${visibleCount === 1 ? "" : "s"} in ${activeAreaLabel}. ${overflowCount} more match elsewhere in this guide.`;
+  return `Showing ${visibleCount} place${visibleCount === 1 ? "" : "s"} in ${activeAreaLabel}. ${overflowCount} more match${overflowCount === 1 ? "" : "es"} elsewhere in this guide.`;
 }
 
 export function buildEmptyStateMessage({ activeAreaLabel = "", overflowCount = 0, query = "" }) {
+  const matchWord = overflowCount === 1 ? "match" : "matches";
+
   if (query && activeAreaLabel && overflowCount > 0) {
-    return `No places matched "${query}" in ${activeAreaLabel}. ${overflowCount} more match elsewhere in this guide. Try another area or clear the area filter.`;
+    return `No places matched "${query}" in ${activeAreaLabel}. ${overflowCount} more ${matchWord} elsewhere in this guide. Try another area or clear the area filter.`;
   }
   if (activeAreaLabel && overflowCount > 0) {
-    return `No matches in ${activeAreaLabel}. ${overflowCount} more match elsewhere in this guide. Try another area or clear the area filter.`;
+    return `No matches in ${activeAreaLabel}. ${overflowCount} more ${matchWord} elsewhere in this guide. Try another area or clear the area filter.`;
   }
   if (query) {
     return `No places matched "${query}" in this guide. Try a broader search or clear filters.`;
@@ -119,7 +121,9 @@ if (root) {
       ? new Map(searchState.results.map((result) => [result.entry.id, result.score]))
       : new Map();
 
-    const activeAreaLabel = areaButtons.find((button) => (button.dataset.area || "") === activeArea)?.dataset.areaLabel || "";
+    const activeAreaLabel = activeArea
+      ? areaButtons.find((button) => (button.dataset.area || "") === activeArea)?.dataset.areaLabel || ""
+      : "";
     const visibleCards = cards.filter((card) => {
       const matchesSearch = matchesCardSearch(card, { normalizedQuery, searchResultIds });
       const matchesTag = cardHasTag(card, activeTag);

--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -175,7 +175,15 @@ if (root) {
         tag: activeTag,
       })
       : visibleCards.length;
-    const areaOverflowCount = activeArea ? Math.max(0, broaderAreaCount - visibleCards.length) : 0;
+    const areaMatchCount = activeArea
+      ? countMatchingCards(cards, {
+        activeArea,
+        normalizedQuery,
+        searchResultIds,
+        tag: activeTag,
+      })
+      : visibleCards.length;
+    const areaOverflowCount = activeArea ? Math.max(0, broaderAreaCount - areaMatchCount) : 0;
 
     tagButtons.forEach((button) => {
       const tag = button.dataset.tag || "";

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -45,7 +45,8 @@ OPERATIONAL_CACHE_TTL = timedelta(days=14)
 RAW_SOURCE_CACHE_TTL = timedelta(days=14)
 RAW_SOURCE_REFRESH_JITTER = timedelta(days=3)
 STRONG_MATCH_SCORE = 45
-MAP_PIN_DISTANCE_WARNING_METERS = 200_000.0
+MAP_PIN_DISTANCE_WARNING_MIN_METERS = 100_000.0
+MAP_PIN_DISTANCE_WARNING_BUFFER_METERS = 50_000.0
 PLACES_TEXT_SEARCH_URL = "https://places.googleapis.com/v1/places:searchText"
 COUNTRY_LOCALITY_ALIASES = (
     "England",
@@ -945,8 +946,9 @@ def warn_far_map_pins(
     places: list[NormalizedPlace],
     center: tuple[float | None, float | None],
 ) -> None:
+    warning_distance_meters = guide_map_pin_warning_distance_meters(places, center)
     center_lat, center_lng = center
-    if center_lat is None or center_lng is None:
+    if center_lat is None or center_lng is None or warning_distance_meters is None:
         return
 
     for place in places:
@@ -954,7 +956,7 @@ def warn_far_map_pins(
             continue
 
         distance_meters = haversine_meters(center_lat, center_lng, place.lat, place.lng)
-        if distance_meters < MAP_PIN_DISTANCE_WARNING_METERS:
+        if distance_meters < warning_distance_meters:
             continue
 
         print(
@@ -963,6 +965,35 @@ def warn_far_map_pins(
             f"{distance_meters / 1000:.0f} km from the guide center; "
             "check whether it belongs in this city/country."
         )
+
+
+def guide_map_pin_warning_distance_meters(
+    places: list[NormalizedPlace],
+    center: tuple[float | None, float | None],
+) -> float | None:
+    center_lat, center_lng = center
+    if center_lat is None or center_lng is None:
+        return None
+
+    coordinates = [
+        (place.lat, place.lng)
+        for place in places
+        if place.lat is not None and place.lng is not None
+    ]
+    if not coordinates:
+        return None
+    if len(coordinates) < 4:
+        return MAP_PIN_DISTANCE_WARNING_MIN_METERS
+
+    inlier_coordinates = guide_location_inliers(coordinates)
+    inlier_radius_meters = max(
+        haversine_meters(center_lat, center_lng, latitude, longitude)
+        for latitude, longitude in inlier_coordinates
+    )
+    return max(
+        MAP_PIN_DISTANCE_WARNING_MIN_METERS,
+        inlier_radius_meters + MAP_PIN_DISTANCE_WARNING_BUFFER_METERS,
+    )
 
 
 def guide_location_inliers(coordinates: list[tuple[float, float]]) -> list[tuple[float, float]]:

--- a/src/components/GuideCard.astro
+++ b/src/components/GuideCard.astro
@@ -1,5 +1,6 @@
 ---
 import type { GuideManifest } from "../lib/types";
+import { getDisplayGuideTags } from "../lib/placeTags";
 import { renderRichText } from "../lib/renderRichText";
 
 interface Props {
@@ -8,6 +9,11 @@ interface Props {
 
 const { guide } = Astro.props;
 const guideDescriptionHtml = renderRichText(guide.description);
+const displayGuideTags = getDisplayGuideTags(guide.list_tags, {
+  cityName: guide.city_name,
+  countryCode: guide.country_code,
+  countryName: guide.country_name,
+});
 const guideSearchText = [
   guide.title,
   guide.description,
@@ -71,11 +77,13 @@ const guideDisplayTitle = trimCountryFromTitle(guide.title);
     }
   </div>
 
-  <div class="tag-row">
-    {guide.list_tags.slice(0, 4).map((tag) => (
-      <span class="tag-pill">#{tag}</span>
-    ))}
-  </div>
+  {displayGuideTags.length > 0 && (
+    <div class="tag-row">
+      {displayGuideTags.slice(0, 4).map((tag) => (
+        <span class="tag-pill">#{tag}</span>
+      ))}
+    </div>
+  )}
 
   <div class="guide-card-footer">
     <div class="stats-row">

--- a/src/components/PlaceCard.astro
+++ b/src/components/PlaceCard.astro
@@ -1,6 +1,6 @@
 ---
 import type { Place } from "../lib/types";
-import { getDisplayGuideTags, getDisplayPlaceTags } from "../lib/placeTags";
+import { getDisplayGuideTags, getDisplayPlaceTags, getTagComparisonValue } from "../lib/placeTags";
 import { renderRichText } from "../lib/renderRichText";
 
 interface Props {
@@ -15,6 +15,8 @@ interface Props {
 const { guideContext = {}, place } = Astro.props;
 const displayTags = getDisplayGuideTags(getDisplayPlaceTags(place.tags), guideContext);
 const displayVibeTags = getDisplayPlaceTags(place.vibe_tags);
+const filterTagTokens = JSON.stringify(displayTags.map(getTagComparisonValue));
+const filterVibeTagTokens = JSON.stringify(displayVibeTags.map(getTagComparisonValue));
 const whyRecommendedHtml = renderRichText(place.why_recommended);
 const noteHtml = renderRichText(place.note);
 ---
@@ -25,8 +27,8 @@ const noteHtml = renderRichText(place.note);
   data-place-card
   data-place-id={place.id}
   data-name={place.name.toLowerCase()}
-  data-tags={displayTags.join(" ").toLowerCase()}
-  data-vibe-tags={displayVibeTags.join(" ").toLowerCase()}
+  data-tags={filterTagTokens}
+  data-vibe-tags={filterVibeTagTokens}
   data-category={(place.primary_category ?? "").toLowerCase()}
   data-neighborhood={(place.neighborhood ?? "").toLowerCase()}
   data-top-pick={place.top_pick ? "true" : "false"}

--- a/src/components/PlaceCard.astro
+++ b/src/components/PlaceCard.astro
@@ -1,14 +1,19 @@
 ---
 import type { Place } from "../lib/types";
-import { getDisplayPlaceTags } from "../lib/placeTags";
+import { getDisplayGuideTags, getDisplayPlaceTags } from "../lib/placeTags";
 import { renderRichText } from "../lib/renderRichText";
 
 interface Props {
+  guideContext?: {
+    cityName?: string | null;
+    countryCode?: string | null;
+    countryName?: string | null;
+  };
   place: Place;
 }
 
-const { place } = Astro.props;
-const displayTags = getDisplayPlaceTags(place.tags);
+const { guideContext = {}, place } = Astro.props;
+const displayTags = getDisplayGuideTags(getDisplayPlaceTags(place.tags), guideContext);
 const displayVibeTags = getDisplayPlaceTags(place.vibe_tags);
 const whyRecommendedHtml = renderRichText(place.why_recommended);
 const noteHtml = renderRichText(place.note);
@@ -52,11 +57,13 @@ const noteHtml = renderRichText(place.note);
   {noteHtml && <p class="small-copy rich-copy" set:html={noteHtml} />}
   {place.address && <p class="small-copy">{place.address}</p>}
 
-  <div class="tag-row">
-    {displayTags.map((tag) => (
-      <span class="tag-pill">#{tag}</span>
-    ))}
-  </div>
+  {displayTags.length > 0 && (
+    <div class="tag-row">
+      {displayTags.map((tag) => (
+        <span class="tag-pill">#{tag}</span>
+      ))}
+    </div>
+  )}
 
   <div class="place-card-footer">
     <a class="action-pill" href={place.maps_url} target="_blank" rel="noreferrer">

--- a/src/lib/placeTags.ts
+++ b/src/lib/placeTags.ts
@@ -52,6 +52,17 @@ export function normalizeTagValue(value: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
+export function getTagComparisonValue(value: string): string {
+  const normalizedText = value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+
+  return normalizeTagValue(normalizedText) || normalizedText;
+}
+
 function getGuideLocationTagsToHide({
   cityName,
   countryCode,
@@ -59,7 +70,7 @@ function getGuideLocationTagsToHide({
 }: GuideTagContext): Set<string> {
   const hiddenTags = new Set<string>();
   const addTag = (value?: string | null) => {
-    const normalized = value ? normalizeTagValue(value) : "";
+    const normalized = value ? getTagComparisonValue(value) : "";
     if (normalized) {
       hiddenTags.add(normalized);
       (COUNTRY_TAG_ALIASES[normalized] ?? []).forEach((alias) => hiddenTags.add(alias));
@@ -90,8 +101,8 @@ export function getDisplayPlaceTags(tags: string[]): string[] {
 export function getDisplayGuideTags(tags: string[], context: GuideTagContext = {}): string[] {
   const hiddenTags = getGuideLocationTagsToHide(context);
   return tags.filter((tag) => {
-    const normalizedTag = normalizeTagValue(tag);
-    return normalizedTag.length > 0 && !hiddenTags.has(normalizedTag);
+    const normalizedTag = getTagComparisonValue(tag);
+    return tag.trim().length > 0 && !hiddenTags.has(normalizedTag);
   });
 }
 

--- a/src/lib/placeTags.ts
+++ b/src/lib/placeTags.ts
@@ -42,7 +42,7 @@ function normalizeAreaText(area: string): string {
     .toLowerCase();
 }
 
-function slugifyTagValue(value: string): string {
+export function normalizeTagValue(value: string): string {
   return value
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
@@ -59,7 +59,7 @@ function getGuideLocationTagsToHide({
 }: GuideTagContext): Set<string> {
   const hiddenTags = new Set<string>();
   const addTag = (value?: string | null) => {
-    const normalized = value ? slugifyTagValue(value) : "";
+    const normalized = value ? normalizeTagValue(value) : "";
     if (normalized) {
       hiddenTags.add(normalized);
       (COUNTRY_TAG_ALIASES[normalized] ?? []).forEach((alias) => hiddenTags.add(alias));
@@ -90,7 +90,7 @@ export function getDisplayPlaceTags(tags: string[]): string[] {
 export function getDisplayGuideTags(tags: string[], context: GuideTagContext = {}): string[] {
   const hiddenTags = getGuideLocationTagsToHide(context);
   return tags.filter((tag) => {
-    const normalizedTag = slugifyTagValue(tag);
+    const normalizedTag = normalizeTagValue(tag);
     return normalizedTag.length > 0 && !hiddenTags.has(normalizedTag);
   });
 }

--- a/src/lib/placeTags.ts
+++ b/src/lib/placeTags.ts
@@ -9,6 +9,14 @@ const ADDRESS_TAG_PATTERNS = [
 const STREET_AREA_PATTERN =
   /^(p\.|d\.|ng\.|c\/|c\.|carrer\b|rda\.|calle\b|av\b|av\.|jl\.|jalan\b|ngo\b|duong\b)/;
 const DEFAULT_AREA_FILTER_LIMIT = 12;
+const GUIDE_LOCATION_PART_SPLIT_PATTERN = /\s*(?:&|\/|\+|\band\b)\s*/i;
+const COUNTRY_TAG_ALIASES: Record<string, string[]> = {
+  korea: ["kr", "south-korea"],
+  "south-korea": ["kr", "korea"],
+  "united-arab-emirates": ["ae", "uae"],
+  "united-kingdom": ["gb", "uk"],
+  "united-states": ["us", "usa"],
+};
 
 interface AreaFilterPlace {
   neighborhood: string | null;
@@ -20,12 +28,54 @@ export interface AreaFilter {
   count: number;
 }
 
+interface GuideTagContext {
+  cityName?: string | null;
+  countryCode?: string | null;
+  countryName?: string | null;
+}
+
 function normalizeAreaText(area: string): string {
   return area
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
     .trim()
     .toLowerCase();
+}
+
+function slugifyTagValue(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function getGuideLocationTagsToHide({
+  cityName,
+  countryCode,
+  countryName,
+}: GuideTagContext): Set<string> {
+  const hiddenTags = new Set<string>();
+  const addTag = (value?: string | null) => {
+    const normalized = value ? slugifyTagValue(value) : "";
+    if (normalized) {
+      hiddenTags.add(normalized);
+      (COUNTRY_TAG_ALIASES[normalized] ?? []).forEach((alias) => hiddenTags.add(alias));
+    }
+  };
+
+  addTag(cityName);
+  cityName
+    ?.split(GUIDE_LOCATION_PART_SPLIT_PATTERN)
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .forEach(addTag);
+  addTag(countryName);
+  addTag(countryCode);
+
+  return hiddenTags;
 }
 
 export function isDisplayPlaceTag(tag: string): boolean {
@@ -35,6 +85,14 @@ export function isDisplayPlaceTag(tag: string): boolean {
 
 export function getDisplayPlaceTags(tags: string[]): string[] {
   return tags.filter(isDisplayPlaceTag);
+}
+
+export function getDisplayGuideTags(tags: string[], context: GuideTagContext = {}): string[] {
+  const hiddenTags = getGuideLocationTagsToHide(context);
+  return tags.filter((tag) => {
+    const normalizedTag = slugifyTagValue(tag);
+    return normalizedTag.length > 0 && !hiddenTags.has(normalizedTag);
+  });
 }
 
 export function getGuideAreaFilters(

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -4,7 +4,7 @@ import { siteConfig } from "../../data/site";
 import GuideMap from "../../components/GuideMap.astro";
 import PlaceCard from "../../components/PlaceCard.astro";
 import { getGuides } from "../../lib/data";
-import { getDisplayPlaceTags, getGuideAreaFilters } from "../../lib/placeTags";
+import { getDisplayGuideTags, getDisplayPlaceTags, getGuideAreaFilters } from "../../lib/placeTags";
 import { renderRichText } from "../../lib/renderRichText";
 
 export function getStaticPaths() {
@@ -19,6 +19,11 @@ const { guide } = Astro.props;
 const visiblePlaces = guide.places.filter((place) => !place.hidden);
 const topPicks = visiblePlaces.filter((place) => guide.featured_place_ids.includes(place.id)).slice(0, 3);
 const areaFilters = getGuideAreaFilters(visiblePlaces);
+const displayGuideTags = getDisplayGuideTags(guide.list_tags, {
+  cityName: guide.city_name,
+  countryCode: guide.country_code,
+  countryName: guide.country_name,
+});
 const guideVibeFilters = [
   ...new Set(
     visiblePlaces.flatMap((place) =>
@@ -41,6 +46,13 @@ const guideVibeFilters = [
 ].sort((a, b) => a.localeCompare(b));
 const guideDescriptionHtml = renderRichText(guide.description);
 const formatVibeLabel = (tag: string) => tag.replaceAll("-", " ");
+const countPlacesForVibe = (tag: string) =>
+  visiblePlaces.filter((place) => getDisplayPlaceTags(place.vibe_tags).includes(tag)).length;
+const placeTagGuideContext = {
+  cityName: guide.city_name,
+  countryCode: guide.country_code,
+  countryName: guide.country_name,
+};
 ---
 
 <Layout title={`${guide.title} · ${siteConfig.siteName}`} description={guide.description ?? undefined}>
@@ -68,14 +80,16 @@ const formatVibeLabel = (tag: string) => tag.replaceAll("-", " ");
         </div>
       </div>
 
-      <div class="section-stack">
-        <p class="eyebrow">List tags</p>
-        <div class="tag-row">
-          {guide.list_tags.map((tag) => (
-            <span class="tag-pill">#{tag}</span>
-          ))}
+      {displayGuideTags.length > 0 && (
+        <div class="section-stack">
+          <p class="eyebrow">List tags</p>
+          <div class="tag-row">
+            {displayGuideTags.map((tag) => (
+              <span class="tag-pill">#{tag}</span>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   </section>
 
@@ -90,7 +104,7 @@ const formatVibeLabel = (tag: string) => tag.replaceAll("-", " ");
 
       <div class="top-picks-grid">
         {topPicks.map((place) => (
-          <PlaceCard place={place} />
+          <PlaceCard place={place} guideContext={placeTagGuideContext} />
         ))}
       </div>
     </section>
@@ -132,11 +146,17 @@ const formatVibeLabel = (tag: string) => tag.replaceAll("-", " ");
               <div class="control-group" style="grid-column: 1 / -1;">
                 <span class="control-label">Area</span>
                 <div class="tag-row">
-                  <button class="tag-pill" type="button" data-area-filter data-area="">
+                  <button class="tag-pill" type="button" data-area-filter data-area="" data-area-label="All areas">
                     All
                   </button>
                   {areaFilters.map((area) => (
-                    <button class="tag-pill" type="button" data-area-filter data-area={area.value}>
+                    <button
+                      class="tag-pill"
+                      type="button"
+                      data-area-filter
+                      data-area={area.value}
+                      data-area-label={area.label}
+                    >
                       {area.label} ({area.count})
                     </button>
                   ))}
@@ -148,12 +168,28 @@ const formatVibeLabel = (tag: string) => tag.replaceAll("-", " ");
               <div class="control-group" style="grid-column: 1 / -1;">
                 <span class="control-label">Vibe</span>
                 <div class="tag-row">
-                  <button class="tag-pill" type="button" data-tag-filter data-tag="">
-                    All
+                  <button
+                    class="tag-pill"
+                    type="button"
+                    data-tag-filter
+                    data-tag=""
+                    data-tag-label="All"
+                    data-tag-count={visiblePlaces.length}
+                  >
+                    <span>All</span>
+                    <span class="tag-pill-count" data-tag-count-text>{visiblePlaces.length}</span>
                   </button>
                   {guideVibeFilters.map((tag) => (
-                    <button class="tag-pill" type="button" data-tag-filter data-tag={tag}>
-                      {formatVibeLabel(tag)}
+                    <button
+                      class="tag-pill"
+                      type="button"
+                      data-tag-filter
+                      data-tag={tag}
+                      data-tag-label={formatVibeLabel(tag)}
+                      data-tag-count={countPlacesForVibe(tag)}
+                    >
+                      <span>{formatVibeLabel(tag)}</span>
+                      <span class="tag-pill-count" data-tag-count-text>{countPlacesForVibe(tag)}</span>
                     </button>
                   ))}
                 </div>
@@ -166,12 +202,13 @@ const formatVibeLabel = (tag: string) => tag.replaceAll("-", " ");
           <p class="small-copy" data-results-count>{visiblePlaces.length} places</p>
           <button class="map-filter-reset" type="button" data-map-filter-reset hidden>Reset map</button>
         </div>
+        <p class="map-filter-status small-copy" data-area-filter-status hidden></p>
         <p class="map-filter-status small-copy" data-map-filter-status hidden>Filtered to the visible map area.</p>
         <div class="empty-state" data-empty-state>No matches. Try a broader search or clear the tag filter.</div>
 
         <div class="card-grid" data-kind="places" data-place-list>
           {visiblePlaces.map((place) => (
-            <PlaceCard place={place} />
+            <PlaceCard place={place} guideContext={placeTagGuideContext} />
           ))}
         </div>
       </div>

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -24,30 +24,31 @@ const displayGuideTags = getDisplayGuideTags(guide.list_tags, {
   countryCode: guide.country_code,
   countryName: guide.country_name,
 });
-const guideVibeFilters = [
-  ...new Set(
-    visiblePlaces.flatMap((place) =>
-      getDisplayPlaceTags(place.vibe_tags).filter((tag) =>
-        [
-          "cozy",
-          "quiet",
-          "lively",
-          "date-night",
-          "laptop-friendly",
-          "scenic",
-          "hidden-gem",
-          "cheap-eats",
-          "splurge",
-          "rainy-day",
-        ].includes(tag),
-      ),
-    ),
-  ),
-].sort((a, b) => a.localeCompare(b));
+const supportedGuideVibeTags = new Set([
+  "cozy",
+  "quiet",
+  "lively",
+  "date-night",
+  "laptop-friendly",
+  "scenic",
+  "hidden-gem",
+  "cheap-eats",
+  "splurge",
+  "rainy-day",
+]);
+const guideVibeCounts = visiblePlaces.reduce((counts, place) => {
+  getDisplayPlaceTags(place.vibe_tags).forEach((tag) => {
+    if (!supportedGuideVibeTags.has(tag)) {
+      return;
+    }
+
+    counts.set(tag, (counts.get(tag) ?? 0) + 1);
+  });
+  return counts;
+}, new Map<string, number>());
+const guideVibeFilters = [...guideVibeCounts.keys()].sort((a, b) => a.localeCompare(b));
 const guideDescriptionHtml = renderRichText(guide.description);
 const formatVibeLabel = (tag: string) => tag.replaceAll("-", " ");
-const countPlacesForVibe = (tag: string) =>
-  visiblePlaces.filter((place) => getDisplayPlaceTags(place.vibe_tags).includes(tag)).length;
 const placeTagGuideContext = {
   cityName: guide.city_name,
   countryCode: guide.country_code,
@@ -186,10 +187,10 @@ const placeTagGuideContext = {
                       data-tag-filter
                       data-tag={tag}
                       data-tag-label={formatVibeLabel(tag)}
-                      data-tag-count={countPlacesForVibe(tag)}
+                      data-tag-count={guideVibeCounts.get(tag) ?? 0}
                     >
                       <span>{formatVibeLabel(tag)}</span>
-                      <span class="tag-pill-count" data-tag-count-text>{countPlacesForVibe(tag)}</span>
+                      <span class="tag-pill-count" data-tag-count-text>{guideVibeCounts.get(tag) ?? 0}</span>
                     </button>
                   ))}
                 </div>

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -4,7 +4,12 @@ import { siteConfig } from "../../data/site";
 import GuideMap from "../../components/GuideMap.astro";
 import PlaceCard from "../../components/PlaceCard.astro";
 import { getGuides } from "../../lib/data";
-import { getDisplayGuideTags, getDisplayPlaceTags, getGuideAreaFilters } from "../../lib/placeTags";
+import {
+  getDisplayGuideTags,
+  getDisplayPlaceTags,
+  getGuideAreaFilters,
+  normalizeTagValue,
+} from "../../lib/placeTags";
 import { renderRichText } from "../../lib/renderRichText";
 
 export function getStaticPaths() {
@@ -38,11 +43,12 @@ const supportedGuideVibeTags = new Set([
 ]);
 const guideVibeCounts = visiblePlaces.reduce((counts, place) => {
   getDisplayPlaceTags(place.vibe_tags).forEach((tag) => {
-    if (!supportedGuideVibeTags.has(tag)) {
+    const normalizedTag = normalizeTagValue(tag);
+    if (!supportedGuideVibeTags.has(normalizedTag)) {
       return;
     }
 
-    counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    counts.set(normalizedTag, (counts.get(normalizedTag) ?? 0) + 1);
   });
   return counts;
 }, new Map<string, number>());

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -181,6 +181,12 @@ img {
   color: var(--muted);
 }
 
+.tag-pill-count {
+  opacity: 0.72;
+  font-size: 0.76rem;
+  font-variant-numeric: tabular-nums;
+}
+
 .tag-pill[data-active="true"] {
   background: var(--accent);
   color: var(--surface);

--- a/tests/frontend/guideFilters.test.mjs
+++ b/tests/frontend/guideFilters.test.mjs
@@ -86,4 +86,25 @@ describe("guide filters", () => {
       query: "coffee",
     })).toBe('No places matched "coffee" in South Brisbane. 1 more match elsewhere in this guide. Try another area or clear the area filter.');
   });
+
+  it("lets guide-wide overflow ignore the current map frame", () => {
+    const cards = [
+      makeCard({ placeId: "1", neighborhood: "south brisbane", search: "brunch", vibeTags: "date-night" }),
+      makeCard({ placeId: "2", neighborhood: "west end", search: "brunch", vibeTags: "date-night" }),
+    ];
+
+    expect(countMatchingCards(cards, {
+      activeArea: "south brisbane",
+      mapFramePlaceIds: new Set(["1"]),
+      normalizedQuery: "brunch",
+      searchResultIds: new Set(["1", "2"]),
+      tag: "date-night",
+    })).toBe(1);
+
+    expect(countMatchingCards(cards, {
+      normalizedQuery: "brunch",
+      searchResultIds: new Set(["1", "2"]),
+      tag: "date-night",
+    })).toBe(2);
+  });
 });

--- a/tests/frontend/guideFilters.test.mjs
+++ b/tests/frontend/guideFilters.test.mjs
@@ -127,4 +127,35 @@ describe("guide filters", () => {
       tag: "date-night",
     })).toBe(2);
   });
+
+  it("does not count off-screen matches in the same area as guide-wide overflow", () => {
+    const cards = [
+      makeCard({ placeId: "1", neighborhood: "south brisbane", search: "brunch", vibeTags: "date-night" }),
+      makeCard({ placeId: "2", neighborhood: "south brisbane", search: "brunch", vibeTags: "date-night" }),
+    ];
+
+    const broaderAreaCount = countMatchingCards(cards, {
+      normalizedQuery: "brunch",
+      searchResultIds: new Set(["1", "2"]),
+      tag: "date-night",
+    });
+    const areaMatchCount = countMatchingCards(cards, {
+      activeArea: "south brisbane",
+      normalizedQuery: "brunch",
+      searchResultIds: new Set(["1", "2"]),
+      tag: "date-night",
+    });
+    const visibleCountInMapFrame = countMatchingCards(cards, {
+      activeArea: "south brisbane",
+      mapFramePlaceIds: new Set(["1"]),
+      normalizedQuery: "brunch",
+      searchResultIds: new Set(["1", "2"]),
+      tag: "date-night",
+    });
+
+    expect(broaderAreaCount).toBe(2);
+    expect(areaMatchCount).toBe(2);
+    expect(visibleCountInMapFrame).toBe(1);
+    expect(Math.max(0, broaderAreaCount - areaMatchCount)).toBe(0);
+  });
 });

--- a/tests/frontend/guideFilters.test.mjs
+++ b/tests/frontend/guideFilters.test.mjs
@@ -56,12 +56,34 @@ describe("guide filters", () => {
       activeAreaLabel: "South Brisbane",
       visibleCount: 1,
       overflowCount: 3,
-    })).toBe("Showing 1 place in South Brisbane. 3 more match elsewhere in this guide.");
+    })).toBe("Showing 1 place in South Brisbane. 3 more matches elsewhere in this guide.");
 
     expect(buildEmptyStateMessage({
       activeAreaLabel: "South Brisbane",
       overflowCount: 2,
       query: "",
-    })).toBe("No matches in South Brisbane. 2 more match elsewhere in this guide. Try another area or clear the area filter.");
+    })).toBe("No matches in South Brisbane. 2 more matches elsewhere in this guide. Try another area or clear the area filter.");
+  });
+
+  it("keeps generic empty-state copy when no area filter is active", () => {
+    expect(buildEmptyStateMessage({
+      activeAreaLabel: "",
+      overflowCount: 2,
+      query: "",
+    })).toBe("No matches. Try a broader search or clear the tag filter.");
+  });
+
+  it("uses singular overflow grammar for a single broader result", () => {
+    expect(buildAreaFilterStatusMessage({
+      activeAreaLabel: "South Brisbane",
+      visibleCount: 1,
+      overflowCount: 1,
+    })).toBe("Showing 1 place in South Brisbane. 1 more match elsewhere in this guide.");
+
+    expect(buildEmptyStateMessage({
+      activeAreaLabel: "South Brisbane",
+      overflowCount: 1,
+      query: "coffee",
+    })).toBe('No places matched "coffee" in South Brisbane. 1 more match elsewhere in this guide. Try another area or clear the area filter.');
   });
 });

--- a/tests/frontend/guideFilters.test.mjs
+++ b/tests/frontend/guideFilters.test.mjs
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAreaFilterStatusMessage,
+  buildEmptyStateMessage,
+  cardHasTag,
+  countMatchingCards,
+} from "../../public/scripts/guide-filters.js";
+
+const makeCard = ({
+  neighborhood = "",
+  placeId,
+  search = "",
+  tags = "",
+  vibeTags = "",
+}) => ({
+  dataset: {
+    neighborhood,
+    placeId,
+    search,
+    tags,
+    vibeTags,
+  },
+});
+
+describe("guide filters", () => {
+  it("counts vibe matches within the active area", () => {
+    const cards = [
+      makeCard({ placeId: "1", neighborhood: "south brisbane", search: "coffee brunch", vibeTags: "date-night scenic" }),
+      makeCard({ placeId: "2", neighborhood: "south brisbane", search: "rain museum", vibeTags: "rainy-day" }),
+      makeCard({ placeId: "3", neighborhood: "west end", search: "sunset drinks", vibeTags: "date-night scenic" }),
+    ];
+
+    expect(countMatchingCards(cards, {
+      activeArea: "south brisbane",
+      normalizedQuery: "",
+      tag: "date-night",
+    })).toBe(1);
+    expect(countMatchingCards(cards, {
+      activeArea: "south brisbane",
+      normalizedQuery: "",
+      tag: "",
+    })).toBe(2);
+  });
+
+  it("matches tags across place and vibe tag fields", () => {
+    const card = makeCard({ placeId: "1", tags: "coffee bakery", vibeTags: "cozy scenic" });
+
+    expect(cardHasTag(card, "bakery")).toBe(true);
+    expect(cardHasTag(card, "scenic")).toBe(true);
+    expect(cardHasTag(card, "date-night")).toBe(false);
+  });
+
+  it("builds area-aware status and empty messages when broader matches exist", () => {
+    expect(buildAreaFilterStatusMessage({
+      activeAreaLabel: "South Brisbane",
+      visibleCount: 1,
+      overflowCount: 3,
+    })).toBe("Showing 1 place in South Brisbane. 3 more match elsewhere in this guide.");
+
+    expect(buildEmptyStateMessage({
+      activeAreaLabel: "South Brisbane",
+      overflowCount: 2,
+      query: "",
+    })).toBe("No matches in South Brisbane. 2 more match elsewhere in this guide. Try another area or clear the area filter.");
+  });
+});

--- a/tests/frontend/guideFilters.test.mjs
+++ b/tests/frontend/guideFilters.test.mjs
@@ -44,11 +44,15 @@ describe("guide filters", () => {
   });
 
   it("matches tags across place and vibe tag fields", () => {
-    const card = makeCard({ placeId: "1", tags: "coffee bakery", vibeTags: "cozy scenic" });
+    const card = makeCard({
+      placeId: "1",
+      tags: JSON.stringify(["coffee", "bakery"]),
+      vibeTags: JSON.stringify(["Date Night", "scenic"]),
+    });
 
     expect(cardHasTag(card, "bakery")).toBe(true);
     expect(cardHasTag(card, "scenic")).toBe(true);
-    expect(cardHasTag(card, "date-night")).toBe(false);
+    expect(cardHasTag(card, "date-night")).toBe(true);
   });
 
   it("builds area-aware status and empty messages when broader matches exist", () => {
@@ -85,6 +89,22 @@ describe("guide filters", () => {
       overflowCount: 1,
       query: "coffee",
     })).toBe('No places matched "coffee" in South Brisbane. 1 more match elsewhere in this guide. Try another area or clear the area filter.');
+  });
+
+  it("suppresses the area status line when no places are visible in the selected area", () => {
+    expect(buildAreaFilterStatusMessage({
+      activeAreaLabel: "South Brisbane",
+      visibleCount: 0,
+      overflowCount: 2,
+    })).toBe("");
+  });
+
+  it("keeps the area label in query empty-state copy even with no overflow matches", () => {
+    expect(buildEmptyStateMessage({
+      activeAreaLabel: "South Brisbane",
+      overflowCount: 0,
+      query: "coffee",
+    })).toBe('No places matched "coffee" in South Brisbane. Try another area or clear the area filter.');
   });
 
   it("lets guide-wide overflow ignore the current map frame", () => {

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -38,13 +38,17 @@ describe("guide map interactions", () => {
     const guideMap = readSource("src/components/GuideMap.astro");
     const filters = readSource("public/scripts/guide-filters.js");
 
+    expect(guidePage).toContain("data-area-filter-status");
     expect(guidePage).toContain("data-map-filter-status");
+    expect(guidePage).toContain("data-tag-count-text");
     expect(guidePage).toContain("data-map-filter-reset");
     expect(guideMap).toContain("data-map-frame-filter");
     expect(guideMap).toContain("data-map-full-area");
     expect(guideMap).toContain(">Reset Map</button>");
     expect(guideMap).toContain('new CustomEvent("guide:map-frame-reset-request"');
     expect(guideMap).toContain('new CustomEvent("guide:map-frame-filter"');
+    expect(filters).toContain("countMatchingCards");
+    expect(filters).toContain("buildAreaFilterStatusMessage");
     expect(filters).toContain('root.addEventListener("guide:map-frame-filter"');
     expect(filters).toContain('root.dispatchEvent(new CustomEvent("guide:map-frame-reset"');
   });

--- a/tests/frontend/placeTags.test.ts
+++ b/tests/frontend/placeTags.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { getDisplayGuideTags, getDisplayPlaceTags, getGuideAreaFilters } from "../../src/lib/placeTags";
+import {
+  getDisplayGuideTags,
+  getDisplayPlaceTags,
+  getGuideAreaFilters,
+  normalizeTagValue,
+} from "../../src/lib/placeTags";
 
 describe("getDisplayPlaceTags", () => {
   it("keeps useful tags and hides address fragments", () => {
@@ -111,5 +116,12 @@ describe("getDisplayGuideTags", () => {
         countryName: "Tonga",
       }),
     ).toEqual([]);
+  });
+});
+
+describe("normalizeTagValue", () => {
+  it("slugifies human-readable vibe overrides for guide filter matching", () => {
+    expect(normalizeTagValue("Date Night")).toBe("date-night");
+    expect(normalizeTagValue("Laptop Friendly")).toBe("laptop-friendly");
   });
 });

--- a/tests/frontend/placeTags.test.ts
+++ b/tests/frontend/placeTags.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  getTagComparisonValue,
   getDisplayGuideTags,
   getDisplayPlaceTags,
   getGuideAreaFilters,
@@ -117,11 +118,27 @@ describe("getDisplayGuideTags", () => {
       }),
     ).toEqual([]);
   });
+
+  it("keeps non-latin tags when they are not location duplicates", () => {
+    expect(
+      getDisplayGuideTags(["東京", "coffee"], {
+        cityName: "Tonga",
+        countryCode: "TO",
+        countryName: "Tonga",
+      }),
+    ).toEqual(["東京", "coffee"]);
+  });
 });
 
 describe("normalizeTagValue", () => {
   it("slugifies human-readable vibe overrides for guide filter matching", () => {
     expect(normalizeTagValue("Date Night")).toBe("date-night");
     expect(normalizeTagValue("Laptop Friendly")).toBe("laptop-friendly");
+  });
+});
+
+describe("getTagComparisonValue", () => {
+  it("falls back to normalized non-latin text when ascii slugification is empty", () => {
+    expect(getTagComparisonValue("東京")).toBe("東京");
   });
 });

--- a/tests/frontend/placeTags.test.ts
+++ b/tests/frontend/placeTags.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getDisplayPlaceTags, getGuideAreaFilters } from "../../src/lib/placeTags";
+import { getDisplayGuideTags, getDisplayPlaceTags, getGuideAreaFilters } from "../../src/lib/placeTags";
 
 describe("getDisplayPlaceTags", () => {
   it("keeps useful tags and hides address fragments", () => {
@@ -67,6 +67,49 @@ describe("getGuideAreaFilters", () => {
         { neighborhood: "Tokyo" },
         { neighborhood: "Tokyo" },
       ]),
+    ).toEqual([]);
+  });
+});
+
+describe("getDisplayGuideTags", () => {
+  it("hides broad city and country tags while keeping more specific local tags", () => {
+    expect(
+      getDisplayGuideTags(
+        [
+          "brisbane",
+          "gold-coast",
+          "brisbane-gold-coast",
+          "australia",
+          "south-brisbane",
+          "brisbane-city-hall",
+          "coffee",
+        ],
+        {
+          cityName: "Brisbane & Gold Coast",
+          countryCode: "AU",
+          countryName: "Australia",
+        },
+      ),
+    ).toEqual(["south-brisbane", "brisbane-city-hall", "coffee"]);
+  });
+
+  it("drops common country aliases for display", () => {
+    expect(
+      getDisplayGuideTags(["usa", "new-york", "pizza"], {
+        cityName: "New York",
+        countryCode: "US",
+        countryName: "United States",
+      }),
+    ).toEqual(["pizza"]);
+  });
+
+  it("drops single-location country tags such as tonga", () => {
+    expect(
+      getDisplayGuideTags(["tonga"], {
+        cityName: "Tonga",
+        countryCode: "TO",
+        countryName: "Tonga",
+      }),
     ).toEqual([]);
   });
 });

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -442,6 +442,110 @@ class BuildDataTests(unittest.TestCase):
         self.assertIn("WARNING: tokyo-japan:bad-import", warning)
         self.assertIn("check whether it belongs in this city/country", warning)
 
+    def test_guide_map_pin_warning_distance_uses_inlier_radius_plus_buffer(self) -> None:
+        places = [
+            NormalizedPlace(
+                id="urumqi-1",
+                name="Urumqi 1",
+                lat=43.811,
+                lng=87.606,
+                maps_url="https://maps.example/urumqi-1",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="urumqi-2",
+                name="Urumqi 2",
+                lat=43.825,
+                lng=87.615,
+                maps_url="https://maps.example/urumqi-2",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="urumqi-3",
+                name="Urumqi 3",
+                lat=43.801,
+                lng=87.649,
+                maps_url="https://maps.example/urumqi-3",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="urumqi-4",
+                name="Urumqi 4",
+                lat=43.789,
+                lng=87.632,
+                maps_url="https://maps.example/urumqi-4",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="nalati",
+                name="Nalati Grassland",
+                lat=43.292522,
+                lng=84.229038,
+                maps_url="https://maps.example/nalati",
+                status="active",
+            ),
+        ]
+
+        center = build_data.guide_location_center(places)
+        threshold = build_data.guide_map_pin_warning_distance_meters(places, center)
+
+        self.assertIsNotNone(threshold)
+        self.assertEqual(threshold, build_data.MAP_PIN_DISTANCE_WARNING_MIN_METERS)
+
+    def test_warn_far_map_pins_warns_for_medium_distance_bad_imports(self) -> None:
+        places = [
+            NormalizedPlace(
+                id="tokyo-1",
+                name="Tokyo 1",
+                lat=35.6600,
+                lng=139.7000,
+                maps_url="https://maps.example/tokyo-1",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="tokyo-2",
+                name="Tokyo 2",
+                lat=35.6760,
+                lng=139.6990,
+                maps_url="https://maps.example/tokyo-2",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="tokyo-3",
+                name="Tokyo 3",
+                lat=35.6700,
+                lng=139.7350,
+                maps_url="https://maps.example/tokyo-3",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="tokyo-4",
+                name="Tokyo 4",
+                lat=35.6890,
+                lng=139.6910,
+                maps_url="https://maps.example/tokyo-4",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="beaumont-import",
+                name="Kasama Restaurant",
+                lat=33.9290518,
+                lng=-116.9776347,
+                maps_url="https://maps.example/beaumont-import",
+                status="active",
+            ),
+        ]
+
+        center = build_data.guide_location_center(places)
+
+        with patch("builtins.print") as print_mock:
+            build_data.warn_far_map_pins("tokyo-japan", places, center)
+
+        self.assertEqual(print_mock.call_count, 1)
+        warning = print_mock.call_args.args[0]
+        self.assertIn("WARNING: tokyo-japan:beaumont-import", warning)
+        self.assertIn("Kasama Restaurant", warning)
+
     def test_country_inference_keeps_monaco_english_with_localized_address_tails(self) -> None:
         raw = RawSavedList(
             title="Monaco 🇲🇨",


### PR DESCRIPTION
## Summary
- hide redundant city and country tags from guide and place tag pills while keeping more specific locality tags
- improve guide filtering UX with area-aware empty states, area status messaging, and live vibe-filter counts
- switch map-pin warnings to an adaptive inlier-radius threshold and add frontend and Python regression coverage

## Testing
- bun run check
- bun run build
- bun run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smart tag filtering hides redundant location-based tags
  * Area filters show overflow counts for matches outside the current view
  * Tag filter buttons display real-time matching counts and labels
  * Empty-state messaging now includes area context and overflow info
  * Dynamic map-pin warning threshold computed from guide clustering

* **Style**
  * Improved tag count styling for better readability

* **Tests**
  * Added/expanded frontend and Python tests for filtering, messages, and map-pin warnings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->