### PR TITLE
Add grouped search results and guide map

### DIFF
--- a/public/scripts/home-browser.js
+++ b/public/scripts/home-browser.js
@@ -262,7 +262,7 @@ if (root) {
     );
   };
 
-  const renderGlobalSearch = (query) => {
+  const renderGlobalSearch = (query, placeSearchState, filteredResults) => {
     if (!globalResults || !globalResultsList || !groupedResultsList || !globalResultsEmpty) {
       return;
     }
@@ -324,19 +324,19 @@ if (root) {
       return;
     }
 
-    const state = searchPlaces(query, { index: searchIndex, scope: "all" });
-    const filteredResults = state.results.filter(
-      (result) => !activeCountry || normalizeCountry(result.entry.country) === activeCountry,
-    );
-    const groupedResults = groupSearchResults(filteredResults);
-    const visibleIndividualResults = filteredResults.slice(0, INDIVIDUAL_RESULT_LIMIT);
+    const state = placeSearchState || searchPlaces(query, { index: searchIndex, scope: "all" });
+    const visibleResults =
+      filteredResults ||
+      state.results.filter((result) => !activeCountry || normalizeCountry(result.entry.country) === activeCountry);
+    const groupedResults = groupSearchResults(visibleResults);
+    const visibleIndividualResults = visibleResults.slice(0, INDIVIDUAL_RESULT_LIMIT);
 
     globalResultsList.replaceChildren(...visibleIndividualResults.map((result) => createSearchResultCard(result, query)));
     groupedResultsList.replaceChildren(...groupedResults.map((group) => createGroupedCountryCard(group, query)));
 
     globalResultsList.hidden = searchResultView !== "individual";
     groupedResultsList.hidden = searchResultView !== "grouped";
-    globalResultsEmpty.dataset.visible = filteredResults.length === 0 ? "true" : "false";
+    globalResultsEmpty.dataset.visible = visibleResults.length === 0 ? "true" : "false";
     globalResultsEmpty.textContent = activeCountry
       ? `No matching places in ${countryLabel(activeCountry)}. Try a broader search.`
       : "No matching places. Try a broader search.";
@@ -348,12 +348,12 @@ if (root) {
     if (globalResultsTitle) {
       globalResultsTitle.textContent =
         searchResultView === "grouped"
-          ? `${pluralize(filteredResults.length, "matching place")} across ${pluralize(
+          ? `${pluralize(visibleResults.length, "matching place")} across ${pluralize(
               groupedResults.length,
               "country",
               "countries",
             )}`
-          : `${pluralize(filteredResults.length, "matching place")}`;
+          : `${pluralize(visibleResults.length, "matching place")}`;
     }
 
     if (globalResultsSummary) {
@@ -371,9 +371,9 @@ if (root) {
         summaryBits.push(`Filtered to ${countryLabel(activeCountry)}`);
       }
 
-      if (searchResultView === "grouped" && filteredResults.length > 0) {
+      if (searchResultView === "grouped" && visibleResults.length > 0) {
         summaryBits.push(`Showing up to ${GROUP_LIMIT} places per country`);
-      } else if (searchResultView === "individual" && filteredResults.length > INDIVIDUAL_RESULT_LIMIT) {
+      } else if (searchResultView === "individual" && visibleResults.length > INDIVIDUAL_RESULT_LIMIT) {
         summaryBits.push(`Showing top ${INDIVIDUAL_RESULT_LIMIT} individual matches`);
       }
 
@@ -402,6 +402,15 @@ if (root) {
 
   const update = () => {
     const query = (searchInput?.value || "").trim().toLowerCase();
+    const placeSearchState = searchIndex && query ? searchPlaces(query, { index: searchIndex, scope: "all" }) : null;
+    const filteredPlaceResults = placeSearchState
+      ? placeSearchState.results.filter(
+          (result) => !activeCountry || normalizeCountry(result.entry.country) === activeCountry,
+        )
+      : [];
+    const placeMatchGuideSlugs = placeSearchState
+      ? new Set(filteredPlaceResults.map((result) => result.entry.guide_slug))
+      : null;
     const guideMatches =
       searchIndex && query
         ? new Set(searchGuides(query, { index: searchIndex }).map((result) => result.guide.slug))
@@ -419,7 +428,12 @@ if (root) {
         if (!query) {
           return true;
         }
-        return (card.dataset.search || "").includes(query) || guideMatches?.has(card.dataset.guideSlug || "");
+        const guideSlug = card.dataset.guideSlug || "";
+        return (
+          placeMatchGuideSlugs?.has(guideSlug) ||
+          (card.dataset.search || "").includes(query) ||
+          guideMatches?.has(guideSlug)
+        );
       });
       const matchingCardSet = new Set(matchingCards);
 
@@ -465,7 +479,7 @@ if (root) {
     }
 
     dispatchMapUpdate([...new Set(visibleGuideSlugs)], visibleGuideCount, query);
-    renderGlobalSearch(query);
+    renderGlobalSearch(query, placeSearchState, filteredPlaceResults);
   };
 
   const selectCountry = (country, { fromLocation = false, scroll = false } = {}) => {

--- a/public/scripts/home-browser.js
+++ b/public/scripts/home-browser.js
@@ -1,5 +1,9 @@
 import { loadSearchIndex, searchGuides, searchPlaces } from "./place-search.js";
 
+const GROUP_LIMIT = 5;
+const INDIVIDUAL_RESULT_LIMIT = 24;
+const FLAG_SUFFIX_PATTERN = /(?:\s*[\u{1F1E6}-\u{1F1FF}]{2})+$/u;
+
 const root = document.querySelector("[data-home-browser-root]");
 
 if (root) {
@@ -10,24 +14,40 @@ if (root) {
   const emptyState = root.querySelector("[data-home-empty-state]");
   const locationButton = root.querySelector("[data-location-target]");
   const locationStatus = root.querySelector("[data-location-status]");
-  const locationGuideIndex = document.querySelector("[data-location-guide-index]");
+  const homeGuideMap = root.querySelector("[data-home-guide-map]");
   const globalResults = root.querySelector("[data-global-search-results]");
   const globalResultsTitle = root.querySelector("[data-global-search-title]");
   const globalResultsSummary = root.querySelector("[data-global-search-summary]");
+  const globalResultsToolbar = root.querySelector("[data-global-search-toolbar]");
   const globalResultsList = root.querySelector("[data-global-search-list]");
+  const groupedResultsList = root.querySelector("[data-grouped-search-list]");
   const globalResultsEmpty = root.querySelector("[data-global-search-empty]");
+  const searchViewToggles = Array.from(root.querySelectorAll("[data-search-view-toggle]"));
 
   let activeCountry = "";
   let locationMatchCountry = "";
   let searchIndex = null;
   let searchIndexUnavailable = false;
+  let searchResultView = "grouped";
 
   const pluralize = (count, singular, plural = `${singular}s`) =>
     `${count} ${count === 1 ? singular : plural}`;
 
+  const normalizeCountry = (value) => String(value || "").trim().toLowerCase();
+
+  const countryLabel = (country) => {
+    if (!country) {
+      return "";
+    }
+
+    const button = countryButtons.find((candidate) => (candidate.dataset.country || "") === country);
+    const label = button?.querySelector("span")?.textContent || country;
+    return label.replace(FLAG_SUFFIX_PATTERN, "").trim();
+  };
+
   const guideLocations = (() => {
     try {
-      return JSON.parse(locationGuideIndex?.textContent || "[]").filter(
+      return JSON.parse(homeGuideMap?.dataset.guides || "[]").filter(
         (guide) =>
           guide &&
           typeof guide.country === "string" &&
@@ -86,28 +106,281 @@ if (root) {
       return nearest;
     }, null);
 
-  const selectCountry = (country, { fromLocation = false, scroll = false } = {}) => {
-    activeCountry = country;
+  const createGuideLink = (entry, query) => {
+    const params = new URLSearchParams();
+    params.set("place", entry.id);
+    if (query) {
+      params.set("q", query);
+    }
+    return `/guides/${entry.guide_slug}/?${params.toString()}`;
+  };
 
-    if (fromLocation) {
-      locationMatchCountry = country;
-      if (searchInput) {
-        searchInput.value = "";
+  const truncateText = (value, maxLength) => {
+    if (!value || value.length <= maxLength) {
+      return value || "";
+    }
+    return `${value.slice(0, maxLength - 1).trim()}...`;
+  };
+
+  const groupSearchResults = (results) =>
+    [...results.reduce((groups, result) => {
+      const country = result.entry.country || "Unknown";
+      if (!groups.has(country)) {
+        groups.set(country, []);
       }
-    } else {
-      locationMatchCountry = "";
-      setLocationStatus("");
+      groups.get(country).push(result);
+      return groups;
+    }, new Map()).entries()]
+      .map(([country, items]) => ({ country, items }))
+      .sort(
+        (left, right) =>
+          right.items.length - left.items.length ||
+          right.items[0].score - left.items[0].score ||
+          left.country.localeCompare(right.country),
+      );
+
+  const updateSearchViewButtons = () => {
+    searchViewToggles.forEach((toggle) => {
+      const selected = (toggle.dataset.searchView || "") === searchResultView;
+      toggle.dataset.active = selected ? "true" : "false";
+      toggle.setAttribute("aria-pressed", selected ? "true" : "false");
+    });
+  };
+
+  const createSearchResultCard = (result, query) => {
+    const entry = result.entry;
+    const card = document.createElement("article");
+    card.className = "search-result-card";
+
+    const title = document.createElement("h4");
+    title.textContent = entry.name || "Saved place";
+
+    const meta = document.createElement("p");
+    meta.className = "meta-copy";
+    meta.textContent = [
+      entry.guide_title,
+      [entry.category, entry.neighborhood].filter(Boolean).join(" · "),
+      [entry.city, entry.country].filter(Boolean).join(", "),
+    ]
+      .filter(Boolean)
+      .join(" · ");
+
+    const copy = document.createElement("p");
+    copy.className = "small-copy";
+    copy.textContent = truncateText(entry.why_recommended || entry.note || "", 180);
+    copy.hidden = !copy.textContent;
+
+    const tags = document.createElement("div");
+    tags.className = "tag-row";
+    [...(entry.vibe_tags || []), ...(entry.tags || [])].slice(0, 5).forEach((tag) => {
+      const pill = document.createElement("span");
+      pill.className = "tag-pill";
+      pill.textContent = tag.includes("-") ? tag.replaceAll("-", " ") : `#${tag}`;
+      tags.appendChild(pill);
+    });
+    tags.hidden = tags.childElementCount === 0;
+
+    const link = document.createElement("a");
+    link.className = "action-pill";
+    link.href = createGuideLink(entry, query);
+    link.textContent = "Open in guide";
+
+    card.append(title, meta, copy, tags, link);
+    return card;
+  };
+
+  const createGroupedCountryCard = (group, query) => {
+    const card = document.createElement("article");
+    card.className = "search-country-card";
+
+    const header = document.createElement("div");
+    header.className = "search-country-card-head";
+
+    const title = document.createElement("h4");
+    title.textContent = group.country;
+
+    const count = document.createElement("p");
+    count.className = "small-copy";
+    count.textContent =
+      group.items.length > GROUP_LIMIT
+        ? `${pluralize(group.items.length, "match")} · top ${GROUP_LIMIT} shown`
+        : pluralize(group.items.length, "match");
+
+    header.append(title, count);
+
+    const list = document.createElement("div");
+    list.className = "search-country-list";
+
+    group.items.slice(0, GROUP_LIMIT).forEach((result) => {
+      const entry = result.entry;
+      const link = document.createElement("a");
+      link.className = "search-country-item";
+      link.href = createGuideLink(entry, query);
+
+      const itemTitle = document.createElement("span");
+      itemTitle.className = "search-country-item-title";
+      itemTitle.textContent = entry.name || "Saved place";
+
+      const itemMeta = document.createElement("span");
+      itemMeta.className = "search-country-item-meta";
+      itemMeta.textContent = [
+        entry.guide_title,
+        [entry.category, entry.neighborhood].filter(Boolean).join(" · "),
+        entry.city,
+      ]
+        .filter(Boolean)
+        .join(" · ");
+
+      link.append(itemTitle, itemMeta);
+      list.append(link);
+    });
+
+    card.append(header, list);
+
+    if (group.items.length > GROUP_LIMIT) {
+      const overflow = document.createElement("p");
+      overflow.className = "search-country-overflow";
+      overflow.textContent = `${group.items.length - GROUP_LIMIT} more matching place${
+        group.items.length - GROUP_LIMIT === 1 ? "" : "s"
+      }. Switch to individual view to browse more.`;
+      card.append(overflow);
     }
 
-    update();
+    return card;
+  };
 
-    if (scroll) {
-      const button = countryButtons.find((candidate) => (candidate.dataset.country || "") === country);
-      const block = countryBlocks.find((candidate) => (candidate.dataset.country || "") === country);
+  const dispatchMapUpdate = (visibleGuideSlugs, visibleGuideCount, query) => {
+    document.dispatchEvent(
+      new CustomEvent("favorite-places:home-map-update", {
+        detail: {
+          activeCountry: countryLabel(activeCountry),
+          query,
+          visibleGuideCount,
+          visibleGuideSlugs,
+        },
+      }),
+    );
+  };
 
-      button?.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" });
-      block?.scrollIntoView({ behavior: "smooth", block: "start" });
+  const renderGlobalSearch = (query) => {
+    if (!globalResults || !globalResultsList || !groupedResultsList || !globalResultsEmpty) {
+      return;
     }
+
+    globalResults.hidden = !query;
+    globalResults.setAttribute("aria-hidden", query ? "false" : "true");
+
+    if (!query) {
+      globalResultsList.replaceChildren();
+      groupedResultsList.replaceChildren();
+      globalResultsList.hidden = true;
+      groupedResultsList.hidden = false;
+      globalResultsEmpty.dataset.visible = "false";
+      if (globalResultsToolbar) {
+        globalResultsToolbar.hidden = false;
+      }
+      if (globalResultsTitle) {
+        globalResultsTitle.textContent = "Matching places";
+      }
+      if (globalResultsSummary) {
+        globalResultsSummary.textContent = "";
+      }
+      updateSearchViewButtons();
+      return;
+    }
+
+    if (searchIndexUnavailable) {
+      globalResultsList.replaceChildren();
+      groupedResultsList.replaceChildren();
+      globalResultsList.hidden = true;
+      groupedResultsList.hidden = true;
+      globalResultsEmpty.dataset.visible = "true";
+      globalResultsEmpty.textContent = "Place search is unavailable. Guide browsing still works.";
+      if (globalResultsToolbar) {
+        globalResultsToolbar.hidden = true;
+      }
+      if (globalResultsTitle) {
+        globalResultsTitle.textContent = "Place search unavailable";
+      }
+      if (globalResultsSummary) {
+        globalResultsSummary.textContent = "";
+      }
+      return;
+    }
+
+    if (!searchIndex) {
+      globalResultsList.replaceChildren();
+      groupedResultsList.replaceChildren();
+      globalResultsEmpty.dataset.visible = "false";
+      if (globalResultsToolbar) {
+        globalResultsToolbar.hidden = true;
+      }
+      if (globalResultsTitle) {
+        globalResultsTitle.textContent = "Loading matching places";
+      }
+      if (globalResultsSummary) {
+        globalResultsSummary.textContent = "Loading index...";
+      }
+      return;
+    }
+
+    const state = searchPlaces(query, { index: searchIndex, scope: "all" });
+    const filteredResults = state.results.filter(
+      (result) => !activeCountry || normalizeCountry(result.entry.country) === activeCountry,
+    );
+    const groupedResults = groupSearchResults(filteredResults);
+    const visibleIndividualResults = filteredResults.slice(0, INDIVIDUAL_RESULT_LIMIT);
+
+    globalResultsList.replaceChildren(...visibleIndividualResults.map((result) => createSearchResultCard(result, query)));
+    groupedResultsList.replaceChildren(...groupedResults.map((group) => createGroupedCountryCard(group, query)));
+
+    globalResultsList.hidden = searchResultView !== "individual";
+    groupedResultsList.hidden = searchResultView !== "grouped";
+    globalResultsEmpty.dataset.visible = filteredResults.length === 0 ? "true" : "false";
+    globalResultsEmpty.textContent = activeCountry
+      ? `No matching places in ${countryLabel(activeCountry)}. Try a broader search.`
+      : "No matching places. Try a broader search.";
+
+    if (globalResultsToolbar) {
+      globalResultsToolbar.hidden = false;
+    }
+
+    if (globalResultsTitle) {
+      globalResultsTitle.textContent =
+        searchResultView === "grouped"
+          ? `${pluralize(filteredResults.length, "matching place")} across ${pluralize(
+              groupedResults.length,
+              "country",
+              "countries",
+            )}`
+          : `${pluralize(filteredResults.length, "matching place")}`;
+    }
+
+    if (globalResultsSummary) {
+      const parsed = [
+        ...state.parsed.vibes.map((vibe) => vibe.replaceAll("-", " ")),
+        ...state.parsed.categories,
+      ];
+      const summaryBits = [];
+
+      if (parsed.length > 0) {
+        summaryBits.push(parsed.join(" · "));
+      }
+
+      if (activeCountry) {
+        summaryBits.push(`Filtered to ${countryLabel(activeCountry)}`);
+      }
+
+      if (searchResultView === "grouped" && filteredResults.length > 0) {
+        summaryBits.push(`Showing up to ${GROUP_LIMIT} places per country`);
+      } else if (searchResultView === "individual" && filteredResults.length > INDIVIDUAL_RESULT_LIMIT) {
+        summaryBits.push(`Showing top ${INDIVIDUAL_RESULT_LIMIT} individual matches`);
+      }
+
+      globalResultsSummary.textContent = summaryBits.join(" · ") || "All guides";
+    }
+
+    updateSearchViewButtons();
   };
 
   const updateCountryButtons = (matchingGuidesByCountry, totalMatchingGuides) => {
@@ -129,10 +402,12 @@ if (root) {
 
   const update = () => {
     const query = (searchInput?.value || "").trim().toLowerCase();
-    const guideMatches = searchIndex && query ? new Set(
-      searchGuides(query, { index: searchIndex }).map((result) => result.guide.slug),
-    ) : null;
+    const guideMatches =
+      searchIndex && query
+        ? new Set(searchGuides(query, { index: searchIndex }).map((result) => result.guide.slug))
+        : null;
     const matchingGuidesByCountry = new Map();
+    const visibleGuideSlugs = [];
     let visibleGuideCount = 0;
     let visibleCountryCount = 0;
     let totalMatchingGuides = 0;
@@ -158,8 +433,12 @@ if (root) {
       cards.forEach((card) => {
         const visible = selectedCountryMatches && matchingCardSet.has(card);
         card.hidden = !visible;
+
         if (visible) {
           blockVisibleGuideCount += 1;
+          if (card.dataset.guideSlug) {
+            visibleGuideSlugs.push(card.dataset.guideSlug);
+          }
         }
       });
 
@@ -185,121 +464,42 @@ if (root) {
       emptyState.dataset.visible = visibleGuideCount === 0 ? "true" : "false";
     }
 
+    dispatchMapUpdate([...new Set(visibleGuideSlugs)], visibleGuideCount, query);
     renderGlobalSearch(query);
   };
 
-  const renderGlobalSearch = (query) => {
-    if (!globalResults || !globalResultsList || !globalResultsEmpty) {
-      return;
+  const selectCountry = (country, { fromLocation = false, scroll = false } = {}) => {
+    activeCountry = country;
+
+    if (fromLocation) {
+      locationMatchCountry = country;
+      if (searchInput) {
+        searchInput.value = "";
+      }
+    } else {
+      locationMatchCountry = "";
+      setLocationStatus("");
     }
 
-    globalResults.hidden = !query;
-    globalResults.setAttribute("aria-hidden", query ? "false" : "true");
-    if (!query) {
-      globalResultsList.replaceChildren();
-      globalResultsEmpty.dataset.visible = "false";
-      if (globalResultsTitle) {
-        globalResultsTitle.textContent = "Matching places";
-      }
-      if (globalResultsSummary) {
-        globalResultsSummary.textContent = "";
-      }
-      return;
-    }
+    update();
 
-    if (searchIndexUnavailable) {
-      globalResultsList.replaceChildren();
-      globalResultsEmpty.dataset.visible = "true";
-      globalResultsEmpty.textContent = "Place search is unavailable. Guide browsing still works.";
-      if (globalResultsTitle) {
-        globalResultsTitle.textContent = "Place search unavailable";
-      }
-      if (globalResultsSummary) {
-        globalResultsSummary.textContent = "";
-      }
-      return;
-    }
+    if (scroll) {
+      const button = countryButtons.find((candidate) => (candidate.dataset.country || "") === country);
+      const block = countryBlocks.find((candidate) => (candidate.dataset.country || "") === country);
 
-    if (!searchIndex) {
-      globalResultsList.replaceChildren();
-      globalResultsEmpty.dataset.visible = "false";
-      if (globalResultsTitle) {
-        globalResultsTitle.textContent = "Loading matching places";
-      }
-      if (globalResultsSummary) {
-        globalResultsSummary.textContent = "Loading index...";
-      }
-      return;
+      button?.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" });
+      block?.scrollIntoView({ behavior: "smooth", block: "start" });
     }
-
-    const state = searchPlaces(query, { index: searchIndex, scope: "all" });
-    const results = state.results.slice(0, 24);
-    globalResultsList.replaceChildren(...results.map((result) => createSearchResultCard(result, query)));
-
-    if (globalResultsTitle) {
-      globalResultsTitle.textContent = `${state.count} matching place${state.count === 1 ? "" : "s"}`;
-    }
-    if (globalResultsSummary) {
-      const parsed = [
-        ...state.parsed.vibes.map((vibe) => vibe.replaceAll("-", " ")),
-        ...state.parsed.categories,
-      ];
-      globalResultsSummary.textContent = parsed.length > 0 ? parsed.join(" · ") : "All guides";
-    }
-    globalResultsEmpty.dataset.visible = state.count === 0 ? "true" : "false";
-    globalResultsEmpty.textContent = "No matching places. Try a broader search.";
   };
 
-  const createSearchResultCard = (result, query) => {
-    const entry = result.entry;
-    const card = document.createElement("article");
-    card.className = "search-result-card";
-
-    const title = document.createElement("h4");
-    title.textContent = entry.name || "Saved place";
-
-    const meta = document.createElement("p");
-    meta.className = "meta-copy";
-    meta.textContent = [
-      entry.guide_title,
-      [entry.category, entry.neighborhood].filter(Boolean).join(" · "),
-      [entry.city, entry.country].filter(Boolean).join(", "),
-    ].filter(Boolean).join(" · ");
-
-    const copy = document.createElement("p");
-    copy.className = "small-copy";
-    copy.textContent = truncateText(entry.why_recommended || entry.note || "", 180);
-    copy.hidden = !copy.textContent;
-
-    const tags = document.createElement("div");
-    tags.className = "tag-row";
-    [...(entry.vibe_tags || []), ...(entry.tags || [])].slice(0, 5).forEach((tag) => {
-      const pill = document.createElement("span");
-      pill.className = "tag-pill";
-      pill.textContent = tag.includes("-") ? tag.replaceAll("-", " ") : `#${tag}`;
-      tags.appendChild(pill);
-    });
-    tags.hidden = tags.childElementCount === 0;
-
-    const link = document.createElement("a");
-    link.className = "action-pill";
-    const params = new URLSearchParams();
-    params.set("place", entry.id);
-    if (query) {
-      params.set("q", query);
+  const setSearchView = (view) => {
+    const nextView = view === "individual" ? "individual" : "grouped";
+    if (searchResultView === nextView) {
+      return;
     }
-    link.href = `/guides/${entry.guide_slug}/?${params.toString()}`;
-    link.textContent = "Open in guide";
 
-    card.append(title, meta, copy, tags, link);
-    return card;
-  };
-
-  const truncateText = (value, maxLength) => {
-    if (!value || value.length <= maxLength) {
-      return value || "";
-    }
-    return `${value.slice(0, maxLength - 1).trim()}...`;
+    searchResultView = nextView;
+    renderGlobalSearch((searchInput?.value || "").trim().toLowerCase());
   };
 
   searchInput?.addEventListener("input", update);
@@ -307,6 +507,12 @@ if (root) {
   countryButtons.forEach((button) => {
     button.addEventListener("click", () => {
       selectCountry(button.dataset.country || "");
+    });
+  });
+
+  searchViewToggles.forEach((toggle) => {
+    toggle.addEventListener("click", () => {
+      setSearchView(toggle.dataset.searchView || "grouped");
     });
   });
 
@@ -361,6 +567,7 @@ if (root) {
     }
   }
 
+  updateSearchViewButtons();
   update();
 
   loadSearchIndex()

--- a/src/components/HomeGuideMap.astro
+++ b/src/components/HomeGuideMap.astro
@@ -4,9 +4,11 @@ interface HomeMapGuide {
   title: string;
   country: string;
   countryName: string;
+  countryCode: string | null;
   cityName: string;
   lat: number;
   lng: number;
+  markerLabel: string;
   placeCount: number;
   url: string;
 }
@@ -64,9 +66,11 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     title: string;
     country: string;
     countryName: string;
+    countryCode: string | null;
     cityName: string;
     lat: number;
     lng: number;
+    markerLabel: string;
     placeCount: number;
     url: string;
   }
@@ -117,6 +121,9 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
         getMap: () => unknown;
         setMap: (map: unknown | null) => void;
       };
+      SymbolPath: {
+        CIRCLE: unknown;
+      };
     };
   }
 
@@ -157,6 +164,10 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
       </div>
     `;
   };
+
+  const markerHtml = (guide: HomeMapGuide) => `
+    <span class="home-guide-marker-badge" aria-hidden="true">${escapeHtml(guide.markerLabel)}</span>
+  `;
 
   const fitGuides = (map: L.Map, guides: HomeMapGuide[]) => {
     if (guides.length === 0) return;
@@ -276,15 +287,17 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
       maxZoom: 19,
     }).addTo(map);
 
-    const markers = new Map<string, L.CircleMarker>();
+    const markers = new Map<string, L.Marker>();
     guides.forEach((guide) => {
-      const marker = L.circleMarker([guide.lat, guide.lng], {
-        color: MARKER_COLOR,
-        fillColor: "#fffaf1",
-        fillOpacity: 0.9,
-        opacity: 0.95,
-        radius: 7,
-        weight: 2,
+      const marker = L.marker([guide.lat, guide.lng], {
+        icon: L.divIcon({
+          className: "home-guide-marker",
+          html: markerHtml(guide),
+          iconSize: [40, 40],
+          iconAnchor: [20, 20],
+          popupAnchor: [0, -18],
+        }),
+        title: guide.title,
       }).bindPopup(popupHtml(guide), {
         className: "guide-map-popup-shell",
         closeButton: false,
@@ -327,6 +340,22 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
 
     guides.forEach((guide) => {
       const marker = new googleMaps.maps.Marker({
+        icon: {
+          fillColor: "#fffaf1",
+          fillOpacity: 0.96,
+          path: googleMaps.maps.SymbolPath.CIRCLE,
+          scale: 18,
+          strokeColor: MARKER_COLOR,
+          strokeOpacity: 0.98,
+          strokeWeight: 2,
+        },
+        label: {
+          color: "#1f1a16",
+          fontFamily: '"Avenir Next", "Segoe UI", sans-serif',
+          fontSize: guide.markerLabel.length <= 2 ? "14px" : "18px",
+          fontWeight: "800",
+          text: guide.markerLabel,
+        },
         map,
         position: { lat: guide.lat, lng: guide.lng },
         title: guide.title,

--- a/src/components/HomeGuideMap.astro
+++ b/src/components/HomeGuideMap.astro
@@ -1,0 +1,463 @@
+---
+interface HomeMapGuide {
+  slug: string;
+  title: string;
+  country: string;
+  countryName: string;
+  cityName: string;
+  lat: number;
+  lng: number;
+  placeCount: number;
+  url: string;
+}
+
+interface Props {
+  guides: HomeMapGuide[];
+}
+
+const { guides } = Astro.props;
+const configuredGoogleMapsApiKey = process.env.GOOGLE_MAPS_JS_API_KEY || "";
+const requestedMapProvider = (import.meta.env.PUBLIC_MAP_PROVIDER || "").toLowerCase();
+const mapProvider = requestedMapProvider === "leaflet" ? "leaflet" : configuredGoogleMapsApiKey ? "google" : "leaflet";
+const googleMapsApiKey = mapProvider === "google" ? configuredGoogleMapsApiKey : "";
+const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.isFinite(guide.lng));
+---
+
+{
+  mapGuides.length > 0 && (
+    <aside class="map-panel home-map-panel" aria-label="Guide map">
+      <div class="home-map-head">
+        <div>
+          <p class="eyebrow">Map view</p>
+          <h3 class="section-title">Guide locations</h3>
+        </div>
+        <p class="small-copy" data-home-map-summary>
+          Showing {mapGuides.length} guide{mapGuides.length === 1 ? "" : "s"} on the map.
+        </p>
+      </div>
+
+      <div
+        class="guide-map"
+        data-home-guide-map
+        data-map-provider={mapProvider}
+        data-google-maps-api-key={googleMapsApiKey}
+        data-guides={JSON.stringify(mapGuides).replace(/</g, "\\u003c")}
+      />
+
+      <noscript>
+        <div class="map-fallback">
+          {mapGuides.slice(0, 8).map((guide) => (
+            <a href={guide.url}>{guide.title}</a>
+          ))}
+        </div>
+      </noscript>
+    </aside>
+  )
+}
+
+<script>
+  import L from "leaflet";
+  import "leaflet/dist/leaflet.css";
+
+  interface HomeMapGuide {
+    slug: string;
+    title: string;
+    country: string;
+    countryName: string;
+    cityName: string;
+    lat: number;
+    lng: number;
+    placeCount: number;
+    url: string;
+  }
+
+  interface Coordinates {
+    lat: number;
+    lng: number;
+  }
+
+  interface HomeGuideMapElement extends HTMLElement {
+    homeGuideMapInitialized?: boolean;
+  }
+
+  interface HomeMapRuntime {
+    fitGuides: (guides: HomeMapGuide[]) => void;
+    setVisibleGuides: (visibleGuideSlugs: Set<string>) => void;
+  }
+
+  interface HomeMapUpdateEvent extends CustomEvent {
+    detail: {
+      activeCountry?: string;
+      query?: string;
+      visibleGuideCount: number;
+      visibleGuideSlugs: string[];
+    };
+  }
+
+  interface GoogleMapsApi {
+    maps: {
+      InfoWindow: new (options?: { content?: string }) => {
+        close: () => void;
+        open: (options: { anchor: unknown; map: unknown; shouldFocus?: boolean }) => void;
+        setContent: (content: string) => void;
+      };
+      LatLngBounds: new () => {
+        extend: (coordinates: Coordinates) => void;
+      };
+      Map: new (
+        element: HTMLElement,
+        options: Record<string, unknown>,
+      ) => {
+        fitBounds: (bounds: unknown, padding?: number | { top: number; right: number; bottom: number; left: number }) => void;
+        setCenter: (coordinates: Coordinates) => void;
+        setZoom: (zoom: number) => void;
+      };
+      Marker: new (options: Record<string, unknown>) => {
+        addListener: (eventName: string, handler: () => void) => void;
+        getMap: () => unknown;
+        setMap: (map: unknown | null) => void;
+      };
+    };
+  }
+
+  const MARKER_COLOR = "#c4312d";
+  const favoritePlacesWindow = window as Window & {
+    __favoritePlacesGoogleMapsInit?: () => void;
+    __favoritePlacesGoogleMapsLoader?: Promise<unknown>;
+    google?: unknown;
+  };
+
+  const escapeHtml = (value: string) =>
+    value
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
+
+  const safeUrl = (value: string) => {
+    try {
+      const url = new URL(value, window.location.origin);
+      return url.protocol === "https:" || url.protocol === "http:" ? url.toString() : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const popupHtml = (guide: HomeMapGuide) => {
+    const safeGuideUrl = safeUrl(guide.url);
+    const meta = [guide.cityName, guide.countryName].filter(Boolean).join(", ");
+
+    return `
+      <div class="guide-map-popup-content">
+        <strong>${escapeHtml(guide.title)}</strong>
+        <span>${escapeHtml(meta)}</span>
+        <span>${guide.placeCount} saved place${guide.placeCount === 1 ? "" : "s"}</span>
+        ${safeGuideUrl ? `<a href="${escapeHtml(safeGuideUrl)}">Open guide</a>` : ""}
+      </div>
+    `;
+  };
+
+  const fitGuides = (map: L.Map, guides: HomeMapGuide[]) => {
+    if (guides.length === 0) return;
+
+    if (guides.length === 1) {
+      map.setView([guides[0].lat, guides[0].lng], 5);
+      return;
+    }
+
+    const bounds = L.latLngBounds(guides.map((guide) => [guide.lat, guide.lng]));
+    map.fitBounds(bounds, {
+      maxZoom: 6,
+      padding: [28, 28],
+    });
+  };
+
+  const loadGoogleMapsApi = (apiKey: string) => {
+    const cachedGoogleMaps = favoritePlacesWindow.google as GoogleMapsApi | undefined;
+    if (cachedGoogleMaps?.maps) {
+      return Promise.resolve(cachedGoogleMaps);
+    }
+
+    if (favoritePlacesWindow.__favoritePlacesGoogleMapsLoader) {
+      return favoritePlacesWindow.__favoritePlacesGoogleMapsLoader as Promise<GoogleMapsApi>;
+    }
+
+    const loader = new Promise<GoogleMapsApi>((resolve, reject) => {
+      const existingScript = document.querySelector<HTMLScriptElement>('script[data-google-maps-loader="favorite-places"]');
+      if (existingScript) {
+        const existingGoogleMaps = favoritePlacesWindow.google as GoogleMapsApi | undefined;
+        if (existingGoogleMaps?.maps) {
+          resolve(existingGoogleMaps);
+          return;
+        }
+        if (
+          existingScript.dataset.googleMapsStatus === "loaded" ||
+          existingScript.dataset.googleMapsStatus === "error"
+        ) {
+          existingScript.remove();
+          delete favoritePlacesWindow.__favoritePlacesGoogleMapsInit;
+        } else {
+          existingScript.addEventListener(
+            "load",
+            () => {
+              const loadedGoogleMaps = favoritePlacesWindow.google as GoogleMapsApi | undefined;
+              if (loadedGoogleMaps?.maps) {
+                resolve(loadedGoogleMaps);
+                return;
+              }
+              reject(new Error("Google Maps loaded without the Maps API namespace"));
+            },
+            { once: true },
+          );
+          existingScript.addEventListener("error", () => reject(new Error("Google Maps failed to load")), {
+            once: true,
+          });
+          return;
+        }
+      }
+
+      const callbackName = "__favoritePlacesGoogleMapsInit";
+      favoritePlacesWindow[callbackName] = () => {
+        const loadedGoogleMaps = favoritePlacesWindow.google as GoogleMapsApi | undefined;
+        if (loadedGoogleMaps?.maps) {
+          script.dataset.googleMapsStatus = "loaded";
+          delete favoritePlacesWindow.__favoritePlacesGoogleMapsInit;
+          resolve(loadedGoogleMaps);
+          return;
+        }
+
+        script.dataset.googleMapsStatus = "loaded";
+        delete favoritePlacesWindow.__favoritePlacesGoogleMapsInit;
+        reject(new Error("Google Maps loaded without the Maps API namespace"));
+      };
+
+      const script = document.createElement("script");
+      script.async = true;
+      script.dataset.googleMapsLoader = "favorite-places";
+      script.dataset.googleMapsStatus = "loading";
+      script.src =
+        "https://maps.googleapis.com/maps/api/js?" +
+        new URLSearchParams({
+          key: apiKey,
+          loading: "async",
+          callback: callbackName,
+          v: "weekly",
+          auth_referrer_policy: "origin",
+        }).toString();
+      script.addEventListener("error", () => {
+        script.dataset.googleMapsStatus = "error";
+        delete favoritePlacesWindow.__favoritePlacesGoogleMapsInit;
+        reject(new Error("Google Maps failed to load"));
+      });
+      document.head.append(script);
+    }).catch((error) => {
+      delete favoritePlacesWindow.__favoritePlacesGoogleMapsLoader;
+      throw error;
+    });
+
+    ((favoritePlacesWindow as unknown) as Record<string, unknown>).__favoritePlacesGoogleMapsLoader = loader;
+
+    return loader;
+  };
+
+  const initLeafletRuntime = (element: HTMLElement, guides: HomeMapGuide[]): HomeMapRuntime => {
+    const map = L.map(element, {
+      dragging: true,
+      maxZoom: 12,
+      scrollWheelZoom: false,
+      touchZoom: "center",
+      zoomControl: true,
+      zoomSnap: 0.25,
+    });
+
+    L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      maxZoom: 19,
+    }).addTo(map);
+
+    const markers = new Map<string, L.CircleMarker>();
+    guides.forEach((guide) => {
+      const marker = L.circleMarker([guide.lat, guide.lng], {
+        color: MARKER_COLOR,
+        fillColor: "#fffaf1",
+        fillOpacity: 0.9,
+        opacity: 0.95,
+        radius: 7,
+        weight: 2,
+      }).bindPopup(popupHtml(guide), {
+        className: "guide-map-popup-shell",
+        closeButton: false,
+      });
+      marker.addTo(map);
+      markers.set(guide.slug, marker);
+    });
+
+    return {
+      fitGuides: (visibleGuides) => fitGuides(map, visibleGuides),
+      setVisibleGuides: (visibleGuideSlugs) => {
+        markers.forEach((marker, guideSlug) => {
+          if (visibleGuideSlugs.has(guideSlug)) {
+            marker.addTo(map);
+          } else {
+            marker.removeFrom(map);
+          }
+        });
+      },
+    };
+  };
+
+  const initGoogleRuntime = async (
+    element: HTMLElement,
+    guides: HomeMapGuide[],
+    apiKey: string,
+  ): Promise<HomeMapRuntime> => {
+    const googleMaps = (await loadGoogleMapsApi(apiKey)) as GoogleMapsApi;
+    const map = new googleMaps.maps.Map(element, {
+      center: { lat: guides[0].lat, lng: guides[0].lng },
+      clickableIcons: false,
+      disableDefaultUI: true,
+      gestureHandling: "greedy",
+      keyboardShortcuts: true,
+      zoom: 4,
+      zoomControl: true,
+    });
+    const infoWindow = new googleMaps.maps.InfoWindow();
+    const markers = new Map<string, any>();
+
+    guides.forEach((guide) => {
+      const marker = new googleMaps.maps.Marker({
+        map,
+        position: { lat: guide.lat, lng: guide.lng },
+        title: guide.title,
+      });
+      marker.addListener("click", () => {
+        infoWindow.setContent(popupHtml(guide));
+        infoWindow.open({ anchor: marker, map, shouldFocus: false });
+      });
+      markers.set(guide.slug, marker);
+    });
+
+    return {
+      fitGuides: (visibleGuides) => {
+        if (visibleGuides.length === 0) return;
+
+        if (visibleGuides.length === 1) {
+          map.setCenter({ lat: visibleGuides[0].lat, lng: visibleGuides[0].lng });
+          map.setZoom(5);
+          return;
+        }
+
+        const bounds = new googleMaps.maps.LatLngBounds();
+        visibleGuides.forEach((guide) => bounds.extend({ lat: guide.lat, lng: guide.lng }));
+        map.fitBounds(bounds, 28);
+      },
+      setVisibleGuides: (visibleGuideSlugs) => {
+        markers.forEach((marker, guideSlug) => marker.setMap(visibleGuideSlugs.has(guideSlug) ? map : null));
+        infoWindow.close();
+      },
+    };
+  };
+
+  const updateSummary = (
+    summary: HTMLElement | null,
+    count: number,
+    activeCountry: string,
+    query: string,
+  ) => {
+    if (!summary) return;
+
+    if (count === 0) {
+      summary.textContent = "No matching guides are visible on the map.";
+      return;
+    }
+
+    if (query && activeCountry) {
+      summary.textContent = `Showing ${count} matching guide${count === 1 ? "" : "s"} in ${activeCountry}.`;
+      return;
+    }
+
+    if (query) {
+      summary.textContent = `Showing ${count} matching guide${count === 1 ? "" : "s"} on the map.`;
+      return;
+    }
+
+    if (activeCountry) {
+      summary.textContent = `Showing ${count} guide${count === 1 ? "" : "s"} in ${activeCountry}.`;
+      return;
+    }
+
+    summary.textContent = `Showing ${count} guide${count === 1 ? "" : "s"} on the map.`;
+  };
+
+  const initMap = async (element: HomeGuideMapElement) => {
+    if (element.homeGuideMapInitialized) {
+      return;
+    }
+
+    const guides = JSON.parse(element.dataset.guides || "[]") as HomeMapGuide[];
+    if (guides.length === 0) {
+      return;
+    }
+
+    const summary = document.querySelector<HTMLElement>("[data-home-map-summary]");
+    const requestedProvider = element.dataset.mapProvider === "google" ? "google" : "leaflet";
+    const apiKey = element.dataset.googleMapsApiKey || "";
+    let runtime: HomeMapRuntime;
+    let currentVisibleGuideSlugs = new Set(guides.map((guide) => guide.slug));
+    let currentVisibleGuides = guides;
+
+    try {
+      runtime =
+        requestedProvider === "google" && apiKey
+          ? await initGoogleRuntime(element, guides, apiKey).catch(() => initLeafletRuntime(element, guides))
+          : initLeafletRuntime(element, guides);
+    } catch {
+      runtime = initLeafletRuntime(element, guides);
+    }
+
+    const applyVisibility = (
+      visibleGuideSlugs: string[],
+      visibleGuideCount: number,
+      activeCountry = "",
+      query = "",
+    ) => {
+      currentVisibleGuideSlugs =
+        visibleGuideCount === 0
+          ? new Set()
+          : new Set(visibleGuideSlugs.length > 0 ? visibleGuideSlugs : guides.map((guide) => guide.slug));
+      currentVisibleGuides = guides.filter((guide) => currentVisibleGuideSlugs.has(guide.slug));
+      runtime.setVisibleGuides(currentVisibleGuideSlugs);
+      runtime.fitGuides(currentVisibleGuides);
+      updateSummary(summary, currentVisibleGuides.length, activeCountry, query);
+    };
+
+    document.addEventListener(
+      "favorite-places:home-map-update",
+      ((event: HomeMapUpdateEvent) => {
+        applyVisibility(
+          event.detail.visibleGuideSlugs,
+          event.detail.visibleGuideCount,
+          event.detail.activeCountry || "",
+          event.detail.query || "",
+        );
+      }) as EventListener,
+    );
+
+    runtime.fitGuides(currentVisibleGuides);
+    updateSummary(summary, currentVisibleGuides.length, "", "");
+    element.homeGuideMapInitialized = true;
+  };
+
+  const initMaps = () => {
+    document.querySelectorAll<HomeGuideMapElement>("[data-home-guide-map]").forEach((element) => {
+      void initMap(element);
+    });
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initMaps, { once: true });
+  } else {
+    initMaps();
+  }
+</script>

--- a/src/components/HomeGuideMap.astro
+++ b/src/components/HomeGuideMap.astro
@@ -432,18 +432,15 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     const summary = document.querySelector<HTMLElement>("[data-home-map-summary]");
     const requestedProvider = element.dataset.mapProvider === "google" ? "google" : "leaflet";
     const apiKey = element.dataset.googleMapsApiKey || "";
-    let runtime: HomeMapRuntime;
+    let runtime: HomeMapRuntime | null = null;
     let currentVisibleGuideSlugs = new Set(guides.map((guide) => guide.slug));
     let currentVisibleGuides = guides;
-
-    try {
-      runtime =
-        requestedProvider === "google" && apiKey
-          ? await initGoogleRuntime(element, guides, apiKey).catch(() => initLeafletRuntime(element, guides))
-          : initLeafletRuntime(element, guides);
-    } catch {
-      runtime = initLeafletRuntime(element, guides);
-    }
+    let pendingState = {
+      activeCountry: "",
+      query: "",
+      visibleGuideCount: guides.length,
+      visibleGuideSlugs: guides.map((guide) => guide.slug),
+    };
 
     const applyVisibility = (
       visibleGuideSlugs: string[],
@@ -456,25 +453,46 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
           ? new Set()
           : new Set(visibleGuideSlugs.length > 0 ? visibleGuideSlugs : guides.map((guide) => guide.slug));
       currentVisibleGuides = guides.filter((guide) => currentVisibleGuideSlugs.has(guide.slug));
-      runtime.setVisibleGuides(currentVisibleGuideSlugs);
-      runtime.fitGuides(currentVisibleGuides);
+      runtime?.setVisibleGuides(currentVisibleGuideSlugs);
+      runtime?.fitGuides(currentVisibleGuides);
       updateSummary(summary, currentVisibleGuides.length, activeCountry, query);
     };
 
+    const handleHomeMapUpdate = ((event: HomeMapUpdateEvent) => {
+      pendingState = {
+        activeCountry: event.detail.activeCountry || "",
+        query: event.detail.query || "",
+        visibleGuideCount: event.detail.visibleGuideCount,
+        visibleGuideSlugs: event.detail.visibleGuideSlugs,
+      };
+      applyVisibility(
+        pendingState.visibleGuideSlugs,
+        pendingState.visibleGuideCount,
+        pendingState.activeCountry,
+        pendingState.query,
+      );
+    }) as EventListener;
+
     document.addEventListener(
       "favorite-places:home-map-update",
-      ((event: HomeMapUpdateEvent) => {
-        applyVisibility(
-          event.detail.visibleGuideSlugs,
-          event.detail.visibleGuideCount,
-          event.detail.activeCountry || "",
-          event.detail.query || "",
-        );
-      }) as EventListener,
+      handleHomeMapUpdate,
     );
 
-    runtime.fitGuides(currentVisibleGuides);
-    updateSummary(summary, currentVisibleGuides.length, "", "");
+    try {
+      runtime =
+        requestedProvider === "google" && apiKey
+          ? await initGoogleRuntime(element, guides, apiKey).catch(() => initLeafletRuntime(element, guides))
+          : initLeafletRuntime(element, guides);
+    } catch {
+      runtime = initLeafletRuntime(element, guides);
+    }
+
+    applyVisibility(
+      pendingState.visibleGuideSlugs,
+      pendingState.visibleGuideCount,
+      pendingState.activeCountry,
+      pendingState.query,
+    );
     element.homeGuideMapInitialized = true;
   };
 

--- a/src/components/HomeGuideMap.astro
+++ b/src/components/HomeGuideMap.astro
@@ -169,6 +169,8 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     <span class="home-guide-marker-badge" aria-hidden="true">${escapeHtml(guide.markerLabel)}</span>
   `;
 
+  const markerLabelUnits = (label: string) => Array.from(label).length;
+
   const fitGuides = (map: L.Map, guides: HomeMapGuide[]) => {
     if (guides.length === 0) return;
 
@@ -352,7 +354,7 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
         label: {
           color: "#1f1a16",
           fontFamily: '"Avenir Next", "Segoe UI", sans-serif',
-          fontSize: guide.markerLabel.length <= 2 ? "14px" : "18px",
+          fontSize: markerLabelUnits(guide.markerLabel) <= 2 ? "14px" : "18px",
           fontWeight: "800",
           text: guide.markerLabel,
         },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -106,19 +106,23 @@ const guideMarkerLabel = (guide: (typeof guides)[number]) => {
 };
 const locationGuideCandidates = guides
   .filter((guide) => typeof guide.center_lat === "number" && typeof guide.center_lng === "number")
-  .map((guide) => ({
-    cityName: guide.city_name,
-    countryCode: guide.country_code,
-    slug: guide.slug,
-    title: guide.title,
-    country: guide.country_name.toLowerCase(),
-    countryName: guide.country_name,
-    lat: guide.center_lat as number,
-    lng: guide.center_lng as number,
-    markerLabel: guideMarkerLabel(guide),
-    placeCount: guide.place_count,
-    url: `/guides/${guide.slug}/`,
-  }));
+  .map((guide) => {
+    const countryName = guide.country_name || "Unknown";
+
+    return {
+      cityName: guide.city_name || "",
+      countryCode: guide.country_code,
+      slug: guide.slug,
+      title: guide.title,
+      country: countryName.toLowerCase(),
+      countryName,
+      lat: guide.center_lat as number,
+      lng: guide.center_lng as number,
+      markerLabel: guideMarkerLabel(guide),
+      placeCount: guide.place_count,
+      url: `/guides/${guide.slug}/`,
+    };
+  });
 const countryCount = guidesByCountry.length;
 const placeCount = guides.reduce((count, guide) => count + guide.place_count, 0);
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import GuideCard from "../components/GuideCard.astro";
+import HomeGuideMap from "../components/HomeGuideMap.astro";
 import Layout from "../components/Layout.astro";
 import { siteConfig } from "../data/site";
 import { getGuideManifests } from "../lib/data";
@@ -36,14 +37,16 @@ const guidesByCountry = countryEntries.map(([countryName, countryGuides]) => ({
 const locationGuideCandidates = guides
   .filter((guide) => typeof guide.center_lat === "number" && typeof guide.center_lng === "number")
   .map((guide) => ({
+    cityName: guide.city_name,
     slug: guide.slug,
     title: guide.title,
     country: guide.country_name.toLowerCase(),
     countryName: guide.country_name,
-    lat: guide.center_lat,
-    lng: guide.center_lng,
+    lat: guide.center_lat as number,
+    lng: guide.center_lng as number,
+    placeCount: guide.place_count,
+    url: `/guides/${guide.slug}/`,
   }));
-const locationGuideJson = JSON.stringify(locationGuideCandidates).replace(/</g, "\\u003c");
 const countryCount = guidesByCountry.length;
 const placeCount = guides.reduce((count, guide) => count + guide.place_count, 0);
 ---
@@ -84,6 +87,8 @@ const placeCount = guides.reduce((count, guide) => count + guide.place_count, 0)
         More travel notes at <a href={siteConfig.demFlyersUrl}>DEM Flyers</a>.
       </p>
     </div>
+
+    <HomeGuideMap guides={locationGuideCandidates} />
 
     <div class="controls-panel country-browser" data-home-browser-controls>
       <div class="controls-grid">
@@ -177,9 +182,32 @@ const placeCount = guides.reduce((count, guide) => count + guide.place_count, 0)
           <p class="eyebrow">Search results</p>
           <h3 class="section-title" data-global-search-title>Matching places</h3>
         </div>
-        <p class="small-copy" data-global-search-summary></p>
       </div>
-      <div class="search-result-grid" data-global-search-list aria-live="polite"></div>
+      <div class="search-results-toolbar" data-global-search-toolbar>
+        <p class="small-copy" data-global-search-summary></p>
+        <div class="search-view-toggle-group" role="group" aria-label="Search results view">
+          <button
+            class="search-view-toggle"
+            type="button"
+            data-search-view-toggle
+            data-search-view="grouped"
+            aria-pressed="true"
+          >
+            By country
+          </button>
+          <button
+            class="search-view-toggle"
+            type="button"
+            data-search-view-toggle
+            data-search-view="individual"
+            aria-pressed="false"
+          >
+            Individual
+          </button>
+        </div>
+      </div>
+      <div class="search-country-grid" data-grouped-search-list aria-live="polite"></div>
+      <div class="search-result-grid" data-global-search-list aria-live="polite" hidden></div>
       <div class="empty-state" data-global-search-empty role="status" aria-live="polite">
         No matching places. Try a broader search.
       </div>
@@ -203,6 +231,5 @@ const placeCount = guides.reduce((count, guide) => count + guide.place_count, 0)
     ))}
   </section>
 
-  <script is:inline type="application/json" data-location-guide-index set:html={locationGuideJson}></script>
   <script is:inline type="module" src="/scripts/home-browser.js"></script>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -282,8 +282,8 @@ const placeCount = guides.reduce((count, guide) => count + guide.place_count, 0)
           </button>
         </div>
       </div>
-      <div class="search-country-grid" data-grouped-search-list aria-live="polite"></div>
-      <div class="search-result-grid" data-global-search-list aria-live="polite" hidden></div>
+      <div class="search-country-grid" data-grouped-search-list></div>
+      <div class="search-result-grid" data-global-search-list hidden></div>
       <div class="empty-state" data-global-search-empty role="status" aria-live="polite">
         No matching places. Try a broader search.
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -68,6 +68,7 @@ const cityMarkerEmoji: Record<string, string> = {
   oaxaca: "🌮",
   paris: "🥐",
   sapporo: "🍺",
+  "san-francisco": "🌉",
   seoul: "🎧",
   singapore: "🦁",
   sydney: "🎭",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,6 +34,57 @@ const guidesByCountry = countryEntries.map(([countryName, countryGuides]) => ({
   countryName,
   countryFlag: getCountryFlag(countryGuides),
 }));
+const cityMarkerEmoji: Record<string, string> = {
+  amsterdam: "🚲",
+  bangkok: "🛺",
+  barcelona: "🏖️",
+  belfast: "🛳️",
+  berlin: "🪩",
+  "cape-town": "⛰️",
+  chicago: "🌆",
+  copenhagen: "🚲",
+  dubai: "🏙️",
+  florence: "🎨",
+  fukuoka: "🍜",
+  hakodate: "🌃",
+  hanoi: "🛵",
+  "hong-kong": "🌃",
+  ibiza: "🎧",
+  ishigaki: "🌺",
+  kanazawa: "🍵",
+  karuizawa: "🌲",
+  kyoto: "⛩️",
+  "las-vegas": "🎰",
+  london: "🎡",
+  "los-angeles": "🎬",
+  madrid: "💃",
+  melbourne: "☕",
+  "mexico-city": "🌮",
+  monaco: "🏎️",
+  nagasaki: "⛪",
+  nagoya: "🏯",
+  "new-york": "🗽",
+  oahu: "🏄",
+  oaxaca: "🌮",
+  paris: "🥐",
+  sapporo: "🍺",
+  seoul: "🎧",
+  singapore: "🦁",
+  sydney: "🎭",
+  taipei: "🥟",
+  takayama: "🏯",
+  tokyo: "🗼",
+  venice: "🛶",
+  vienna: "🎼",
+  yufuin: "♨️",
+  zurich: "🏔️",
+};
+const normalizeCityMarkerKey = (cityName: string) =>
+  cityName
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 const countryCodeToFlag = (countryCode: string | null) =>
   countryCode
     ? countryCode
@@ -49,7 +100,8 @@ const cityInitials = (cityName: string) =>
     .join("") || cityName.slice(0, 2).toUpperCase();
 const guideMarkerLabel = (guide: (typeof guides)[number]) => {
   const titleFlags = [...guide.title.matchAll(flagPattern)].map(([flag]) => flag);
-  return titleFlags.at(-1) || countryCodeToFlag(guide.country_code) || cityInitials(guide.city_name);
+  const cityEmoji = cityMarkerEmoji[normalizeCityMarkerKey(guide.city_name)];
+  return cityEmoji || titleFlags.at(-1) || countryCodeToFlag(guide.country_code) || cityInitials(guide.city_name);
 };
 const locationGuideCandidates = guides
   .filter((guide) => typeof guide.center_lat === "number" && typeof guide.center_lng === "number")

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,16 +34,35 @@ const guidesByCountry = countryEntries.map(([countryName, countryGuides]) => ({
   countryName,
   countryFlag: getCountryFlag(countryGuides),
 }));
+const countryCodeToFlag = (countryCode: string | null) =>
+  countryCode
+    ? countryCode
+        .toUpperCase()
+        .replace(/./g, (character) => String.fromCodePoint(127397 + character.charCodeAt(0)))
+    : "";
+const cityInitials = (cityName: string) =>
+  cityName
+    .split(/[\s-]+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("") || cityName.slice(0, 2).toUpperCase();
+const guideMarkerLabel = (guide: (typeof guides)[number]) => {
+  const titleFlags = [...guide.title.matchAll(flagPattern)].map(([flag]) => flag);
+  return titleFlags.at(-1) || countryCodeToFlag(guide.country_code) || cityInitials(guide.city_name);
+};
 const locationGuideCandidates = guides
   .filter((guide) => typeof guide.center_lat === "number" && typeof guide.center_lng === "number")
   .map((guide) => ({
     cityName: guide.city_name,
+    countryCode: guide.country_code,
     slug: guide.slug,
     title: guide.title,
     country: guide.country_name.toLowerCase(),
     countryName: guide.country_name,
     lat: guide.center_lat as number,
     lng: guide.center_lng as number,
+    markerLabel: guideMarkerLabel(guide),
     placeCount: guide.place_count,
     url: `/guides/${guide.slug}/`,
   }));

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -770,6 +770,38 @@ select {
   padding: 1rem;
 }
 
+.home-map-panel .guide-map {
+  min-height: 12rem;
+  height: clamp(12rem, 34vh, 20rem);
+}
+
+.home-guide-marker {
+  background: transparent;
+  border: 0;
+}
+
+.home-guide-marker-badge {
+  width: 2.3rem;
+  height: 2.3rem;
+  display: grid;
+  place-items: center;
+  border: 2px solid var(--accent);
+  border-radius: 999px;
+  background: rgba(255, 250, 241, 0.96);
+  box-shadow: 0 6px 18px rgba(31, 26, 22, 0.16);
+  color: var(--ink);
+  font-family:
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Noto Color Emoji",
+    "Avenir Next",
+    "Segoe UI",
+    sans-serif;
+  font-size: 1rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
 .guide-map {
   width: 100%;
   min-height: 24rem;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -329,6 +329,7 @@ img {
   gap: 0.25rem;
   border: 1px solid var(--line);
   border-radius: var(--radius-md);
+  background-color: var(--surface);
   color: inherit;
   text-decoration: none;
   transition:
@@ -339,7 +340,7 @@ img {
 .search-country-item:hover,
 .search-country-item:focus-visible {
   border-color: var(--accent);
-  background: #fffdfd;
+  background-color: #fffdfd;
 }
 
 .search-country-item:focus-visible {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -238,6 +238,133 @@ img {
   border-top: 1px solid var(--line);
 }
 
+.search-results-toolbar,
+.home-map-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+}
+
+.search-results-toolbar {
+  margin-bottom: 1rem;
+}
+
+.search-view-toggle-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface-strong);
+}
+
+.search-view-toggle {
+  min-height: 2.2rem;
+  padding: 0 0.9rem;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.search-view-toggle:hover,
+.search-view-toggle:focus-visible {
+  color: var(--accent);
+}
+
+.search-view-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.search-view-toggle[data-active="true"] {
+  background: var(--accent);
+  color: var(--surface);
+}
+
+.search-country-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.search-country-card {
+  padding: 1rem;
+  display: grid;
+  gap: 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+}
+
+.search-country-card-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.search-country-card h4 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 1.14rem;
+  line-height: 1.25;
+}
+
+.search-country-list {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.search-country-item {
+  padding: 0.85rem 0.95rem;
+  display: grid;
+  gap: 0.25rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  color: inherit;
+  text-decoration: none;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease;
+}
+
+.search-country-item:hover,
+.search-country-item:focus-visible {
+  border-color: var(--accent);
+  background: #fffdfd;
+}
+
+.search-country-item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.search-country-item-title {
+  color: var(--ink);
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 1rem;
+  font-weight: 800;
+  line-height: 1.35;
+}
+
+.search-country-item-meta,
+.search-country-overflow {
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.search-country-overflow {
+  margin: 0;
+}
+
 .search-result-grid {
   display: grid;
   gap: 0.8rem;
@@ -636,6 +763,13 @@ select {
     width 180ms ease;
 }
 
+.home-map-panel {
+  position: relative;
+  top: auto;
+  order: 0;
+  padding: 1rem;
+}
+
 .guide-map {
   width: 100%;
   min-height: 24rem;
@@ -941,6 +1075,10 @@ select {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .search-country-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .top-picks-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
@@ -956,6 +1094,12 @@ select {
   .top-picks-grid,
   .controls-grid {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .search-results-toolbar,
+  .home-map-head {
+    align-items: start;
+    flex-direction: column;
   }
 }
 

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -75,4 +75,21 @@ describe("guide map interactions", () => {
     expect(css).toContain('.map-icon-button[data-location-state="checking"]');
     expect(css).toContain(".map-icon-button[data-busy=\"true\"] svg");
   });
+
+  it("keeps the home guide map event contract in sync with the home browser", () => {
+    const homePage = readSource("src/pages/index.astro");
+    const homeMap = readSource("src/components/HomeGuideMap.astro");
+    const homeBrowser = readSource("public/scripts/home-browser.js");
+
+    expect(homePage).toContain("<HomeGuideMap guides={locationGuideCandidates} />");
+    expect(homeMap).toContain("data-home-guide-map");
+    expect(homeMap).toContain("data-guides={JSON.stringify(mapGuides).replace(/</g, \"\\\\u003c\")}");
+    expect(homeBrowser).toContain('root.querySelector("[data-home-guide-map]")');
+    expect(homeBrowser).toContain('new CustomEvent("favorite-places:home-map-update"');
+    expect(homeMap).toContain('document.addEventListener(\n      "favorite-places:home-map-update"');
+    expect(homeMap).toContain("pendingState");
+    expect(homeMap).toContain("runtime?.setVisibleGuides(currentVisibleGuideSlugs)");
+    expect(homeMap).toContain("runtime?.fitGuides(currentVisibleGuides)");
+    expect(homeMap).toContain("applyVisibility(\n      pendingState.visibleGuideSlugs,");
+  });
 });


### PR DESCRIPTION
Adds a home page map that shows guide locations and syncs with the visible guide set from country filters and search.

It changes global search results to default to grouped country summaries with up to five places per country, while keeping a toggle back to the individual place cards.

It also updates the home browser logic and styling to support the new grouped search layout, map state syncing, and responsive presentation.

Verification: bun run check && bun run build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive map displaying guide locations with real-time filtering based on search results.
  * Introduced a toggle to switch between grouped (by country) and individual search result view modes.
  * Enhanced search results display with country-based organization and improved layout.
  * Improved map support with automatic provider selection (Google Maps or Leaflet).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->