### PR TITLE
Add type-based map marker icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "bun run test:frontend && bun run test:python",
     "test:frontend": "vitest run",
     "test:python": "uv run python3 -m unittest discover -s tests/python -p 'test_*.py'",
+    "export:marker-icons": "bun scripts/export_marker_icons.mjs",
     "build:data": "uv run python3 scripts/build_data.py",
     "sync:sources": "uv run python3 scripts/build_data.py --refresh",
     "sync:sources:force": "uv run python3 scripts/build_data.py --refresh --refresh-force",

--- a/public/marker-icons/attraction.svg
+++ b/public/marker-icons/attraction.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" fill="none" aria-hidden="true">
+      <title>Tourist attraction</title>
+      
+      <circle cx="20" cy="20" r="14.9" fill="#ec4899" stroke="#9d174d" stroke-width="2.15" />
+      <circle cx="20" cy="20" r="9.15" fill="#fce7f3" fill-opacity="0.18" />
+      <g transform="translate(8 8)" stroke="#ffffff" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+        
+    <path d="m12 6.75 1.65 3.35 3.7.55-2.7 2.65.65 3.7L12 15.25 8.7 17l.65-3.7-2.7-2.65 3.7-.55L12 6.75Z" />
+  
+      </g>
+    </svg>

--- a/public/marker-icons/bakery.svg
+++ b/public/marker-icons/bakery.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" fill="none" aria-hidden="true">
+      <title>Bakery</title>
+      
+      <circle cx="20" cy="20" r="14.9" fill="#f59e0b" stroke="#92400e" stroke-width="2.15" />
+      <circle cx="20" cy="20" r="9.15" fill="#fef3c7" fill-opacity="0.18" />
+      <g transform="translate(8 8)" stroke="#ffffff" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+        
+    <path d="M7 14.55c0-3.05 2.45-5.55 5.5-5.55 2.55 0 4.75 1.7 5.35 4.05.95.1 1.65.7 1.65 1.9v2.3H7v-2.7Z" />
+    <path d="M10.2 12.4c.6-.8 1.45-1.4 2.4-1.75" />
+  
+      </g>
+    </svg>

--- a/public/marker-icons/bar.svg
+++ b/public/marker-icons/bar.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" fill="none" aria-hidden="true">
+      <title>Bar</title>
+      
+      <circle cx="20" cy="20" r="14.9" fill="#8b5cf6" stroke="#4c1d95" stroke-width="2.15" />
+      <circle cx="20" cy="20" r="9.15" fill="#ede9fe" fill-opacity="0.18" />
+      <g transform="translate(8 8)" stroke="#ffffff" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+        
+    <path d="M6.75 8.25h10.5l-4.45 4.7v4.15" />
+    <path d="M10.25 17.1h4.1" />
+  
+      </g>
+    </svg>

--- a/public/marker-icons/beach.svg
+++ b/public/marker-icons/beach.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" fill="none" aria-hidden="true">
+      <title>Beach</title>
+      
+      <circle cx="20" cy="20" r="14.9" fill="#06b6d4" stroke="#155e75" stroke-width="2.15" />
+      <circle cx="20" cy="20" r="9.15" fill="#cffafe" fill-opacity="0.18" />
+      <g transform="translate(8 8)" stroke="#ffffff" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+        
+    <path d="M7 16.75h10" />
+    <path d="M12 7.25v9.5" />
+    <path d="M12 7.25c2.4 0 4.3 1.3 5.25 3.5-1.4.85-3.15 1.3-5.25 1.3" />
+    <path d="M10.1 18.35c.7-.9 1.65-1.35 2.9-1.35 1.3 0 2.25.45 2.95 1.35" />
+  
+      </g>
+    </svg>

--- a/public/marker-icons/cafe.svg
+++ b/public/marker-icons/cafe.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" fill="none" aria-hidden="true">
+      <title>Cafe</title>
+      
+      <circle cx="20" cy="20" r="14.9" fill="#c46a16" stroke="#7c3f10" stroke-width="2.15" />
+      <circle cx="20" cy="20" r="9.15" fill="#fde3b0" fill-opacity="0.18" />
+      <g transform="translate(8 8)" stroke="#ffffff" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+        
+    <path d="M7.25 10.25h7.5v4.4a2.6 2.6 0 0 1-2.6 2.6H9.85a2.6 2.6 0 0 1-2.6-2.6v-4.4Z" />
+    <path d="M14.75 11.35h1.15a1.75 1.75 0 1 1 0 3.5h-1.15" />
+    <path d="M9.25 7.25c.7.55.7 1.35 0 1.9" />
+    <path d="M12.15 7.25c.7.55.7 1.35 0 1.9" />
+  
+      </g>
+    </svg>

--- a/public/marker-icons/default.svg
+++ b/public/marker-icons/default.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" fill="none" aria-hidden="true">
+      <title>Saved place</title>
+      
+      <circle cx="20" cy="20" r="14.9" fill="#8b95a7" stroke="#4b5563" stroke-width="2.15" />
+      <circle cx="20" cy="20" r="9.15" fill="#eef2f7" fill-opacity="0.18" />
+      <g transform="translate(8 8)" stroke="#ffffff" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+        
+    <circle cx="12" cy="12" r="2.4" />
+    <path d="M12 5.75v1.65M12 16.6v1.65M5.75 12h1.65M16.6 12h1.65M7.55 7.55l1.2 1.2M15.25 15.25l1.2 1.2M16.45 7.55l-1.2 1.2M8.75 15.25l-1.2 1.2" />
+  
+      </g>
+    </svg>

--- a/public/marker-icons/hotel.svg
+++ b/public/marker-icons/hotel.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" fill="none" aria-hidden="true">
+      <title>Hotel</title>
+      
+      <circle cx="20" cy="20" r="14.9" fill="#6366f1" stroke="#3730a3" stroke-width="2.15" />
+      <circle cx="20" cy="20" r="9.15" fill="#e0e7ff" fill-opacity="0.18" />
+      <g transform="translate(8 8)" stroke="#ffffff" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+        
+    <path d="M7 10.75v5.75" />
+    <path d="M7 12.5h10" />
+    <path d="M10 12.5v-1.2a1.8 1.8 0 0 1 1.8-1.8h1.65A2.55 2.55 0 0 1 16 12.05v4.45" />
+    <path d="M7 16.5h10" />
+  
+      </g>
+    </svg>

--- a/public/marker-icons/index.html
+++ b/public/marker-icons/index.html
@@ -1,0 +1,152 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Favorite Places Marker Icons</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f7efe3;
+        --card: rgba(255, 250, 241, 0.92);
+        --line: rgba(39, 26, 22, 0.12);
+        --ink: #1f1a16;
+        --muted: #6e5e53;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Avenir Next", "Segoe UI", sans-serif;
+        background:
+          radial-gradient(circle at top, rgba(196, 166, 133, 0.28), transparent 38%),
+          linear-gradient(180deg, #fbf6ef 0%, var(--bg) 100%);
+        color: var(--ink);
+      }
+
+      main {
+        width: min(72rem, calc(100% - 2rem));
+        margin: 0 auto;
+        padding: 2rem 0 3rem;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 5vw, 3rem);
+        line-height: 1.05;
+      }
+
+      p {
+        max-width: 42rem;
+        color: var(--muted);
+        font-size: 1rem;
+        line-height: 1.6;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+        gap: 1rem;
+        margin-top: 1.5rem;
+      }
+
+      .card {
+        display: grid;
+        gap: 0.75rem;
+        justify-items: center;
+        padding: 1.1rem 1rem 1rem;
+        border: 1px solid var(--line);
+        border-radius: 1.1rem;
+        background: var(--card);
+        box-shadow: 0 14px 40px rgba(31, 26, 22, 0.06);
+        text-align: center;
+      }
+
+      .card img {
+        width: 54px;
+        height: 72px;
+      }
+
+      .card strong {
+        font-size: 0.96rem;
+      }
+
+      .card code {
+        color: var(--muted);
+        font-size: 0.8rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Marker Icons</h1>
+      <p>Static SVG exports generated from the same marker source used by the guide map. Grab any file directly from this folder or use the manifest for programmatic lookups.</p>
+      <section class="grid">
+        <article class="card">
+                <img src="./default.svg" alt="Saved place" />
+                <strong>Saved place</strong>
+                <code>default.svg</code>
+              </article>
+        <article class="card">
+                <img src="./cafe.svg" alt="Cafe" />
+                <strong>Cafe</strong>
+                <code>cafe.svg</code>
+              </article>
+        <article class="card">
+                <img src="./restaurant.svg" alt="Restaurant" />
+                <strong>Restaurant</strong>
+                <code>restaurant.svg</code>
+              </article>
+        <article class="card">
+                <img src="./bar.svg" alt="Bar" />
+                <strong>Bar</strong>
+                <code>bar.svg</code>
+              </article>
+        <article class="card">
+                <img src="./bakery.svg" alt="Bakery" />
+                <strong>Bakery</strong>
+                <code>bakery.svg</code>
+              </article>
+        <article class="card">
+                <img src="./museum.svg" alt="Museum" />
+                <strong>Museum</strong>
+                <code>museum.svg</code>
+              </article>
+        <article class="card">
+                <img src="./attraction.svg" alt="Tourist attraction" />
+                <strong>Tourist attraction</strong>
+                <code>attraction.svg</code>
+              </article>
+        <article class="card">
+                <img src="./park.svg" alt="Park" />
+                <strong>Park</strong>
+                <code>park.svg</code>
+              </article>
+        <article class="card">
+                <img src="./beach.svg" alt="Beach" />
+                <strong>Beach</strong>
+                <code>beach.svg</code>
+              </article>
+        <article class="card">
+                <img src="./shopping.svg" alt="Shopping" />
+                <strong>Shopping</strong>
+                <code>shopping.svg</code>
+              </article>
+        <article class="card">
+                <img src="./hotel.svg" alt="Hotel" />
+                <strong>Hotel</strong>
+                <code>hotel.svg</code>
+              </article>
+        <article class="card">
+                <img src="./spa.svg" alt="Spa" />
+                <strong>Spa</strong>
+                <code>spa.svg</code>
+              </article>
+      </section>
+    </main>
+  </body>
+</html>
+

--- a/public/marker-icons/manifest.json
+++ b/public/marker-icons/manifest.json
@@ -1,0 +1,62 @@
+[
+  {
+    "file": "default.svg",
+    "key": "default",
+    "label": "Saved place"
+  },
+  {
+    "file": "cafe.svg",
+    "key": "cafe",
+    "label": "Cafe"
+  },
+  {
+    "file": "restaurant.svg",
+    "key": "restaurant",
+    "label": "Restaurant"
+  },
+  {
+    "file": "bar.svg",
+    "key": "bar",
+    "label": "Bar"
+  },
+  {
+    "file": "bakery.svg",
+    "key": "bakery",
+    "label": "Bakery"
+  },
+  {
+    "file": "museum.svg",
+    "key": "museum",
+    "label": "Museum"
+  },
+  {
+    "file": "attraction.svg",
+    "key": "attraction",
+    "label": "Tourist attraction"
+  },
+  {
+    "file": "park.svg",
+    "key": "park",
+    "label": "Park"
+  },
+  {
+    "file": "beach.svg",
+    "key": "beach",
+    "label": "Beach"
+  },
+  {
+    "file": "shopping.svg",
+    "key": "shopping",
+    "label": "Shopping"
+  },
+  {
+    "file": "hotel.svg",
+    "key": "hotel",
+    "label": "Hotel"
+  },
+  {
+    "file": "spa.svg",
+    "key": "spa",
+    "label": "Spa"
+  }
+]

--- a/public/marker-icons/museum.svg
+++ b/public/marker-icons/museum.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" fill="none" aria-hidden="true">
+      <title>Museum</title>
+      
+      <circle cx="20" cy="20" r="14.9" fill="#3b82f6" stroke="#1d4ed8" stroke-width="2.15" />
+      <circle cx="20" cy="20" r="9.15" fill="#dbeafe" fill-opacity="0.18" />
+      <g transform="translate(8 8)" stroke="#ffffff" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+        
+    <path d="M6.5 10.1 12 7l5.5 3.1" />
+    <path d="M7.4 10.35h9.2" />
+    <path d="M8.75 10.35v6" />
+    <path d="M12 10.35v6" />
+    <path d="M15.25 10.35v6" />
+    <path d="M6.75 16.75h10.5" />
+  
+      </g>
+    </svg>

--- a/public/marker-icons/park.svg
+++ b/public/marker-icons/park.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" fill="none" aria-hidden="true">
+      <title>Park</title>
+      
+      <circle cx="20" cy="20" r="14.9" fill="#16a34a" stroke="#166534" stroke-width="2.15" />
+      <circle cx="20" cy="20" r="9.15" fill="#dcfce7" fill-opacity="0.18" />
+      <g transform="translate(8 8)" stroke="#ffffff" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+        
+    <path d="M12 7c1.85 0 3.25 1.45 3.25 3.25 1.6.25 2.75 1.65 2.75 3.35A3.4 3.4 0 0 1 14.6 17H9.4A3.4 3.4 0 0 1 6 13.6c0-1.7 1.15-3.1 2.75-3.35C8.75 8.45 10.15 7 12 7Z" />
+    <path d="M12 17v3" />
+  
+      </g>
+    </svg>

--- a/public/marker-icons/restaurant.svg
+++ b/public/marker-icons/restaurant.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" fill="none" aria-hidden="true">
+      <title>Restaurant</title>
+      
+      <circle cx="20" cy="20" r="14.9" fill="#e24d3f" stroke="#8f241c" stroke-width="2.15" />
+      <circle cx="20" cy="20" r="9.15" fill="#fde0d7" fill-opacity="0.18" />
+      <g transform="translate(8 8)" stroke="#ffffff" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+        
+    <path d="M7.25 6.75v3.85a1.45 1.45 0 0 0 2.9 0V6.75" />
+    <path d="M8.7 6.75v10.5" />
+    <path d="M14.9 6.75v10.5" />
+    <path d="M16.75 6.75c0 2.65-.7 4.35-1.85 5.1" />
+  
+      </g>
+    </svg>

--- a/public/marker-icons/shopping.svg
+++ b/public/marker-icons/shopping.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" fill="none" aria-hidden="true">
+      <title>Shopping</title>
+      
+      <circle cx="20" cy="20" r="14.9" fill="#db2777" stroke="#9d174d" stroke-width="2.15" />
+      <circle cx="20" cy="20" r="9.15" fill="#fce7f3" fill-opacity="0.18" />
+      <g transform="translate(8 8)" stroke="#ffffff" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+        
+    <path d="M8 10.25h8l-.7 7.5H8.7L8 10.25Z" />
+    <path d="M10.2 10.25V9a1.8 1.8 0 0 1 3.6 0v1.25" />
+  
+      </g>
+    </svg>

--- a/public/marker-icons/spa.svg
+++ b/public/marker-icons/spa.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" fill="none" aria-hidden="true">
+      <title>Spa</title>
+      
+      <circle cx="20" cy="20" r="14.9" fill="#14b8a6" stroke="#115e59" stroke-width="2.15" />
+      <circle cx="20" cy="20" r="9.15" fill="#ccfbf1" fill-opacity="0.18" />
+      <g transform="translate(8 8)" stroke="#ffffff" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+        
+    <path d="M7 14.25c1.05-1.2 2.1-1.8 3.2-1.8 1.05 0 1.95.35 2.75 1 .8.65 1.6.95 2.35.95.95 0 1.9-.4 2.9-1.15" />
+    <path d="M8.5 10.1c.45-.9 1.2-1.7 2.2-2.2" />
+    <path d="M12.35 9.25c.35-.75.95-1.4 1.8-1.95" />
+  
+      </g>
+    </svg>

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -632,13 +632,14 @@ try:
         EnrichmentPlace,
         Guide,
         GuideManifest,
+        MarkerIcon,
         NormalizedPlace,
         PlacesSettings,
+        PlaceField,
+        PlaceProvenance,
         RawPlace,
         RawSavedList,
         SourceConfig,
-        PlaceField,
-        PlaceProvenance,
     )
 except ModuleNotFoundError:
     from scripts.pipeline_models import (
@@ -646,13 +647,14 @@ except ModuleNotFoundError:
         EnrichmentPlace,
         Guide,
         GuideManifest,
+        MarkerIcon,
         NormalizedPlace,
         PlacesSettings,
+        PlaceField,
+        PlaceProvenance,
         RawPlace,
         RawSavedList,
         SourceConfig,
-        PlaceField,
-        PlaceProvenance,
     )
 
 try:
@@ -1479,7 +1481,6 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
             place,
             enrichment=enrichment,
             category=primary_category,
-            tags=tags,
             note=note,
             why_recommended=why_recommended,
         )
@@ -1981,10 +1982,9 @@ def derive_marker_icon(
     *,
     enrichment: EnrichmentPlace,
     category: str | None,
-    tags: list[str],
     note: str | None,
     why_recommended: str | None,
-) -> str:
+) -> MarkerIcon:
     candidate_slugs = [
         slugify(term.replace("_", "-"))
         for term in [
@@ -1992,7 +1992,6 @@ def derive_marker_icon(
             enrichment.primary_type,
             enrichment.primary_type_display_name,
             *enrichment.types,
-            *tags,
         ]
         if term
     ]
@@ -2008,12 +2007,10 @@ def derive_marker_icon(
                 None,
                 [
                     place.name,
-                    place.address,
                     place.note,
                     note,
                     why_recommended,
                     category,
-                    " ".join(tags),
                 ],
             )
         )

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -311,6 +311,320 @@ VIBE_CATEGORY_RULES: dict[str, tuple[str, ...]] = {
     "park": ("scenic", "family-friendly"),
     "tourist-attraction": ("touristy-but-worth-it", "scenic"),
 }
+MARKER_ICON_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "cafe",
+        (
+            "cafe",
+            "coffee",
+            "coffee-shop",
+            "coffee-roasters",
+            "espresso-bar",
+            "tea",
+            "tea-house",
+            "tea-room",
+            "bubble-tea",
+        ),
+    ),
+    (
+        "bakery",
+        (
+            "bakery",
+            "patisserie",
+            "pastry",
+            "pastry-shop",
+            "dessert",
+            "dessert-shop",
+            "confectionery",
+            "chocolate-shop",
+            "ice-cream",
+            "donut-shop",
+        ),
+    ),
+    (
+        "bar",
+        (
+            "bar",
+            "pub",
+            "cocktail-bar",
+            "wine-bar",
+            "beer-hall",
+            "brewery",
+            "sports-bar",
+            "night-club",
+            "izakaya",
+            "karaoke",
+            "live-music-venue",
+        ),
+    ),
+    (
+        "restaurant",
+        (
+            "restaurant",
+            "food",
+            "food-court",
+            "meal-takeaway",
+            "meal-delivery",
+            "pizza",
+            "ramen",
+            "sushi",
+            "noodle",
+            "steakhouse",
+            "barbecue",
+            "brunch",
+            "diner",
+            "bistro",
+            "cafeteria",
+            "fast-food",
+            "seafood",
+            "tapas",
+            "grill",
+        ),
+    ),
+    (
+        "museum",
+        (
+            "museum",
+            "gallery",
+            "library",
+            "archive",
+            "planetarium",
+            "cultural-center",
+        ),
+    ),
+    (
+        "attraction",
+        (
+            "tourist-attraction",
+            "landmark",
+            "monument",
+            "historical-landmark",
+            "observation-deck",
+            "visitor-center",
+            "church",
+            "cathedral",
+            "basilica",
+            "temple",
+            "shrine",
+            "mosque",
+            "synagogue",
+            "castle",
+            "palace",
+            "aquarium",
+            "zoo",
+            "amusement-park",
+            "ferris-wheel",
+        ),
+    ),
+    (
+        "park",
+        (
+            "park",
+            "botanical-garden",
+            "garden",
+            "hiking-area",
+            "campground",
+            "picnic-ground",
+            "nature-preserve",
+            "national-park",
+            "trailhead",
+        ),
+    ),
+    (
+        "beach",
+        (
+            "beach",
+            "marina",
+            "waterfront",
+            "pier",
+            "swimming",
+            "surf",
+        ),
+    ),
+    (
+        "shopping",
+        (
+            "store",
+            "market",
+            "shopping-mall",
+            "gift-shop",
+            "book-store",
+            "clothing-store",
+            "department-store",
+            "antique-store",
+        ),
+    ),
+    (
+        "hotel",
+        (
+            "lodging",
+            "hotel",
+            "hostel",
+            "resort",
+            "inn",
+            "ryokan",
+        ),
+    ),
+    (
+        "spa",
+        (
+            "spa",
+            "sauna",
+            "onsen",
+            "massage",
+            "hot-spring",
+        ),
+    ),
+)
+MARKER_ICON_TEXT_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "cafe",
+        (
+            "cafe",
+            "coffee",
+            "espresso",
+            "kissaten",
+            "tea",
+            "matcha",
+            "roastery",
+        ),
+    ),
+    (
+        "bakery",
+        (
+            "bakery",
+            "baker",
+            "bread",
+            "pastry",
+            "patisserie",
+            "viennoiserie",
+            "dessert",
+            "gelato",
+            "ice cream",
+        ),
+    ),
+    (
+        "bar",
+        (
+            "bar",
+            "cocktail",
+            "wine",
+            "pub",
+            "taproom",
+            "speakeasy",
+            "izakaya",
+            "nightclub",
+            "karaoke",
+            "beer hall",
+        ),
+    ),
+    (
+        "restaurant",
+        (
+            "restaurant",
+            "pizza",
+            "ramen",
+            "sushi",
+            "udon",
+            "soba",
+            "yakitori",
+            "yakiniku",
+            "grill",
+            "kitchen",
+            "diner",
+            "bistro",
+            "trattoria",
+            "osteria",
+            "taqueria",
+            "bbq",
+            "burger",
+            "curry",
+            "noodle",
+        ),
+    ),
+    (
+        "museum",
+        (
+            "museum",
+            "gallery",
+            "archive",
+            "exhibit",
+            "library",
+        ),
+    ),
+    (
+        "attraction",
+        (
+            "temple",
+            "shrine",
+            "church",
+            "cathedral",
+            "mosque",
+            "synagogue",
+            "castle",
+            "palace",
+            "tower",
+            "landmark",
+            "monument",
+            "observatory",
+            "observation deck",
+            "viewpoint",
+            "park entrance",
+        ),
+    ),
+    (
+        "park",
+        (
+            "park",
+            "garden",
+            "forest",
+            "hike",
+            "trail",
+        ),
+    ),
+    (
+        "beach",
+        (
+            "beach",
+            "coast",
+            "bay",
+            "surf",
+            "island",
+        ),
+    ),
+    (
+        "shopping",
+        (
+            "shopping",
+            "market",
+            "store",
+            "district",
+            "shotengai",
+            "mall",
+            "bookstore",
+        ),
+    ),
+    (
+        "hotel",
+        (
+            "hotel",
+            "hostel",
+            "ryokan",
+            "resort",
+            "inn",
+        ),
+    ),
+    (
+        "spa",
+        (
+            "spa",
+            "onsen",
+            "sauna",
+            "bathhouse",
+            "massage",
+        ),
+    ),
+)
 
 try:
     from pipeline_models import (
@@ -1161,6 +1475,14 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
                 why_recommended=why_recommended,
                 top_pick=top_pick,
             )
+        marker_icon = derive_marker_icon(
+            place,
+            enrichment=enrichment,
+            category=primary_category,
+            tags=tags,
+            note=note,
+            why_recommended=why_recommended,
+        )
         manual_rank = as_int(override.get("manual_rank")) or 0
         status = (
             as_string(override.get("status"))
@@ -1183,6 +1505,7 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
             google_place_id=enrichment.google_place_id,
             google_place_resource_name=enrichment.google_place_resource_name,
             primary_category=primary_category,
+            marker_icon=marker_icon,
             tags=tags,
             vibe_tags=vibe_tags,
             neighborhood=neighborhood,
@@ -1653,6 +1976,55 @@ def derive_place_tags(
     return sorted(tag for tag in tags if tag)
 
 
+def derive_marker_icon(
+    place: RawPlace,
+    *,
+    enrichment: EnrichmentPlace,
+    category: str | None,
+    tags: list[str],
+    note: str | None,
+    why_recommended: str | None,
+) -> str:
+    candidate_slugs = [
+        slugify(term.replace("_", "-"))
+        for term in [
+            category,
+            enrichment.primary_type,
+            enrichment.primary_type_display_name,
+            *enrichment.types,
+            *tags,
+        ]
+        if term
+    ]
+
+    for candidate_slug in candidate_slugs:
+        for marker_icon, phrases in MARKER_ICON_RULES:
+            if any(slug_phrase_matches(candidate_slug, phrase) for phrase in phrases):
+                return marker_icon
+
+    lookup_text = normalize_vibe_lookup_text(
+        " ".join(
+            filter(
+                None,
+                [
+                    place.name,
+                    place.address,
+                    place.note,
+                    note,
+                    why_recommended,
+                    category,
+                    " ".join(tags),
+                ],
+            )
+        )
+    )
+    for marker_icon, keywords in MARKER_ICON_TEXT_RULES:
+        if any(vibe_keyword_matches(lookup_text, keyword) for keyword in keywords):
+            return marker_icon
+
+    return "default"
+
+
 def derive_vibe_tags(
     place: RawPlace,
     *,
@@ -1708,6 +2080,18 @@ def derive_vibe_tags(
 
 def normalize_vibe_lookup_text(value: str) -> str:
     return re.sub(r"\s+", " ", value.replace("_", " ").replace("-", " ").lower()).strip()
+
+
+def slug_phrase_matches(candidate_slug: str, phrase: str) -> bool:
+    normalized_phrase = slugify(phrase.replace("_", "-"))
+    if not candidate_slug or not normalized_phrase:
+        return False
+    return (
+        candidate_slug == normalized_phrase
+        or candidate_slug.startswith(f"{normalized_phrase}-")
+        or candidate_slug.endswith(f"-{normalized_phrase}")
+        or f"-{normalized_phrase}-" in candidate_slug
+    )
 
 
 def vibe_keyword_matches(lookup_text: str, keyword: str) -> bool:

--- a/scripts/export_marker_icons.mjs
+++ b/scripts/export_marker_icons.mjs
@@ -1,0 +1,139 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  buildMapMarkerSvg,
+  getMapMarkerColors,
+  getMapMarkerLabel,
+  MAP_MARKER_ICON_NAMES,
+} from "../src/lib/mapMarkerIcons";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(currentDir, "..");
+const outputDir = resolve(rootDir, "public", "marker-icons");
+
+mkdirSync(outputDir, { recursive: true });
+
+const manifest = MAP_MARKER_ICON_NAMES.map((icon) => {
+  const filename = `${icon}.svg`;
+  const svg = `${buildMapMarkerSvg(icon, getMapMarkerColors(icon))}\n`;
+
+  writeFileSync(resolve(outputDir, filename), svg, "utf8");
+
+  return {
+    file: filename,
+    key: icon,
+    label: getMapMarkerLabel(icon),
+  };
+});
+
+writeFileSync(resolve(outputDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+const previewHtml = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Favorite Places Marker Icons</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f7efe3;
+        --card: rgba(255, 250, 241, 0.92);
+        --line: rgba(39, 26, 22, 0.12);
+        --ink: #1f1a16;
+        --muted: #6e5e53;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Avenir Next", "Segoe UI", sans-serif;
+        background:
+          radial-gradient(circle at top, rgba(196, 166, 133, 0.28), transparent 38%),
+          linear-gradient(180deg, #fbf6ef 0%, var(--bg) 100%);
+        color: var(--ink);
+      }
+
+      main {
+        width: min(72rem, calc(100% - 2rem));
+        margin: 0 auto;
+        padding: 2rem 0 3rem;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 5vw, 3rem);
+        line-height: 1.05;
+      }
+
+      p {
+        max-width: 42rem;
+        color: var(--muted);
+        font-size: 1rem;
+        line-height: 1.6;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+        gap: 1rem;
+        margin-top: 1.5rem;
+      }
+
+      .card {
+        display: grid;
+        gap: 0.75rem;
+        justify-items: center;
+        padding: 1.1rem 1rem 1rem;
+        border: 1px solid var(--line);
+        border-radius: 1.1rem;
+        background: var(--card);
+        box-shadow: 0 14px 40px rgba(31, 26, 22, 0.06);
+        text-align: center;
+      }
+
+      .card img {
+        width: 54px;
+        height: 72px;
+      }
+
+      .card strong {
+        font-size: 0.96rem;
+      }
+
+      .card code {
+        color: var(--muted);
+        font-size: 0.8rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Marker Icons</h1>
+      <p>Static SVG exports generated from the same marker source used by the guide map. Grab any file directly from this folder or use the manifest for programmatic lookups.</p>
+      <section class="grid">
+        ${manifest
+          .map(
+            (entry) => `
+              <article class="card">
+                <img src="./${entry.file}" alt="${entry.label}" />
+                <strong>${entry.label}</strong>
+                <code>${entry.file}</code>
+              </article>
+            `.trim(),
+          )
+          .join("\n        ")}
+      </section>
+    </main>
+  </body>
+</html>
+`;
+
+writeFileSync(resolve(outputDir, "index.html"), `${previewHtml}\n`, "utf8");
+
+console.log(`Exported ${manifest.length} marker icons to ${outputDir}`);

--- a/scripts/pipeline_models.py
+++ b/scripts/pipeline_models.py
@@ -170,6 +170,21 @@ FieldSource = Literal[
     "website",
 ]
 
+MarkerIcon = Literal[
+    "default",
+    "cafe",
+    "restaurant",
+    "bar",
+    "bakery",
+    "museum",
+    "attraction",
+    "park",
+    "beach",
+    "shopping",
+    "hotel",
+    "spa",
+]
+
 
 class PlaceField(PipelineModel):
     value: Any
@@ -211,6 +226,7 @@ class NormalizedPlace(PipelineModel):
     google_place_id: str | None = None
     google_place_resource_name: str | None = None
     primary_category: str | None = None
+    marker_icon: MarkerIcon = "default"
     tags: list[str] = Field(default_factory=list)
     vibe_tags: list[str] = Field(default_factory=list)
     neighborhood: str | None = None

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -16,6 +16,7 @@ const mapPlaces = places
     id: place.id,
     name: place.name,
     category: place.primary_category ?? "Saved place",
+    markerIcon: place.marker_icon,
     neighborhood: place.neighborhood,
     lat: place.lat,
     lng: place.lng,
@@ -76,11 +77,19 @@ const mapPlaces = places
 <script>
   import L from "leaflet";
   import "leaflet/dist/leaflet.css";
+  import {
+    buildMapMarkerDataUrl,
+    buildMapMarkerSvg,
+    getMapMarkerColors,
+    getMapMarkerSize,
+  } from "../lib/mapMarkerIcons";
+  import type { MarkerIcon } from "../lib/types";
 
   interface MapPlace {
     id: string;
     name: string;
     category: string;
+    markerIcon: MarkerIcon;
     neighborhood: string | null;
     lat: number;
     lng: number;
@@ -156,6 +165,8 @@ const mapPlaces = places
         setMap: (map: unknown | null) => void;
         setZIndex: (zIndex: number) => void;
       };
+      Point: new (x: number, y: number) => unknown;
+      Size: new (width: number, height: number) => unknown;
       SymbolPath: {
         CIRCLE: unknown;
       };
@@ -172,9 +183,6 @@ const mapPlaces = places
 
   const MAP_COLLAPSED_KEY = "favoritePlacesMapCollapsed";
 
-  const DEFAULT_MARKER_COLOR = "#1f1a16";
-  const TOP_PICK_MARKER_COLOR = "#b64d1f";
-  const ACTIVE_MARKER_COLOR = "#c4312d";
   const LOCATION_PROXIMITY_BUFFER_KM = 25;
   const LOCATION_PROXIMITY_MULTIPLIER = 1.8;
   const LOCATION_OUTLIER_MIN_DISTANCE_KM = 50;
@@ -208,17 +216,32 @@ const mapPlaces = places
     `;
   };
 
-  const markerStyle = (place: MapPlace, active = false): L.CircleMarkerOptions => ({
-    radius: active ? (place.topPick ? 11 : 9) : place.topPick ? 8 : 6,
-    color: active ? ACTIVE_MARKER_COLOR : place.topPick ? TOP_PICK_MARKER_COLOR : DEFAULT_MARKER_COLOR,
-    fillColor: active ? ACTIVE_MARKER_COLOR : place.topPick ? TOP_PICK_MARKER_COLOR : "#fffaf1",
-    fillOpacity: active ? 0.96 : place.topPick ? 0.92 : 0.86,
-    opacity: 0.95,
-    weight: active ? 3 : 2,
-  });
+  const markerColors = (place: MapPlace, active = false) =>
+    getMapMarkerColors(place.markerIcon, {
+      active,
+      topPick: place.topPick,
+    });
 
-  const placeCircle = (place: MapPlace) =>
-    L.circleMarker([place.lat, place.lng], markerStyle(place)).bindPopup(popupHtml(place), {
+  const markerSvg = (place: MapPlace, active = false) =>
+    buildMapMarkerSvg(place.markerIcon, {
+      active,
+      ...markerColors(place, active),
+      topPick: place.topPick,
+    });
+
+  const leafletMarkerIcon = (place: MapPlace, active = false) => {
+    const size = getMapMarkerSize(place.markerIcon, place.topPick, active);
+    return L.divIcon({
+      className: "guide-map-marker",
+      html: markerSvg(place, active),
+      iconAnchor: [size.anchorX, size.anchorY],
+      iconSize: [size.width, size.height],
+      popupAnchor: [0, -size.popupOffsetY],
+    });
+  };
+
+  const placeMarker = (place: MapPlace) =>
+    L.marker([place.lat, place.lng], { icon: leafletMarkerIcon(place) }).bindPopup(popupHtml(place), {
       className: "guide-map-popup-shell",
       closeButton: false,
     });
@@ -513,9 +536,9 @@ const mapPlaces = places
       attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     }).addTo(map);
 
-    const markers = new Map<string, L.CircleMarker>();
+    const markers = new Map<string, L.Marker>();
     places.forEach((place) => {
-      const marker = placeCircle(place).addTo(map);
+      const marker = placeMarker(place).addTo(map);
       marker.on("click", () => onSelectPlace(place.id));
       markers.set(place.id, marker);
     });
@@ -530,10 +553,8 @@ const mapPlaces = places
       highlightPlace: (place, active) => {
         const marker = markers.get(place.id);
         if (!marker) return;
-        marker.setStyle(markerStyle(place, active));
-        if (active && map.hasLayer(marker)) {
-          marker.bringToFront();
-        }
+        marker.setIcon(leafletMarkerIcon(place, active));
+        marker.setZIndexOffset(active ? 1000 : place.topPick ? 10 : 0);
       },
       invalidateSize: () => map.invalidateSize(),
       openPlace: (place) => {
@@ -577,15 +598,18 @@ const mapPlaces = places
     const infoWindow = new google.maps.InfoWindow();
     const markers = new Map<string, any>();
 
-    const markerIcon = (place: MapPlace, active = false) => ({
-      fillColor: active ? ACTIVE_MARKER_COLOR : place.topPick ? TOP_PICK_MARKER_COLOR : "#fffaf1",
-      fillOpacity: active ? 0.96 : place.topPick ? 0.92 : 0.86,
-      path: google.maps.SymbolPath.CIRCLE,
-      scale: active ? (place.topPick ? 11 : 9) : place.topPick ? 8 : 6,
-      strokeColor: active ? ACTIVE_MARKER_COLOR : place.topPick ? TOP_PICK_MARKER_COLOR : DEFAULT_MARKER_COLOR,
-      strokeOpacity: 0.95,
-      strokeWeight: active ? 3 : 2,
-    });
+    const markerIcon = (place: MapPlace, active = false) => {
+      const size = getMapMarkerSize(place.markerIcon, place.topPick, active);
+      return {
+        anchor: new google.maps.Point(size.anchorX, size.anchorY),
+        scaledSize: new google.maps.Size(size.width, size.height),
+        url: buildMapMarkerDataUrl(place.markerIcon, {
+          active,
+          ...markerColors(place, active),
+          topPick: place.topPick,
+        }),
+      };
+    };
 
     places.forEach((place) => {
       const marker = new google.maps.Marker({

--- a/src/lib/mapMarkerIcons.ts
+++ b/src/lib/mapMarkerIcons.ts
@@ -1,0 +1,250 @@
+import type { MarkerIcon } from "./types";
+
+export interface MapMarkerSvgOptions {
+  active?: boolean;
+  fillColor: string;
+  haloColor: string;
+  ringColor?: string;
+  strokeColor: string;
+  topPick?: boolean;
+}
+
+export interface MapMarkerSize {
+  anchorX: number;
+  anchorY: number;
+  height: number;
+  popupOffsetY: number;
+  width: number;
+}
+
+export const MAP_MARKER_ICON_NAMES = [
+  "default",
+  "cafe",
+  "restaurant",
+  "bar",
+  "bakery",
+  "museum",
+  "attraction",
+  "park",
+  "beach",
+  "shopping",
+  "hotel",
+  "spa",
+] as const satisfies readonly MarkerIcon[];
+
+export interface MapMarkerPalette {
+  fillColor: string;
+  haloColor: string;
+  strokeColor: string;
+}
+
+const MAP_MARKER_PALETTES: Record<MarkerIcon, MapMarkerPalette> = {
+  default: {
+    fillColor: "#8b95a7",
+    haloColor: "#eef2f7",
+    strokeColor: "#4b5563",
+  },
+  cafe: {
+    fillColor: "#c46a16",
+    haloColor: "#fde3b0",
+    strokeColor: "#7c3f10",
+  },
+  restaurant: {
+    fillColor: "#e24d3f",
+    haloColor: "#fde0d7",
+    strokeColor: "#8f241c",
+  },
+  bar: {
+    fillColor: "#8b5cf6",
+    haloColor: "#ede9fe",
+    strokeColor: "#4c1d95",
+  },
+  bakery: {
+    fillColor: "#f59e0b",
+    haloColor: "#fef3c7",
+    strokeColor: "#92400e",
+  },
+  museum: {
+    fillColor: "#3b82f6",
+    haloColor: "#dbeafe",
+    strokeColor: "#1d4ed8",
+  },
+  attraction: {
+    fillColor: "#ec4899",
+    haloColor: "#fce7f3",
+    strokeColor: "#9d174d",
+  },
+  park: {
+    fillColor: "#16a34a",
+    haloColor: "#dcfce7",
+    strokeColor: "#166534",
+  },
+  beach: {
+    fillColor: "#06b6d4",
+    haloColor: "#cffafe",
+    strokeColor: "#155e75",
+  },
+  shopping: {
+    fillColor: "#db2777",
+    haloColor: "#fce7f3",
+    strokeColor: "#9d174d",
+  },
+  hotel: {
+    fillColor: "#6366f1",
+    haloColor: "#e0e7ff",
+    strokeColor: "#3730a3",
+  },
+  spa: {
+    fillColor: "#14b8a6",
+    haloColor: "#ccfbf1",
+    strokeColor: "#115e59",
+  },
+};
+
+const MARKER_LABELS: Record<MarkerIcon, string> = {
+  default: "Saved place",
+  cafe: "Cafe",
+  restaurant: "Restaurant",
+  bar: "Bar",
+  bakery: "Bakery",
+  museum: "Museum",
+  attraction: "Tourist attraction",
+  park: "Park",
+  beach: "Beach",
+  shopping: "Shopping",
+  hotel: "Hotel",
+  spa: "Spa",
+};
+
+const MARKER_SYMBOLS: Record<MarkerIcon, string> = {
+  default: `
+    <circle cx="12" cy="12" r="2.4" />
+    <path d="M12 5.75v1.65M12 16.6v1.65M5.75 12h1.65M16.6 12h1.65M7.55 7.55l1.2 1.2M15.25 15.25l1.2 1.2M16.45 7.55l-1.2 1.2M8.75 15.25l-1.2 1.2" />
+  `,
+  cafe: `
+    <path d="M7.25 10.25h7.5v4.4a2.6 2.6 0 0 1-2.6 2.6H9.85a2.6 2.6 0 0 1-2.6-2.6v-4.4Z" />
+    <path d="M14.75 11.35h1.15a1.75 1.75 0 1 1 0 3.5h-1.15" />
+    <path d="M9.25 7.25c.7.55.7 1.35 0 1.9" />
+    <path d="M12.15 7.25c.7.55.7 1.35 0 1.9" />
+  `,
+  restaurant: `
+    <path d="M7.25 6.75v3.85a1.45 1.45 0 0 0 2.9 0V6.75" />
+    <path d="M8.7 6.75v10.5" />
+    <path d="M14.9 6.75v10.5" />
+    <path d="M16.75 6.75c0 2.65-.7 4.35-1.85 5.1" />
+  `,
+  bar: `
+    <path d="M6.75 8.25h10.5l-4.45 4.7v4.15" />
+    <path d="M10.25 17.1h4.1" />
+  `,
+  bakery: `
+    <path d="M7 14.55c0-3.05 2.45-5.55 5.5-5.55 2.55 0 4.75 1.7 5.35 4.05.95.1 1.65.7 1.65 1.9v2.3H7v-2.7Z" />
+    <path d="M10.2 12.4c.6-.8 1.45-1.4 2.4-1.75" />
+  `,
+  museum: `
+    <path d="M6.5 10.1 12 7l5.5 3.1" />
+    <path d="M7.4 10.35h9.2" />
+    <path d="M8.75 10.35v6" />
+    <path d="M12 10.35v6" />
+    <path d="M15.25 10.35v6" />
+    <path d="M6.75 16.75h10.5" />
+  `,
+  attraction: `
+    <path d="m12 6.75 1.65 3.35 3.7.55-2.7 2.65.65 3.7L12 15.25 8.7 17l.65-3.7-2.7-2.65 3.7-.55L12 6.75Z" />
+  `,
+  park: `
+    <path d="M12 7c1.85 0 3.25 1.45 3.25 3.25 1.6.25 2.75 1.65 2.75 3.35A3.4 3.4 0 0 1 14.6 17H9.4A3.4 3.4 0 0 1 6 13.6c0-1.7 1.15-3.1 2.75-3.35C8.75 8.45 10.15 7 12 7Z" />
+    <path d="M12 17v3" />
+  `,
+  beach: `
+    <path d="M7 16.75h10" />
+    <path d="M12 7.25v9.5" />
+    <path d="M12 7.25c2.4 0 4.3 1.3 5.25 3.5-1.4.85-3.15 1.3-5.25 1.3" />
+    <path d="M10.1 18.35c.7-.9 1.65-1.35 2.9-1.35 1.3 0 2.25.45 2.95 1.35" />
+  `,
+  shopping: `
+    <path d="M8 10.25h8l-.7 7.5H8.7L8 10.25Z" />
+    <path d="M10.2 10.25V9a1.8 1.8 0 0 1 3.6 0v1.25" />
+  `,
+  hotel: `
+    <path d="M7 10.75v5.75" />
+    <path d="M7 12.5h10" />
+    <path d="M10 12.5v-1.2a1.8 1.8 0 0 1 1.8-1.8h1.65A2.55 2.55 0 0 1 16 12.05v4.45" />
+    <path d="M7 16.5h10" />
+  `,
+  spa: `
+    <path d="M7 14.25c1.05-1.2 2.1-1.8 3.2-1.8 1.05 0 1.95.35 2.75 1 .8.65 1.6.95 2.35.95.95 0 1.9-.4 2.9-1.15" />
+    <path d="M8.5 10.1c.45-.9 1.2-1.7 2.2-2.2" />
+    <path d="M12.35 9.25c.35-.75.95-1.4 1.8-1.95" />
+  `,
+};
+
+const escapeXml = (value: string) =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+
+export const getMapMarkerLabel = (icon: MarkerIcon) => MARKER_LABELS[icon];
+
+export const getMapMarkerColors = (
+  icon: MarkerIcon,
+  { active = false, topPick = false } = {},
+): MapMarkerSvgOptions => {
+  const palette = MAP_MARKER_PALETTES[icon];
+
+  if (active) {
+    return {
+      ...palette,
+      ringColor: topPick ? "#fde68a" : "#ffffff",
+      topPick,
+      active,
+    };
+  }
+
+  return {
+    ...palette,
+    ringColor: topPick ? "#fde68a" : undefined,
+    topPick,
+    active,
+  };
+};
+
+export const getMapMarkerSize = (_icon: MarkerIcon, topPick = false, active = false): MapMarkerSize => {
+  const scale = active ? (topPick ? 1.16 : 1.1) : topPick ? 1.08 : 1;
+  const width = Math.round(34 * scale);
+  const height = Math.round(34 * scale);
+
+  return {
+    width,
+    height,
+    anchorX: Math.round(width / 2),
+    anchorY: Math.round(height / 2),
+    popupOffsetY: Math.round(height / 2) + 6,
+  };
+};
+
+export const buildMapMarkerSvg = (icon: MarkerIcon, options: MapMarkerSvgOptions): string => {
+  const { active = false, fillColor, haloColor, ringColor, strokeColor, topPick = false } = options;
+  const label = escapeXml(getMapMarkerLabel(icon));
+  const outerRadius = active ? (topPick ? 16.25 : 15.35) : topPick ? 15.55 : 14.9;
+  const ringRadius = active ? outerRadius + 1.8 : topPick ? outerRadius + 1.35 : 0;
+  const strokeWidth = active ? 2.5 : 2.15;
+
+  return `
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" fill="none" aria-hidden="true">
+      <title>${label}</title>
+      ${ringColor ? `<circle cx="20" cy="20" r="${ringRadius}" fill="${escapeXml(ringColor)}" fill-opacity="${active ? "0.98" : "0.95"}" />` : ""}
+      <circle cx="20" cy="20" r="${outerRadius}" fill="${escapeXml(fillColor)}" stroke="${escapeXml(strokeColor)}" stroke-width="${strokeWidth}" />
+      <circle cx="20" cy="20" r="${Math.max(outerRadius - 5.75, 7.25)}" fill="${escapeXml(haloColor)}" fill-opacity="${active ? "0.22" : "0.18"}" />
+      <g transform="translate(8 8)" stroke="#ffffff" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+        ${MARKER_SYMBOLS[icon]}
+      </g>
+    </svg>
+  `.trim();
+};
+
+export const buildMapMarkerDataUrl = (icon: MarkerIcon, options: MapMarkerSvgOptions): string =>
+  `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(buildMapMarkerSvg(icon, options))}`;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,17 @@
 export type FieldSource = "manual" | "google_list" | "google_places" | "osm" | "wikidata" | "website";
+export type MarkerIcon =
+  | "default"
+  | "cafe"
+  | "restaurant"
+  | "bar"
+  | "bakery"
+  | "museum"
+  | "attraction"
+  | "park"
+  | "beach"
+  | "shopping"
+  | "hotel"
+  | "spa";
 
 export interface PlaceField<T> {
   value: T;
@@ -40,6 +53,7 @@ export interface Place {
   google_place_id: string | null;
   google_place_resource_name: string | null;
   primary_category: string | null;
+  marker_icon: MarkerIcon;
   tags: string[];
   vibe_tags: string[];
   neighborhood: string | null;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -814,6 +814,8 @@ select {
 
 .guide-map-marker svg {
   display: block;
+  width: 100%;
+  height: 100%;
   overflow: visible;
   filter:
     drop-shadow(0 2px 0 rgba(255, 255, 255, 0.92))

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -807,6 +807,19 @@ select {
   font-family: "Avenir Next", "Segoe UI", sans-serif;
 }
 
+.guide-map-marker {
+  background: transparent;
+  border: 0;
+}
+
+.guide-map-marker svg {
+  display: block;
+  overflow: visible;
+  filter:
+    drop-shadow(0 2px 0 rgba(255, 255, 255, 0.92))
+    drop-shadow(0 5px 12px rgba(17, 12, 8, 0.28));
+}
+
 .guide-map .leaflet-control-zoom a {
   color: var(--ink);
 }

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -87,5 +87,7 @@ describe("guide map interactions", () => {
     expect(guideMap).not.toContain("google.maps.SymbolPath.CIRCLE");
     expect(css).toContain(".guide-map-marker");
     expect(css).toContain(".guide-map-marker svg");
+    expect(css).toContain("width: 100%;");
+    expect(css).toContain("height: 100%;");
   });
 });

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -75,4 +75,17 @@ describe("guide map interactions", () => {
     expect(css).toContain('.map-icon-button[data-location-state="checking"]');
     expect(css).toContain(".map-icon-button[data-busy=\"true\"] svg");
   });
+
+  it("renders map pins from normalized place-type icons instead of generic circles", () => {
+    const guideMap = readSource("src/components/GuideMap.astro");
+    const css = readSource("src/styles/global.css");
+
+    expect(guideMap).toContain("markerIcon: place.marker_icon");
+    expect(guideMap).toContain("buildMapMarkerDataUrl");
+    expect(guideMap).toContain("buildMapMarkerSvg");
+    expect(guideMap).toContain('className: "guide-map-marker"');
+    expect(guideMap).not.toContain("google.maps.SymbolPath.CIRCLE");
+    expect(css).toContain(".guide-map-marker");
+    expect(css).toContain(".guide-map-marker svg");
+  });
 });

--- a/tests/frontend/mapMarkerIcons.test.ts
+++ b/tests/frontend/mapMarkerIcons.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMapMarkerSvg,
+  getMapMarkerColors,
+  getMapMarkerLabel,
+  getMapMarkerSize,
+} from "../../src/lib/mapMarkerIcons";
+
+describe("map marker icons", () => {
+  it("renders distinct SVG markers for place types", () => {
+    const cafeSvg = buildMapMarkerSvg("cafe", getMapMarkerColors("cafe"));
+    const museumSvg = buildMapMarkerSvg("museum", getMapMarkerColors("museum"));
+
+    expect(cafeSvg).toContain("<title>Cafe</title>");
+    expect(museumSvg).toContain("<title>Museum</title>");
+    expect(cafeSvg).not.toEqual(museumSvg);
+  });
+
+  it("labels the generic fallback marker clearly", () => {
+    expect(getMapMarkerLabel("default")).toBe("Saved place");
+  });
+
+  it("scales active top picks larger than the default marker", () => {
+    const baseSize = getMapMarkerSize("restaurant", false, false);
+    const activeTopPickSize = getMapMarkerSize("restaurant", true, true);
+
+    expect(activeTopPickSize.width).toBeGreaterThan(baseSize.width);
+    expect(activeTopPickSize.height).toBeGreaterThan(baseSize.height);
+    expect(activeTopPickSize.anchorY).toBeGreaterThan(baseSize.anchorY);
+  });
+
+  it("keeps the default marker on the same circular badge geometry", () => {
+    const defaultSize = getMapMarkerSize("default", false, false);
+    const restaurantSize = getMapMarkerSize("restaurant", false, false);
+    const defaultSvg = buildMapMarkerSvg("default", getMapMarkerColors("default"));
+
+    expect(defaultSize.height).toBe(restaurantSize.height);
+    expect(defaultSize.anchorY).toBe(restaurantSize.anchorY);
+    expect(defaultSvg).toContain('viewBox="0 0 40 40"');
+  });
+
+  it("uses distinct type palettes and adds a ring for active or top-pick markers", () => {
+    const cafeColors = getMapMarkerColors("cafe");
+    const parkColors = getMapMarkerColors("park", { topPick: true });
+    const activeRestaurantColors = getMapMarkerColors("restaurant", { active: true });
+
+    expect(cafeColors.fillColor).not.toBe(parkColors.fillColor);
+    expect(parkColors.ringColor).toBeTruthy();
+    expect(activeRestaurantColors.ringColor).toBeTruthy();
+  });
+});

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -234,6 +234,7 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertEqual(first_place.id, first_place_id)
         self.assertEqual(first_place.primary_category, "Bakery")
+        self.assertEqual(first_place.marker_icon, "bakery")
         self.assertEqual(first_place.note, "Manual note")
         self.assertEqual(first_place.maps_url, "https://maps.google.com/?cid=override")
         self.assertEqual(first_place.neighborhood, "Shibuya")
@@ -402,6 +403,89 @@ class BuildDataTests(unittest.TestCase):
         self.assertIn("cozy", vibes)
         self.assertIn("slow-afternoon", vibes)
         self.assertIn("solo-friendly", vibes)
+
+    def test_derive_marker_icon_prefers_specific_type_matches(self) -> None:
+        test_cases = [
+            (
+                "coffee-shop",
+                EnrichmentPlace(primary_type="restaurant", types=["coffee_shop", "restaurant"]),
+                ["restaurant"],
+                "cafe",
+            ),
+            (
+                "art-gallery",
+                EnrichmentPlace(types=["art_gallery"]),
+                [],
+                "museum",
+            ),
+            (
+                None,
+                EnrichmentPlace(types=["historical_landmark"]),
+                [],
+                "attraction",
+            ),
+            (
+                None,
+                EnrichmentPlace(types=["spa"]),
+                [],
+                "spa",
+            ),
+            (
+                None,
+                EnrichmentPlace(),
+                ["night-market"],
+                "shopping",
+            ),
+        ]
+
+        for category, enrichment, tags, expected_icon in test_cases:
+            with self.subTest(category=category, expected_icon=expected_icon):
+                self.assertEqual(
+                    build_data.derive_marker_icon(
+                        RawPlace(name="Plain Place", maps_url="https://maps.google.com/?cid=1"),
+                        enrichment=enrichment,
+                        category=category,
+                        tags=tags,
+                        note=None,
+                        why_recommended=None,
+                    ),
+                    expected_icon,
+                )
+
+    def test_derive_marker_icon_falls_back_to_default_without_type_signal(self) -> None:
+        self.assertEqual(
+            build_data.derive_marker_icon(
+                RawPlace(name="Plain Place", maps_url="https://maps.google.com/?cid=1"),
+                enrichment=EnrichmentPlace(),
+                category=None,
+                tags=["tokyo", "shibuya"],
+                note=None,
+                why_recommended=None,
+            ),
+            "default",
+        )
+
+    def test_derive_marker_icon_uses_place_name_keyword_fallback_without_enrichment(self) -> None:
+        test_cases = [
+            ("Bar Rooster", "bar"),
+            ("Bear Pond Espresso", "cafe"),
+            ("Ameyoko Shopping District", "shopping"),
+            ("Pizza Strada", "restaurant"),
+        ]
+
+        for place_name, expected_icon in test_cases:
+            with self.subTest(place_name=place_name):
+                self.assertEqual(
+                    build_data.derive_marker_icon(
+                        RawPlace(name=place_name, maps_url="https://maps.google.com/?cid=1"),
+                        enrichment=EnrichmentPlace(),
+                        category=None,
+                        tags=["tokyo"],
+                        note=None,
+                        why_recommended=None,
+                    ),
+                    expected_icon,
+                )
 
     def test_vibe_keyword_matching_uses_token_boundaries(self) -> None:
         self.assertFalse(build_data.vibe_keyword_matches("barcelona cafe", "bar"))

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -409,43 +409,37 @@ class BuildDataTests(unittest.TestCase):
             (
                 "coffee-shop",
                 EnrichmentPlace(primary_type="restaurant", types=["coffee_shop", "restaurant"]),
-                ["restaurant"],
                 "cafe",
             ),
             (
                 "art-gallery",
                 EnrichmentPlace(types=["art_gallery"]),
-                [],
                 "museum",
             ),
             (
                 None,
                 EnrichmentPlace(types=["historical_landmark"]),
-                [],
                 "attraction",
             ),
             (
                 None,
                 EnrichmentPlace(types=["spa"]),
-                [],
                 "spa",
             ),
             (
-                None,
+                "night market",
                 EnrichmentPlace(),
-                ["night-market"],
                 "shopping",
             ),
         ]
 
-        for category, enrichment, tags, expected_icon in test_cases:
+        for category, enrichment, expected_icon in test_cases:
             with self.subTest(category=category, expected_icon=expected_icon):
                 self.assertEqual(
                     build_data.derive_marker_icon(
                         RawPlace(name="Plain Place", maps_url="https://maps.google.com/?cid=1"),
                         enrichment=enrichment,
                         category=category,
-                        tags=tags,
                         note=None,
                         why_recommended=None,
                     ),
@@ -458,7 +452,6 @@ class BuildDataTests(unittest.TestCase):
                 RawPlace(name="Plain Place", maps_url="https://maps.google.com/?cid=1"),
                 enrichment=EnrichmentPlace(),
                 category=None,
-                tags=["tokyo", "shibuya"],
                 note=None,
                 why_recommended=None,
             ),
@@ -480,12 +473,27 @@ class BuildDataTests(unittest.TestCase):
                         RawPlace(name=place_name, maps_url="https://maps.google.com/?cid=1"),
                         enrichment=EnrichmentPlace(),
                         category=None,
-                        tags=["tokyo"],
                         note=None,
                         why_recommended=None,
                     ),
                     expected_icon,
                 )
+
+    def test_derive_marker_icon_does_not_use_locality_tags_as_type_fallback(self) -> None:
+        self.assertEqual(
+            build_data.derive_marker_icon(
+                RawPlace(
+                    name="Plain Place",
+                    address="1 Ocean Drive, Miami Beach, Park City",
+                    maps_url="https://maps.google.com/?cid=1",
+                ),
+                enrichment=EnrichmentPlace(),
+                category=None,
+                note=None,
+                why_recommended=None,
+            ),
+            "default",
+        )
 
     def test_vibe_keyword_matching_uses_token_boundaries(self) -> None:
         self.assertFalse(build_data.vibe_keyword_matches("barcelona cafe", "bar"))


### PR DESCRIPTION
This PR adds normalized type-based map marker icons across the data pipeline and guide map so places can render as cafes, restaurants, bars, museums, attractions, and other common categories.

It adds a shared marker icon module plus an export script, checked-in SVG assets, and a preview page under `public/marker-icons/`.

It also improves marker classification with fallback keyword heuristics when enrichment data is missing, and adds frontend and Python tests covering marker rendering and typing.