### PR TITLE
fix: restore guide hero layout

### DIFF
--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -78,7 +78,6 @@ const placeTagGuideContext = {
         }
         <div class="hero-meta">
           <span class="stat-pill">{guide.place_count} places</span>
-          <span class="stat-pill">{guide.city_name}</span>
           {guide.source_url && (
             <a class="action-pill" href={guide.source_url} target="_blank" rel="noreferrer">
               View source list

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -142,7 +142,6 @@ img {
 .hero-meta,
 .tag-row,
 .stats-row,
-.section-stack,
 .card-grid,
 .top-picks-grid,
 .controls-grid {
@@ -157,6 +156,18 @@ img {
 .meta-copy {
   min-width: 0;
   overflow-wrap: anywhere;
+}
+
+.section-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.hero-meta,
+.stats-row {
+  align-items: center;
 }
 
 .stat-pill,


### PR DESCRIPTION
## Summary
- remove the redundant city stat pill from guide heroes
- restore \.section-stack as a vertical stack so hero copy and meta pills stop collapsing into one wrapping row
- align hero stats rows so the place count and source CTA render at their intended size

## Verification
- bun run check
- bun run build
- browser spot checks on localhost guide pages for Tokyo and Perth & Fremantle