### PR TITLE
Add guide map zoom controls

### DIFF
--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -594,6 +594,7 @@ const mapPlaces = places
       mapTypeControl: false,
       streetViewControl: false,
       zoom: 13,
+      zoomControl: true,
     });
     const infoWindow = new google.maps.InfoWindow();
     const markers = new Map<string, any>();


### PR DESCRIPTION
Enable native +/- zoom controls on guide-page Google Maps so they match the existing Leaflet guide map and the home map behavior.

Validation: `bun run check` and `bun run build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled zoom controls on the map to improve navigation and user interaction capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->