### PR TITLE
Enable Google POI clicks on guide maps

### DIFF
--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -587,7 +587,7 @@ const mapPlaces = places
     const google = await loadGoogleMapsApi(apiKey);
     const map = new google.maps.Map(mapElement, {
       center: { lat: places[0].lat, lng: places[0].lng },
-      clickableIcons: false,
+      clickableIcons: true,
       disableDefaultUI: true,
       gestureHandling: "greedy",
       keyboardShortcuts: true,


### PR DESCRIPTION
## Summary
Enable clickable Google basemap POIs on guide pages by setting clickableIcons to true in the guide map component.

## Testing
- bun run check
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Map markers and annotation icons are now clickable on Google Maps, improving user interaction with map points of interest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->