### PR TITLE
Fix Google Maps place links

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from statistics import median
 from typing import Any
-from urllib.parse import unquote
+from urllib.parse import unquote, urlencode
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
@@ -1493,14 +1493,25 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
         preferred_name = place.name
         if prefer_enrichment_names and enrichment.display_name:
             preferred_name = enrichment.display_name
+        normalized_name = as_string(override.get("name")) or preferred_name
+        normalized_address = place.address or enrichment.formatted_address
+        maps_url = build_public_google_maps_url(
+            name=normalized_name,
+            address=normalized_address,
+            lat=place.lat,
+            lng=place.lng,
+            raw_maps_url=place.maps_url,
+            google_maps_uri=enrichment.google_maps_uri,
+            google_place_id=enrichment.google_place_id,
+        )
 
         normalized = NormalizedPlace(
             id=place_id,
-            name=as_string(override.get("name")) or preferred_name,
-            address=place.address or enrichment.formatted_address,
+            name=normalized_name,
+            address=normalized_address,
             lat=place.lat,
             lng=place.lng,
-            maps_url=enrichment.google_maps_uri or place.maps_url,
+            maps_url=maps_url,
             cid=place.cid,
             google_id=place.google_id,
             google_place_id=enrichment.google_place_id,
@@ -2817,6 +2828,13 @@ def fetch_places_enrichment(place: RawPlace, *, api_key: str | None) -> Enrichme
 
 def fetch_place_page_enrichment(place: RawPlace) -> EnrichmentCacheEntry:
     query = build_text_query(place)
+    place_url = build_public_google_maps_url(
+        name=place.name,
+        address=place.address,
+        lat=place.lat,
+        lng=place.lng,
+        raw_maps_url=place.maps_url,
+    )
     if scrape_place is None:
         return build_cache_entry(
             place,
@@ -2830,7 +2848,7 @@ def fetch_place_page_enrichment(place: RawPlace) -> EnrichmentCacheEntry:
     try:
         try:
             details = scrape_place(
-                place.maps_url,
+                place_url,
                 headless=True,
                 browser_session=browser_session,
                 http_session=http_session,
@@ -2841,7 +2859,7 @@ def fetch_place_page_enrichment(place: RawPlace) -> EnrichmentCacheEntry:
                 browser_session, http_session = build_scraper_configs(session_state, proxy)
                 try:
                     details = scrape_place(
-                        place.maps_url,
+                        place_url,
                         headless=True,
                         browser_session=browser_session,
                         http_session=http_session,
@@ -3061,6 +3079,63 @@ def build_text_query(place: RawPlace) -> str:
     address = place.address or ""
     query = f"{name}, {address}".strip(", ")
     return query or name or address
+
+
+def build_maps_link_query(
+    *,
+    name: str | None,
+    address: str | None,
+    lat: float | None,
+    lng: float | None,
+) -> str | None:
+    text_parts = [part.strip() for part in (name, address) if isinstance(part, str) and part.strip()]
+    if text_parts:
+        return ", ".join(dict.fromkeys(text_parts))
+    if lat is not None and lng is not None:
+        return f"{lat:.7f},{lng:.7f}"
+    return None
+
+
+def build_google_maps_search_url(query: str, *, google_place_id: str | None = None) -> str:
+    params = {"api": "1", "query": query}
+    if google_place_id:
+        params["query_place_id"] = google_place_id
+    return f"https://www.google.com/maps/search/?{urlencode(params)}"
+
+
+def should_rebuild_google_maps_url(maps_url: str | None) -> bool:
+    normalized_url = as_string(maps_url)
+    if normalized_url is None:
+        return True
+    if re.search(r"[?&]cid=[^&#]+", normalized_url):
+        return True
+    if "google." not in normalized_url:
+        return False
+    return bool(re.search(r"[?&]q=-?\d+(?:\.\d+)?,-?\d+(?:\.\d+)?(?:[&#]|$)", normalized_url))
+
+
+def build_public_google_maps_url(
+    *,
+    name: str | None,
+    address: str | None,
+    lat: float | None,
+    lng: float | None,
+    raw_maps_url: str | None,
+    google_maps_uri: str | None = None,
+    google_place_id: str | None = None,
+) -> str:
+    query = build_maps_link_query(name=name, address=address, lat=lat, lng=lng)
+    if query and google_place_id:
+        return build_google_maps_search_url(query, google_place_id=google_place_id)
+
+    preferred_url = as_string(google_maps_uri) or as_string(raw_maps_url)
+    if preferred_url and not should_rebuild_google_maps_url(preferred_url):
+        return preferred_url
+
+    if query:
+        return build_google_maps_search_url(query)
+
+    return preferred_url or raw_maps_url or "https://www.google.com/maps"
 
 
 def score_text_search_candidate(raw_place: RawPlace, candidate: dict[str, Any]) -> int:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -236,7 +236,10 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(first_place.primary_category, "Bakery")
         self.assertEqual(first_place.marker_icon, "bakery")
         self.assertEqual(first_place.note, "Manual note")
-        self.assertEqual(first_place.maps_url, "https://maps.google.com/?cid=override")
+        self.assertEqual(
+            first_place.maps_url,
+            "https://www.google.com/maps/search/?api=1&query=Coffee+House%2C+1+Shibuya%2C+Tokyo%2C+Japan",
+        )
         self.assertEqual(first_place.neighborhood, "Shibuya")
         self.assertTrue(first_place.top_pick)
         self.assertIn("local-favorite", first_place.vibe_tags)
@@ -928,7 +931,10 @@ class BuildDataTests(unittest.TestCase):
         place = guide.places[0]
         self.assertEqual(place.name, "Modern Tea House")
         self.assertEqual(place.address, "1 Songshan, Taipei, Taiwan")
-        self.assertEqual(place.maps_url, "https://maps.google.com/?cid=override")
+        self.assertEqual(
+            place.maps_url,
+            "https://www.google.com/maps/search/?api=1&query=Modern+Tea+House%2C+1+Songshan%2C+Taipei%2C+Taiwan",
+        )
         self.assertEqual(place.provenance.name.source, "google_places")
         self.assertEqual(place.provenance.name.fetched_at, "2026-04-16T00:00:00+00:00")
         self.assertEqual(place.provenance.address.source, "google_places")
@@ -940,6 +946,47 @@ class BuildDataTests(unittest.TestCase):
                 "taipei": "google_list",
                 "tea-house": "google_places",
             },
+        )
+
+    def test_normalize_guide_prefers_place_id_search_url_when_available(self) -> None:
+        raw = RawSavedList(
+            title="Sydney, Australia",
+            places=[
+                RawPlace(
+                    name="Cantina OK!",
+                    address="Council Pl, Sydney NSW 2000, Australia",
+                    lat=-33.8702175,
+                    lng=151.2051413,
+                    maps_url="https://maps.google.com/?cid=7715422616180689913",
+                    cid="7715422616180689913",
+                )
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0])
+        enrichment_cache = {
+            place_id: EnrichmentCacheEntry(
+                fetched_at="2026-04-16T00:00:00+00:00",
+                query="Cantina OK!, Sydney",
+                matched=True,
+                score=88,
+                place=EnrichmentPlace(
+                    display_name="Cantina OK!",
+                    formatted_address="Council Pl, Sydney NSW 2000, Australia",
+                    google_maps_uri="https://maps.google.com/?cid=7715422616180689913",
+                    google_place_id="ChIJGcmcg7ZC1moRAOacd3HoEwM",
+                ),
+            )
+        }
+
+        guide = build_data.normalize_guide("sydney-australia", raw, enrichment_cache=enrichment_cache)
+
+        self.assertEqual(
+            guide.places[0].maps_url,
+            (
+                "https://www.google.com/maps/search/?api=1"
+                "&query=Cantina+OK%21%2C+Council+Pl%2C+Sydney+NSW+2000%2C+Australia"
+                "&query_place_id=ChIJGcmcg7ZC1moRAOacd3HoEwM"
+            ),
         )
 
     def test_resolve_refresh_sources_matches_csv_path_selector(self) -> None:
@@ -1313,6 +1360,49 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(entry.place.primary_type, "japanese_restaurant")
         self.assertEqual(entry.place.user_rating_count, 324)
         self.assertEqual(entry.place.business_status, "OPERATIONAL")
+
+    def test_fetch_place_page_enrichment_rewrites_cid_url_before_scraping(self) -> None:
+        place = RawPlace(
+            name="Cantina OK!",
+            address="Council Pl, Sydney NSW 2000, Australia",
+            lat=-33.8702175,
+            lng=151.2051413,
+            maps_url="https://maps.google.com/?cid=7715422616180689913",
+            cid="7715422616180689913",
+        )
+        details = SimpleNamespace(
+            source_url=(
+                "https://www.google.com/maps/search/?api=1"
+                "&query=Cantina+OK%21%2C+Council+Pl%2C+Sydney+NSW+2000%2C+Australia"
+            ),
+            resolved_url="https://www.google.com/maps/place/Cantina+OK!/@-33.8702175,151.2051413,17z",
+            name="Cantina OK!",
+            category="Cocktail bar",
+            address="Council Pl, Sydney NSW 2000, Australia",
+            status="Open",
+            limited_view=False,
+        )
+
+        with (
+            patch.object(build_data, "current_scraper_proxy", return_value=None),
+            patch.object(build_data, "build_scraper_sessions", return_value=(SimpleNamespace(), None, None)),
+            patch.object(build_data, "record_scraper_session_use"),
+            patch.object(build_data, "release_scraper_session_lock"),
+            patch.object(build_data, "scrape_place", return_value=details) as scrape,
+        ):
+            entry = build_data.fetch_place_page_enrichment(place)
+
+        scrape.assert_called_once_with(
+            (
+                "https://www.google.com/maps/search/?api=1"
+                "&query=Cantina+OK%21%2C+Council+Pl%2C+Sydney+NSW+2000%2C+Australia"
+            ),
+            headless=True,
+            browser_session=None,
+            http_session=None,
+        )
+        self.assertTrue(entry.matched)
+        self.assertEqual(entry.place.display_name, "Cantina OK!")
 
     def test_fetch_places_enrichment_falls_back_to_api_when_page_is_limited(self) -> None:
         place = RawPlace(


### PR DESCRIPTION
Normalize saved Google Maps links so cid-based URLs are converted into supported Maps search URLs built from place metadata.

Prefer query_place_id when enrichment has a Place ID, and use the normalized URL for place-page enrichment scraping.

Add regression coverage for cid rewrites and Place ID search links.

Validated with bun run test, bun run check, and bun run build.