### PR TITLE
Document enrichment behavior and add strategy setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,19 +105,28 @@ bun run build
 
 ## Optional Enrichment
 
-The site works without Google Places enrichment. If you want richer metadata, add a server/build-time key in `.env`:
+The site works without enrichment, and normal builds never call Google. When you run an enrichment command, the pipeline first tries to scrape each place's Google Maps page from the saved-list URL. If that page scrape is blocked, limited, unmatched, or too sparse to trust, the pipeline can optionally fall back to the Google Places API.
+
+Add a server/build-time Places key only if you want that API fallback:
 
 ```bash
 GOOGLE_PLACES_API_KEY=...
 ```
 
-Then run one of:
+Then run one of the enrichment commands:
 
 ```bash
 bun run fill:gaps
 bun run enrich:data
 bun run refresh:enrichment
 ```
+
+The behavior is configurable in a few places:
+
+- `GOOGLE_PLACES_ENRICHMENT_STRATEGY` controls enrichment source selection. Use `scrape` for scraper-only, `api` for API-only, or `scrape_then_api` for scraper first with API fallback. The default is `scrape_then_api`.
+- `GOOGLE_PLACES_API_KEY` enables API-based enrichment. It is required for `api` mode and for the fallback leg of `scrape_then_api`.
+- `GMAPS_SCRAPER_PROXY` routes Google Maps list and place-page scraping through a proxy.
+- The command controls refresh scope: `fill:gaps` fills missing enrichment and photos, `enrich:data` fills missing or stale cache entries, and `refresh:enrichment` refreshes every entry.
 
 Manual overrides always win over machine-enriched fields.
 
@@ -127,8 +136,14 @@ Manual overrides always win over machine-enriched fields.
 # Browser Google Maps display key.
 GOOGLE_MAPS_JS_API_KEY=...
 
-# Server/build-time enrichment fallback.
+# Server/build-time key for API-based enrichment.
 GOOGLE_PLACES_API_KEY=...
+
+# Enrichment source strategy: scrape, api, or scrape_then_api.
+GOOGLE_PLACES_ENRICHMENT_STRATEGY=scrape_then_api
+
+# Optional proxy for Google Maps list and place-page scraping.
+GMAPS_SCRAPER_PROXY=...
 
 # Force Leaflet/OpenStreetMap rendering.
 PUBLIC_MAP_PROVIDER=leaflet

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -239,7 +239,8 @@ Why:
 Common variables:
 
 - `GOOGLE_MAPS_JS_API_KEY`: browser Google Maps display key, read by Astro during render/build and embedded only when the Google map provider is active
-- `GOOGLE_PLACES_API_KEY`: server/build-time fallback key for enrichment
+- `GOOGLE_PLACES_API_KEY`: server/build-time key for API-based enrichment
+- `GOOGLE_PLACES_ENRICHMENT_STRATEGY`: choose `scrape`, `api`, or `scrape_then_api` for place enrichment
 - `PUBLIC_MAP_PROVIDER=leaflet`: force Leaflet/OpenStreetMap rendering
 - `PUBLIC_PLACE_PHOTOS=off`: hide place photos in the UI
 - `FAVORITE_PLACES_SITE_DIR`: point the app and Python pipeline at a non-default site pack
@@ -268,7 +269,7 @@ Manual overrides always win over machine-enriched fields.
 
 ## Google Places Enrichment
 
-Enrichment is optional and cached. A normal build never calls Google.
+Enrichment is optional and cached. A normal build can run without enrichment, but the resulting guides are intentionally sparse: they mostly reflect the raw saved-list data plus manual overrides. Running enrichment is recommended when you want stable categories, Maps links, status, ratings, and photos.
 
 - `bun run enrich:data`: normal incremental enrichment; missing places go first, then stale entries
 - `bun run fill:enrichment`: only places with no cache entry
@@ -276,7 +277,17 @@ Enrichment is optional and cached. A normal build never calls Google.
 - `bun run refresh:enrichment`: force-refresh every entry
 - `bun run export:cache:json`: optional debug export of per-guide cache JSON from SQLite
 
-The current enrichment pass uses Google Places Text Search with a narrow field mask and location bias around scraped coordinates. It fills useful metadata such as category, Maps URI, rating, business status, and photos without making the site build a runtime dependency on Google.
+`GOOGLE_PLACES_ENRICHMENT_STRATEGY` controls source selection:
+
+- `scrape`: Google Maps place-page scraping only
+- `api`: Google Places Text Search only
+- `scrape_then_api`: Google Maps place-page scraping first, then Google Places Text Search when the scraped result is blocked, limited, unmatched, or too sparse to trust
+
+The default strategy is `scrape_then_api`. The scraper path does not require a Places API key. `api` mode and the fallback leg of `scrape_then_api` require `GOOGLE_PLACES_API_KEY`.
+
+The API path uses Google Places Text Search with a narrow field mask and location bias around scraped coordinates.
+
+Enrichment fills useful metadata such as category, Maps URI, rating, business status, and photos without making the rendered site depend on live Google calls.
 
 Cache invalidation is field-aware: raw input changes force refresh, operational places refresh more slowly, and volatile states like ratings, closures, unmatched results, and API errors refresh sooner.
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -17,9 +17,10 @@ from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime, timedelta
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 from statistics import median
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import parse_qsl, quote_plus, unquote, urlencode, urlsplit, urlunsplit
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -2655,6 +2656,7 @@ def enrich_raw_sources(
     refresh_startup_jitter_seconds: float = DEFAULT_REFRESH_STARTUP_JITTER_SECONDS,
 ) -> None:
     api_key = google_places_api_key()
+    strategy = google_places_enrichment_strategy()
     cache_payloads: dict[str, dict[str, EnrichmentCacheEntry]] = {}
     enrich_jobs: list[tuple[str, str, str, str, dict[str, Any]]] = []
 
@@ -2686,6 +2688,18 @@ def enrich_raw_sources(
     if not enrich_jobs:
         return
 
+    if strategy == "api" and api_key is None:
+        raise RuntimeError(
+            "GOOGLE_PLACES_API_KEY is required when GOOGLE_PLACES_ENRICHMENT_STRATEGY=api."
+        )
+
+    if strategy == "scrape_then_api" and api_key is None:
+        print(
+            "GOOGLE_PLACES_API_KEY is not set; enrichment will scrape Google Maps place pages "
+            "without Google Places API fallback.",
+            flush=True,
+        )
+
     enrich_jobs.sort(key=enrichment_job_priority)
 
     effective_startup_jitter_seconds = (
@@ -2701,6 +2715,7 @@ def enrich_raw_sources(
                 refresh_reason,
                 place_payload,
                 api_key=api_key,
+                strategy=strategy,
                 refresh_startup_jitter_seconds=effective_startup_jitter_seconds,
                 existing_entry=cache_payloads[slug].get(place_id),
             )
@@ -2720,6 +2735,7 @@ def enrich_raw_sources(
                 refresh_reason,
                 place_payload,
                 api_key=api_key,
+                strategy=strategy,
                 refresh_startup_jitter_seconds=effective_startup_jitter_seconds,
                 existing_entry=cache_payloads[slug].get(place_id),
             ): (slug, place_id)
@@ -2745,6 +2761,7 @@ def enrich_place_job(
     place_payload: dict[str, Any],
     *,
     api_key: str | None,
+    strategy: Literal["scrape", "api", "scrape_then_api"] | None = None,
     refresh_startup_jitter_seconds: float,
     existing_entry: EnrichmentCacheEntry | None = None,
 ) -> EnrichmentCacheEntry:
@@ -2754,7 +2771,7 @@ def enrich_place_job(
     )
     sleep_for_refresh_startup_jitter(refresh_startup_jitter_seconds)
     place = RawPlace.model_validate(place_payload)
-    refreshed_entry = fetch_places_enrichment(place, api_key=api_key)
+    refreshed_entry = fetch_places_enrichment(place, api_key=api_key, strategy=strategy)
     merged_entry, warning = preserve_existing_enrichment(
         slug=slug,
         place_id=place_id,
@@ -3637,6 +3654,11 @@ def coerce_string_list(value: Any) -> list[str]:
 
 def google_places_api_key() -> str | None:
     return PlacesSettings().google_places_api_key
+
+
+@cache
+def google_places_enrichment_strategy() -> Literal["scrape", "api", "scrape_then_api"]:
+    return PlacesSettings().google_places_enrichment_strategy
 
 
 def configured_source_path(source: SourceConfig) -> Path:
@@ -5364,7 +5386,25 @@ def public_photo_path(filename: str) -> str:
     return f"/place-photos/{filename}"
 
 
-def fetch_places_enrichment(place: RawPlace, *, api_key: str | None) -> EnrichmentCacheEntry:
+def fetch_places_enrichment(
+    place: RawPlace,
+    *,
+    api_key: str | None,
+    strategy: Literal["scrape", "api", "scrape_then_api"] | None = None,
+) -> EnrichmentCacheEntry:
+    if strategy is None:
+        strategy = google_places_enrichment_strategy()
+
+    if strategy == "scrape":
+        return fetch_place_page_enrichment(place)
+
+    if strategy == "api":
+        if api_key is None:
+            raise RuntimeError(
+                "GOOGLE_PLACES_API_KEY is required when GOOGLE_PLACES_ENRICHMENT_STRATEGY=api."
+            )
+        return fetch_places_api_enrichment(place, api_key=api_key)
+
     page_entry = fetch_place_page_enrichment(place)
     if page_entry.error is None and page_entry.place is not None:
         if api_key is None or not should_fallback_to_places_api(page_entry):

--- a/scripts/pipeline_models.py
+++ b/scripts/pipeline_models.py
@@ -21,6 +21,10 @@ class PlacesSettings(BaseSettings):
         default=None,
         validation_alias=AliasChoices("GOOGLE_PLACES_API_KEY", "GOOGLE_MAPS_API_KEY"),
     )
+    google_places_enrichment_strategy: Literal["scrape", "api", "scrape_then_api"] = Field(
+        default="scrape_then_api",
+        validation_alias=AliasChoices("GOOGLE_PLACES_ENRICHMENT_STRATEGY"),
+    )
 
 
 class SourceConfig(PipelineModel):

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -3078,7 +3078,10 @@ class BuildDataTests(unittest.TestCase):
             limited_view=False,
         )
 
-        with patch.object(build_data, "scrape_place", return_value=details) as scrape:
+        with (
+            patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
+            patch.object(build_data, "scrape_place", return_value=details) as scrape,
+        ):
             entry = build_data.fetch_places_enrichment(place, api_key=None)
 
         scrape.assert_called_once()
@@ -3088,6 +3091,89 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(entry.place.primary_type, "japanese_restaurant")
         self.assertEqual(entry.place.user_rating_count, 324)
         self.assertEqual(entry.place.business_status, "OPERATIONAL")
+
+    def test_fetch_places_enrichment_uses_scrape_strategy_without_api_fallback(self) -> None:
+        place = RawPlace(
+            name="Jimbocho Den",
+            address="Tokyo, Japan",
+            maps_url="https://www.google.com/maps/place/Jimbocho+Den",
+        )
+        page_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-16T00:00:00+00:00",
+            refresh_after="2026-04-19T00:00:00+00:00",
+            source="google_maps_page",
+            query="Jimbocho Den, Tokyo, Japan",
+            matched=True,
+            score=45,
+            place=EnrichmentPlace(
+                display_name="Jimbocho Den",
+                formatted_address="Tokyo, Japan",
+                google_maps_uri=place.maps_url,
+                limited_view=True,
+            ),
+        )
+
+        with (
+            patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape"),
+            patch.object(build_data, "fetch_place_page_enrichment", return_value=page_entry) as page_fetch,
+            patch.object(build_data, "fetch_places_api_enrichment") as api_fetch,
+        ):
+            entry = build_data.fetch_places_enrichment(place, api_key="test-key")
+
+        page_fetch.assert_called_once_with(place)
+        api_fetch.assert_not_called()
+        self.assertIs(entry, page_entry)
+
+    def test_fetch_places_enrichment_uses_api_strategy_without_scraping(self) -> None:
+        place = RawPlace(
+            name="Jimbocho Den",
+            address="Tokyo, Japan",
+            maps_url="https://www.google.com/maps/place/Jimbocho+Den",
+        )
+        api_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-16T00:00:00+00:00",
+            refresh_after="2026-04-23T00:00:00+00:00",
+            source="google_places_api",
+            query="Jimbocho Den, Tokyo, Japan",
+            matched=True,
+            score=88,
+            place=EnrichmentPlace(
+                display_name="Jimbocho Den",
+                formatted_address="Tokyo, Japan",
+                google_maps_uri="https://maps.google.com/?cid=1",
+                primary_type="restaurant",
+                primary_type_display_name="Restaurant",
+            ),
+        )
+
+        with (
+            patch.object(build_data, "google_places_enrichment_strategy", return_value="api"),
+            patch.object(build_data, "fetch_place_page_enrichment") as page_fetch,
+            patch.object(build_data, "fetch_places_api_enrichment", return_value=api_entry) as api_fetch,
+        ):
+            entry = build_data.fetch_places_enrichment(place, api_key="test-key")
+
+        page_fetch.assert_not_called()
+        api_fetch.assert_called_once_with(place, api_key="test-key")
+        self.assertIs(entry, api_entry)
+
+    def test_fetch_places_enrichment_fails_for_api_strategy_without_key(self) -> None:
+        place = RawPlace(
+            name="Jimbocho Den",
+            address="Tokyo, Japan",
+            maps_url="https://www.google.com/maps/place/Jimbocho+Den",
+        )
+
+        with (
+            patch.object(build_data, "google_places_enrichment_strategy", return_value="api"),
+            patch.object(build_data, "fetch_place_page_enrichment") as page_fetch,
+            patch.object(build_data, "fetch_places_api_enrichment") as api_fetch,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "GOOGLE_PLACES_API_KEY is required"):
+                build_data.fetch_places_enrichment(place, api_key=None)
+
+        page_fetch.assert_not_called()
+        api_fetch.assert_not_called()
 
     def test_fetch_place_page_enrichment_rewrites_cid_url_before_scraping(self) -> None:
         place = RawPlace(
@@ -3170,6 +3256,7 @@ class BuildDataTests(unittest.TestCase):
         )
 
         with (
+            patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
             patch.object(build_data, "fetch_place_page_enrichment", return_value=page_entry) as page_fetch,
             patch.object(build_data, "fetch_places_api_enrichment", return_value=api_entry) as api_fetch,
         ):
@@ -3209,6 +3296,7 @@ class BuildDataTests(unittest.TestCase):
         )
 
         with (
+            patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
             patch.object(build_data, "fetch_place_page_enrichment", return_value=page_entry) as page_fetch,
             patch.object(build_data, "fetch_places_api_enrichment", return_value=api_entry) as api_fetch,
         ):
@@ -3422,6 +3510,7 @@ class BuildDataTests(unittest.TestCase):
                 patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
                 patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
                 patch.object(build_data, "google_places_api_key", return_value=None),
+                patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
                 patch.object(
                     build_data,
                     "cache_refresh_reason",
@@ -3440,6 +3529,128 @@ class BuildDataTests(unittest.TestCase):
                 )
 
             self.assertEqual(seen_reasons, ["missing-cache-entry"])
+
+    def test_enrich_raw_sources_fails_for_api_strategy_without_key(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo",
+            places=[
+                RawPlace(name="Missing Place", maps_url="https://maps.google.com/?cid=222", cid="222"),
+            ],
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            raw_dir = tmpdir_path / "raw"
+            cache_dir = tmpdir_path / "cache"
+            db_path = tmpdir_path / "places.sqlite"
+            raw_dir.mkdir()
+            cache_dir.mkdir()
+            (raw_dir / "tokyo-japan.json").write_text(
+                json.dumps(raw.model_dump(mode="json"), ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(build_data, "RAW_DIR", raw_dir),
+                patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
+                patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
+                patch.object(build_data, "google_places_api_key", return_value=None),
+                patch.object(build_data, "google_places_enrichment_strategy", return_value="api"),
+                patch.object(build_data, "enrich_place_job") as enrich_job,
+            ):
+                with self.assertRaisesRegex(RuntimeError, "GOOGLE_PLACES_API_KEY is required"):
+                    build_data.enrich_raw_sources(
+                        force_refresh=True,
+                        refresh_workers=1,
+                        refresh_startup_jitter_seconds=0,
+                    )
+
+            enrich_job.assert_not_called()
+            self.assertEqual(list(cache_dir.iterdir()), [])
+
+    def test_enrich_raw_sources_allows_api_strategy_without_key_when_no_jobs_run(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo",
+            places=[
+                RawPlace(name="Cached Place", maps_url="https://maps.google.com/?cid=222", cid="222"),
+            ],
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            raw_dir = tmpdir_path / "raw"
+            cache_dir = tmpdir_path / "cache"
+            db_path = tmpdir_path / "places.sqlite"
+            raw_dir.mkdir()
+            cache_dir.mkdir()
+            (raw_dir / "tokyo-japan.json").write_text(
+                json.dumps(raw.model_dump(mode="json"), ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(build_data, "RAW_DIR", raw_dir),
+                patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
+                patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
+                patch.object(build_data, "google_places_api_key", return_value=None),
+                patch.object(build_data, "google_places_enrichment_strategy", return_value="api"),
+                patch.object(build_data, "cache_refresh_reason", return_value=None),
+                patch.object(build_data, "enrich_place_job") as enrich_job,
+            ):
+                build_data.enrich_raw_sources(
+                    force_refresh=False,
+                    refresh_workers=1,
+                    refresh_startup_jitter_seconds=0,
+                )
+
+            enrich_job.assert_not_called()
+
+    def test_enrich_raw_sources_warns_when_api_fallback_is_unavailable(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo",
+            places=[
+                RawPlace(name="Missing Place", maps_url="https://maps.google.com/?cid=222", cid="222"),
+            ],
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            raw_dir = tmpdir_path / "raw"
+            cache_dir = tmpdir_path / "cache"
+            db_path = tmpdir_path / "places.sqlite"
+            raw_dir.mkdir()
+            cache_dir.mkdir()
+            (raw_dir / "tokyo-japan.json").write_text(
+                json.dumps(raw.model_dump(mode="json"), ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            def fake_enrich_place_job(_slug, _place_id, _place_name, _refresh_reason, _place_payload, **kwargs):
+                self.assertEqual(kwargs["strategy"], "scrape_then_api")
+                return EnrichmentCacheEntry(
+                    fetched_at="2026-04-20T00:00:00+00:00",
+                    query="Missing Place, Tokyo",
+                    matched=True,
+                    place=EnrichmentPlace(display_name="Missing Place"),
+                )
+
+            stdout = StringIO()
+            with (
+                redirect_stdout(stdout),
+                patch.object(build_data, "RAW_DIR", raw_dir),
+                patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
+                patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
+                patch.object(build_data, "google_places_api_key", return_value=None),
+                patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
+                patch.object(build_data, "enrich_place_job", side_effect=fake_enrich_place_job),
+            ):
+                build_data.enrich_raw_sources(
+                    force_refresh=True,
+                    refresh_workers=1,
+                    refresh_startup_jitter_seconds=0,
+                )
+
+            self.assertIn("without Google Places API fallback", stdout.getvalue())
 
     def test_enrich_raw_sources_prioritizes_missing_entries_before_expired_refreshes(self) -> None:
         raw = RawSavedList(
@@ -3478,6 +3689,7 @@ class BuildDataTests(unittest.TestCase):
                 patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
                 patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
                 patch.object(build_data, "google_places_api_key", return_value=None),
+                patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
                 patch.object(
                     build_data,
                     "cache_refresh_reason",
@@ -3585,6 +3797,7 @@ class BuildDataTests(unittest.TestCase):
                 patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
                 patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
                 patch.object(build_data, "google_places_api_key", return_value=None),
+                patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
                 patch.object(build_data, "ThreadPoolExecutor", FakeExecutor),
                 patch.object(build_data, "as_completed", return_value=[first_future, second_future]),
             ):
@@ -4161,6 +4374,7 @@ class BuildDataTests(unittest.TestCase):
                 patch.object(build_data, "RAW_DIR", raw_dir),
                 patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
                 patch.object(build_data, "google_places_api_key", return_value=None),
+                patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
                 patch.object(build_data, "ThreadPoolExecutor", FakeExecutor),
                 patch.object(build_data, "as_completed", return_value=[future]),
                 patch("builtins.print"),


### PR DESCRIPTION
## Description
Clarify the docs so enrichment is described as scraper-first, optional, and recommended because non-enriched builds stay sparse.

Add a user-configurable `GOOGLE_PLACES_ENRICHMENT_STRATEGY` setting with `scrape`, `api`, and `scrape_then_api` modes so enrichment source selection is explicit.

Cover the new strategy behavior with focused build-data tests, including the API-only missing-key case.

Imported from downstream PR: https://github.com/michaelmwu/demflyers-favorites/pull/44
Original commit: `7880942` (`Document and configure enrichment strategy`)

## Testing
- `.venv/bin/python -m unittest tests.python.test_build_data`
- `bun run check`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified when Google Places is used (normal builds remain sparse; enrichment runs only during enrichment commands) and detailed the scrape→API fallback flow, refresh-scope behaviors, and updated environment variable descriptions.

* **Chores**
  * Added configuration for enrichment strategy (scrape / api / scrape_then_api, default scrape_then_api), scraper proxy, and clarified API key requirements.

* **Tests**
  * Added tests validating each enrichment strategy and missing-API-key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->