### PR TITLE
fix: clamp home world map panning

### DIFF
--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -193,7 +193,6 @@ const mapPlaces = places
 
   const MAP_COLLAPSED_KEY = "favoritePlacesMapCollapsed";
   const DESKTOP_MAP_MEDIA_QUERY = "(min-width: 980px)";
-
   const LOCATION_PROXIMITY_BUFFER_KM = 25;
   const LOCATION_PROXIMITY_MULTIPLIER = 1.8;
   const LOCATION_OUTLIER_MIN_DISTANCE_KM = 50;

--- a/src/components/HomeGuideMap.astro
+++ b/src/components/HomeGuideMap.astro
@@ -140,6 +140,18 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
 
   const MARKER_COLOR = "#c4312d";
   const HOME_MAP_COLLAPSED_KEY = "favoritePlacesHomeMapCollapsed";
+  const WORLD_MAP_MAX_LATITUDE = 85.05112878;
+  const WORLD_MAP_MIN_ZOOM = 1;
+  const WORLD_MAP_BOUNDS = {
+    east: 180,
+    north: WORLD_MAP_MAX_LATITUDE,
+    south: -WORLD_MAP_MAX_LATITUDE,
+    west: -180,
+  };
+  const LEAFLET_WORLD_BOUNDS = L.latLngBounds(
+    [-WORLD_MAP_MAX_LATITUDE, -360],
+    [WORLD_MAP_MAX_LATITUDE, 360],
+  );
   const favoritePlacesWindow = window as Window & {
     __favoritePlacesGoogleMapsInit?: () => void;
     __favoritePlacesGoogleMapsLoader?: Promise<unknown>;
@@ -290,10 +302,12 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
   };
 
   const initLeafletRuntime = (element: HTMLElement, guides: HomeMapGuide[]): HomeMapRuntime => {
-    // Keep the overview map unconstrained so country-level fitBounds stays centered near world edges.
     const map = L.map(element, {
       dragging: true,
+      maxBounds: LEAFLET_WORLD_BOUNDS,
+      maxBoundsViscosity: 1,
       maxZoom: 12,
+      minZoom: WORLD_MAP_MIN_ZOOM,
       scrollWheelZoom: false,
       touchZoom: "center",
       zoomControl: true,
@@ -351,6 +365,11 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
       disableDefaultUI: true,
       gestureHandling: "greedy",
       keyboardShortcuts: true,
+      minZoom: WORLD_MAP_MIN_ZOOM,
+      restriction: {
+        latLngBounds: WORLD_MAP_BOUNDS,
+        strictBounds: true,
+      },
       zoom: 4,
       zoomControl: true,
     });

--- a/src/components/HomeGuideMap.astro
+++ b/src/components/HomeGuideMap.astro
@@ -141,16 +141,18 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
   const MARKER_COLOR = "#c4312d";
   const HOME_MAP_COLLAPSED_KEY = "favoritePlacesHomeMapCollapsed";
   const WORLD_MAP_MAX_LATITUDE = 85.05112878;
-  const WORLD_MAP_MIN_ZOOM = 1;
+  const WORLD_MAP_MIN_ZOOM = 0;
+  const WORLD_MAP_MIN_LONGITUDE = -180;
+  const WORLD_MAP_MAX_LONGITUDE = 180;
   const WORLD_MAP_BOUNDS = {
-    east: 180,
+    east: WORLD_MAP_MAX_LONGITUDE,
     north: WORLD_MAP_MAX_LATITUDE,
     south: -WORLD_MAP_MAX_LATITUDE,
-    west: -180,
+    west: WORLD_MAP_MIN_LONGITUDE,
   };
   const LEAFLET_WORLD_BOUNDS = L.latLngBounds(
-    [-WORLD_MAP_MAX_LATITUDE, -360],
-    [WORLD_MAP_MAX_LATITUDE, 360],
+    [-WORLD_MAP_MAX_LATITUDE, WORLD_MAP_MIN_LONGITUDE],
+    [WORLD_MAP_MAX_LATITUDE, WORLD_MAP_MAX_LONGITUDE],
   );
   const favoritePlacesWindow = window as Window & {
     __favoritePlacesGoogleMapsInit?: () => void;

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -249,9 +249,15 @@ describe("guide map interactions", () => {
     const guideMap = readSource("src/components/GuideMap.astro");
 
     expect(homeMap).toContain("const WORLD_MAP_MAX_LATITUDE = 85.05112878");
-    expect(homeMap).toContain("const WORLD_MAP_MIN_ZOOM = 1");
+    expect(homeMap).toContain("const WORLD_MAP_MIN_ZOOM = 0");
+    expect(homeMap).toContain("const WORLD_MAP_MIN_LONGITUDE = -180");
+    expect(homeMap).toContain("const WORLD_MAP_MAX_LONGITUDE = 180");
     expect(homeMap).toContain("const WORLD_MAP_BOUNDS = {");
+    expect(homeMap).toContain("east: WORLD_MAP_MAX_LONGITUDE");
+    expect(homeMap).toContain("west: WORLD_MAP_MIN_LONGITUDE");
     expect(homeMap).toContain("const LEAFLET_WORLD_BOUNDS = L.latLngBounds");
+    expect(homeMap).toContain("[-WORLD_MAP_MAX_LATITUDE, WORLD_MAP_MIN_LONGITUDE]");
+    expect(homeMap).toContain("[WORLD_MAP_MAX_LATITUDE, WORLD_MAP_MAX_LONGITUDE]");
     expect(homeMap).toContain("maxBounds: LEAFLET_WORLD_BOUNDS");
     expect(homeMap).toContain("maxBoundsViscosity: 1");
     expect(homeMap).toContain("minZoom: WORLD_MAP_MIN_ZOOM");

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -243,4 +243,30 @@ describe("guide map interactions", () => {
     expect(homeMap).toContain("runtime?.fitGuides(currentVisibleGuides)");
     expect(homeMap).toContain("applyVisibility(\n      pendingState.visibleGuideSlugs,");
   });
+
+  it("constrains map panning before the world scrolls into grey tile space", () => {
+    const homeMap = readSource("src/components/HomeGuideMap.astro");
+    const guideMap = readSource("src/components/GuideMap.astro");
+
+    expect(homeMap).toContain("const WORLD_MAP_MAX_LATITUDE = 85.05112878");
+    expect(homeMap).toContain("const WORLD_MAP_MIN_ZOOM = 1");
+    expect(homeMap).toContain("const WORLD_MAP_BOUNDS = {");
+    expect(homeMap).toContain("const LEAFLET_WORLD_BOUNDS = L.latLngBounds");
+    expect(homeMap).toContain("maxBounds: LEAFLET_WORLD_BOUNDS");
+    expect(homeMap).toContain("maxBoundsViscosity: 1");
+    expect(homeMap).toContain("minZoom: WORLD_MAP_MIN_ZOOM");
+    expect(homeMap).toContain("restriction: {");
+    expect(homeMap).toContain("latLngBounds: WORLD_MAP_BOUNDS");
+    expect(homeMap).toContain("strictBounds: true");
+
+    expect(guideMap).not.toContain("const WORLD_MAP_MAX_LATITUDE = 85.05112878");
+    expect(guideMap).not.toContain("const WORLD_MAP_MIN_ZOOM");
+    expect(guideMap).not.toContain("const WORLD_MAP_BOUNDS = {");
+    expect(guideMap).not.toContain("const LEAFLET_WORLD_BOUNDS = L.latLngBounds");
+    expect(guideMap).not.toContain("maxBounds: LEAFLET_WORLD_BOUNDS");
+    expect(guideMap).not.toContain("maxBoundsViscosity: 1");
+    expect(guideMap).not.toContain("restriction: {");
+    expect(guideMap).not.toContain("latLngBounds: WORLD_MAP_BOUNDS");
+    expect(guideMap).not.toContain("strictBounds: true");
+  });
 });


### PR DESCRIPTION
## Description
Clamp the home overview map to world bounds so users cannot pan into grey non-world space.
Keep one extra zoom-out step by setting the world map minimum zoom to 1.
Add a regression test that keeps the clamp limited to the home world map and leaves guide maps unchanged.

## Related Issue
None.

## How Has This Been Tested?
- `bun test tests/frontend/guideMapInteractions.test.mjs`
- `bun run check`
- `bun run build`
