### PR TITLE
feat: add guide near-me sort and blue dot

### DIFF
--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -48,6 +48,97 @@ function distanceInKm(fromLat, fromLng, toLat, toLng) {
   return earthRadiusKm * c;
 }
 
+function getCardCoordinates(card) {
+  const lat = card.dataset.lat ? Number(card.dataset.lat) : Number.NaN;
+  const lng = card.dataset.lng ? Number(card.dataset.lng) : Number.NaN;
+
+  return Number.isFinite(lat) && Number.isFinite(lng) ? { lat, lng } : null;
+}
+
+export function buildNearbyDistanceMap(cards, currentLocation) {
+  const distances = new Map();
+  if (!currentLocation) {
+    return distances;
+  }
+
+  cards.forEach((card) => {
+    const coordinates = getCardCoordinates(card);
+    if (!coordinates) {
+      return;
+    }
+
+    distances.set(
+      card.dataset.placeId || "",
+      distanceInKm(currentLocation.lat, currentLocation.lng, coordinates.lat, coordinates.lng),
+    );
+  });
+
+  return distances;
+}
+
+export function compareCardsByCurated(left, right) {
+  const leftTopPick = left.dataset.topPick === "true" ? 1 : 0;
+  const rightTopPick = right.dataset.topPick === "true" ? 1 : 0;
+  if (leftTopPick !== rightTopPick) return rightTopPick - leftTopPick;
+  return (
+    Number(right.dataset.rank || 0) - Number(left.dataset.rank || 0) ||
+    (left.dataset.name || "").localeCompare(right.dataset.name || "")
+  );
+}
+
+export function compareCardsByNearby(
+  left,
+  right,
+  { currentLocation = null, distanceByPlaceId = new Map() } = {},
+) {
+  if (!currentLocation) {
+    return compareCardsByCurated(left, right);
+  }
+
+  const leftDistance = distanceByPlaceId.get(left.dataset.placeId || "");
+  const rightDistance = distanceByPlaceId.get(right.dataset.placeId || "");
+  const leftHasDistance = Number.isFinite(leftDistance);
+  const rightHasDistance = Number.isFinite(rightDistance);
+
+  if (leftHasDistance !== rightHasDistance) {
+    return leftHasDistance ? -1 : 1;
+  }
+
+  if (!leftHasDistance || !rightHasDistance) {
+    return compareCardsByCurated(left, right);
+  }
+
+  return leftDistance - rightDistance || compareCardsByCurated(left, right);
+}
+
+export function resolveLocationSortState({
+  fallbackMessage = "Location unavailable. Showing curated order instead.",
+  fallbackSortValue = "curated",
+  currentLocation = null,
+  currentLocationStatus = "idle",
+  sortValue,
+} = {}) {
+  const shouldFallback =
+    sortValue === "nearby" &&
+    !currentLocation &&
+    currentLocationStatus !== "idle" &&
+    currentLocationStatus !== "checking";
+
+  if (!shouldFallback) {
+    return {
+      message: "",
+      shouldFallback: false,
+      sortValue,
+    };
+  }
+
+  return {
+    message: fallbackMessage,
+    shouldFallback: true,
+    sortValue: fallbackSortValue,
+  };
+}
+
 export function cardHasTag(card, tag) {
   const normalizedTag = getTagComparisonValue(tag);
   if (!normalizedTag) {
@@ -185,6 +276,7 @@ if (root) {
   let searchIndex = null;
   let currentLocation = null;
   let currentLocationStatus = "idle";
+  let nearbyDistanceByPlaceId = new Map();
   const highlightedPlaceId = initialParams.get("place") || "";
   let autocompleteTags = [];
   let highlightedAutocompleteIndex = -1;
@@ -381,44 +473,12 @@ if (root) {
   };
 
   const sorters = {
-    curated: (left, right) => {
-      const leftTopPick = left.dataset.topPick === "true" ? 1 : 0;
-      const rightTopPick = right.dataset.topPick === "true" ? 1 : 0;
-      if (leftTopPick !== rightTopPick) return rightTopPick - leftTopPick;
-      return (
-        Number(right.dataset.rank || 0) - Number(left.dataset.rank || 0) ||
-        (left.dataset.name || "").localeCompare(right.dataset.name || "")
-      );
-    },
-    nearby: (left, right) => {
-      const leftLat = left.dataset.lat ? Number(left.dataset.lat) : Number.NaN;
-      const leftLng = left.dataset.lng ? Number(left.dataset.lng) : Number.NaN;
-      const rightLat = right.dataset.lat ? Number(right.dataset.lat) : Number.NaN;
-      const rightLng = right.dataset.lng ? Number(right.dataset.lng) : Number.NaN;
-      const leftHasCoordinates = Number.isFinite(leftLat) && Number.isFinite(leftLng);
-      const rightHasCoordinates = Number.isFinite(rightLat) && Number.isFinite(rightLng);
-
-      if (!currentLocation) {
-        return sorters.curated(left, right);
-      }
-
-      if (leftHasCoordinates !== rightHasCoordinates) {
-        return leftHasCoordinates ? -1 : 1;
-      }
-
-      if (!leftHasCoordinates || !rightHasCoordinates) {
-        return sorters.curated(left, right);
-      }
-
-      const leftDistance = distanceInKm(currentLocation.lat, currentLocation.lng, leftLat, leftLng);
-      const rightDistance = distanceInKm(
-        currentLocation.lat,
-        currentLocation.lng,
-        rightLat,
-        rightLng,
-      );
-      return leftDistance - rightDistance || sorters.curated(left, right);
-    },
+    curated: compareCardsByCurated,
+    nearby: (left, right) =>
+      compareCardsByNearby(left, right, {
+        currentLocation,
+        distanceByPlaceId: nearbyDistanceByPlaceId,
+      }),
     rating: (left, right) =>
       Number(right.dataset.rating || 0) - Number(left.dataset.rating || 0) ||
       Number(right.dataset.ratingCount || 0) - Number(left.dataset.ratingCount || 0) ||
@@ -496,6 +556,10 @@ if (root) {
         bubbles: true,
       }),
     );
+  };
+
+  const refreshNearbyDistances = () => {
+    nearbyDistanceByPlaceId = buildNearbyDistanceMap(cards, currentLocation);
   };
 
   const update = (source = "list-filter") => {
@@ -797,6 +861,7 @@ if (root) {
           }
         : null;
     currentLocationStatus = detail.status || "idle";
+    refreshNearbyDistances();
 
     if (currentLocation) {
       setLocationSortMessage("");
@@ -806,13 +871,17 @@ if (root) {
       return;
     }
 
-    if (
-      sortSelect?.value === LOCATION_SORT_VALUE &&
-      currentLocationStatus !== "idle" &&
-      currentLocationStatus !== "checking"
-    ) {
-      sortSelect.value = LOCATION_SORT_FALLBACK;
-      setLocationSortMessage(locationSortFallbackText);
+    const nextLocationSortState = resolveLocationSortState({
+      fallbackMessage: locationSortFallbackText,
+      fallbackSortValue: LOCATION_SORT_FALLBACK,
+      currentLocation,
+      currentLocationStatus,
+      sortValue: sortSelect?.value,
+    });
+
+    if (nextLocationSortState.shouldFallback && sortSelect) {
+      sortSelect.value = nextLocationSortState.sortValue;
+      setLocationSortMessage(nextLocationSortState.message);
       update("location-sort-fallback");
     }
   });

--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -30,6 +30,24 @@ function parseCardTagValues(value) {
   }
 }
 
+function toRadians(degrees) {
+  return (degrees * Math.PI) / 180;
+}
+
+function distanceInKm(fromLat, fromLng, toLat, toLng) {
+  const earthRadiusKm = 6371;
+  const latDelta = toRadians(toLat - fromLat);
+  const lngDelta = toRadians(toLng - fromLng);
+  const fromLatRadians = toRadians(fromLat);
+  const toLatRadians = toRadians(toLat);
+  const a =
+    Math.sin(latDelta / 2) ** 2 +
+    Math.cos(fromLatRadians) * Math.cos(toLatRadians) * Math.sin(lngDelta / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return earthRadiusKm * c;
+}
+
 export function cardHasTag(card, tag) {
   const normalizedTag = getTagComparisonValue(tag);
   if (!normalizedTag) {
@@ -128,10 +146,15 @@ if (root) {
   const resultsCount = root.querySelector("[data-results-count]");
   const emptyState = root.querySelector("[data-empty-state]");
   const areaFilterStatus = root.querySelector("[data-area-filter-status]");
+  const locationSortStatus = root.querySelector("[data-location-sort-status]");
   const mapFilterStatus = root.querySelector("[data-map-filter-status]");
   const mapFilterResetButtons = Array.from(root.querySelectorAll("[data-map-filter-reset]"));
   const guideSlug = root.dataset.guideSlug || "";
+  const locationSortFallbackText =
+    root.dataset.locationSortFallbackText || "Location unavailable. Showing curated order instead.";
   const initialParams = new URLSearchParams(window.location.search);
+  const LOCATION_SORT_VALUE = "nearby";
+  const LOCATION_SORT_FALLBACK = "curated";
 
   const normalizeTag = (value) => getTagComparisonValue(String(value || ""));
   const allTags = [
@@ -160,6 +183,8 @@ if (root) {
   let selectedTags = [];
   let mapFramePlaceIds = null;
   let searchIndex = null;
+  let currentLocation = null;
+  let currentLocationStatus = "idle";
   const highlightedPlaceId = initialParams.get("place") || "";
   let autocompleteTags = [];
   let highlightedAutocompleteIndex = -1;
@@ -365,6 +390,35 @@ if (root) {
         (left.dataset.name || "").localeCompare(right.dataset.name || "")
       );
     },
+    nearby: (left, right) => {
+      const leftLat = left.dataset.lat ? Number(left.dataset.lat) : Number.NaN;
+      const leftLng = left.dataset.lng ? Number(left.dataset.lng) : Number.NaN;
+      const rightLat = right.dataset.lat ? Number(right.dataset.lat) : Number.NaN;
+      const rightLng = right.dataset.lng ? Number(right.dataset.lng) : Number.NaN;
+      const leftHasCoordinates = Number.isFinite(leftLat) && Number.isFinite(leftLng);
+      const rightHasCoordinates = Number.isFinite(rightLat) && Number.isFinite(rightLng);
+
+      if (!currentLocation) {
+        return sorters.curated(left, right);
+      }
+
+      if (leftHasCoordinates !== rightHasCoordinates) {
+        return leftHasCoordinates ? -1 : 1;
+      }
+
+      if (!leftHasCoordinates || !rightHasCoordinates) {
+        return sorters.curated(left, right);
+      }
+
+      const leftDistance = distanceInKm(currentLocation.lat, currentLocation.lng, leftLat, leftLng);
+      const rightDistance = distanceInKm(
+        currentLocation.lat,
+        currentLocation.lng,
+        rightLat,
+        rightLng,
+      );
+      return leftDistance - rightDistance || sorters.curated(left, right);
+    },
     rating: (left, right) =>
       Number(right.dataset.rating || 0) - Number(left.dataset.rating || 0) ||
       Number(right.dataset.ratingCount || 0) - Number(left.dataset.ratingCount || 0) ||
@@ -422,6 +476,23 @@ if (root) {
     update("map-reset");
     root.dispatchEvent(
       new CustomEvent("guide:map-frame-reset", {
+        bubbles: true,
+      }),
+    );
+  };
+
+  const setLocationSortMessage = (message = "") => {
+    if (!locationSortStatus) {
+      return;
+    }
+
+    locationSortStatus.hidden = !message;
+    locationSortStatus.textContent = message;
+  };
+
+  const requestCurrentLocation = () => {
+    root.dispatchEvent(
+      new CustomEvent("guide:user-location-request", {
         bubbles: true,
       }),
     );
@@ -610,7 +681,18 @@ if (root) {
     });
   });
 
-  sortSelect?.addEventListener("change", () => update());
+  sortSelect?.addEventListener("change", () => {
+    if (sortSelect.value === LOCATION_SORT_VALUE) {
+      setLocationSortMessage("");
+      if (!currentLocation) {
+        requestCurrentLocation();
+      }
+    } else {
+      setLocationSortMessage("");
+    }
+
+    update();
+  });
 
   typeButtons.forEach((button) => {
     button.addEventListener("click", () => {
@@ -701,6 +783,39 @@ if (root) {
   });
 
   root.addEventListener("guide:map-frame-reset-request", clearMapFrameFilter);
+
+  root.addEventListener("guide:user-location", (event) => {
+    const detail = event.detail || {};
+    const coordinates = detail.coordinates;
+    currentLocation =
+      coordinates &&
+      Number.isFinite(Number(coordinates.lat)) &&
+      Number.isFinite(Number(coordinates.lng))
+        ? {
+            lat: Number(coordinates.lat),
+            lng: Number(coordinates.lng),
+          }
+        : null;
+    currentLocationStatus = detail.status || "idle";
+
+    if (currentLocation) {
+      setLocationSortMessage("");
+      if (sortSelect?.value === LOCATION_SORT_VALUE) {
+        update("location-sort");
+      }
+      return;
+    }
+
+    if (
+      sortSelect?.value === LOCATION_SORT_VALUE &&
+      currentLocationStatus !== "idle" &&
+      currentLocationStatus !== "checking"
+    ) {
+      sortSelect.value = LOCATION_SORT_FALLBACK;
+      setLocationSortMessage(locationSortFallbackText);
+      update("location-sort-fallback");
+    }
+  });
 
   mapFilterResetButtons.forEach((button) => {
     button.addEventListener("click", clearMapFrameFilter);

--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -241,6 +241,7 @@ if (root) {
   const mapFilterStatus = root.querySelector("[data-map-filter-status]");
   const mapFilterResetButtons = Array.from(root.querySelectorAll("[data-map-filter-reset]"));
   const guideSlug = root.dataset.guideSlug || "";
+  const hasMappablePlaces = root.dataset.hasMappablePlaces === "true";
   const locationSortFallbackText =
     root.dataset.locationSortFallbackText || "Location unavailable. Showing curated order instead.";
   const initialParams = new URLSearchParams(window.location.search);
@@ -277,6 +278,9 @@ if (root) {
   let currentLocation = null;
   let currentLocationStatus = "idle";
   let nearbyDistanceByPlaceId = new Map();
+  let hasHandledLocationRequest = false;
+  let directLocationRequestInFlight = false;
+  let directLocationFallbackTimer = null;
   const highlightedPlaceId = initialParams.get("place") || "";
   let autocompleteTags = [];
   let highlightedAutocompleteIndex = -1;
@@ -550,12 +554,85 @@ if (root) {
     locationSortStatus.textContent = message;
   };
 
+  const clearDirectLocationFallbackTimer = () => {
+    if (directLocationFallbackTimer !== null) {
+      window.clearTimeout(directLocationFallbackTimer);
+      directLocationFallbackTimer = null;
+    }
+  };
+
+  const dispatchUserLocation = ({ coordinates = null, source = "filters", status }) => {
+    root.dispatchEvent(
+      new CustomEvent("guide:user-location", {
+        bubbles: true,
+        detail: {
+          coordinates,
+          nearGuide: false,
+          source,
+          status,
+        },
+      }),
+    );
+  };
+
+  const requestCurrentLocationDirectly = () => {
+    if (directLocationRequestInFlight) {
+      return;
+    }
+
+    if (!navigator.geolocation) {
+      dispatchUserLocation({ status: "unavailable" });
+      return;
+    }
+
+    directLocationRequestInFlight = true;
+    dispatchUserLocation({ status: "checking" });
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        directLocationRequestInFlight = false;
+        clearDirectLocationFallbackTimer();
+        dispatchUserLocation({
+          coordinates: {
+            lat: position.coords.latitude,
+            lng: position.coords.longitude,
+          },
+          status: "available",
+        });
+      },
+      (error) => {
+        directLocationRequestInFlight = false;
+        clearDirectLocationFallbackTimer();
+        dispatchUserLocation({
+          status: error.code === error.PERMISSION_DENIED ? "denied" : "unavailable",
+        });
+      },
+      {
+        maximumAge: 300_000,
+        timeout: 10_000,
+      },
+    );
+  };
+
   const requestCurrentLocation = () => {
+    hasHandledLocationRequest = false;
+    clearDirectLocationFallbackTimer();
     root.dispatchEvent(
       new CustomEvent("guide:user-location-request", {
         bubbles: true,
       }),
     );
+
+    if (!hasMappablePlaces || !document.querySelector("[data-guide-map]")) {
+      requestCurrentLocationDirectly();
+      return;
+    }
+
+    directLocationFallbackTimer = window.setTimeout(() => {
+      if (!hasHandledLocationRequest) {
+        requestCurrentLocationDirectly();
+      }
+    }, 500);
   };
 
   const refreshNearbyDistances = () => {
@@ -849,6 +926,8 @@ if (root) {
   root.addEventListener("guide:map-frame-reset-request", clearMapFrameFilter);
 
   root.addEventListener("guide:user-location", (event) => {
+    hasHandledLocationRequest = true;
+    clearDirectLocationFallbackTimer();
     const detail = event.detail || {};
     const coordinates = detail.coordinates;
     currentLocation =

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -142,6 +142,7 @@ const mapPlaces = places
     highlightPlace: (place: MapPlace, active: boolean) => void;
     invalidateSize?: () => void;
     openPlace: (place: MapPlace) => void;
+    setUserLocation: (coordinates: Coordinates | null) => void;
     setView: (coordinates: Coordinates, zoom: number) => void;
     setVisiblePlaces: (visiblePlaceIds: Set<string>) => void;
   }
@@ -173,6 +174,7 @@ const mapPlaces = places
         getMap: () => unknown;
         setIcon: (icon: Record<string, unknown>) => void;
         setMap: (map: unknown | null) => void;
+        setPosition: (position: Coordinates) => void;
         setZIndex: (zIndex: number) => void;
       };
       Point: new (x: number, y: number) => unknown;
@@ -588,6 +590,8 @@ const mapPlaces = places
     }).addTo(map);
 
     const markers = new Map<string, L.Marker>();
+    let userLocationHalo: L.CircleMarker | null = null;
+    let userLocationDot: L.CircleMarker | null = null;
     places.forEach((place) => {
       const marker = placeMarker(place, placePhotosEnabled).addTo(map);
       marker.on("click", () => onSelectPlace(place.id));
@@ -613,6 +617,49 @@ const mapPlaces = places
         if (marker && map.hasLayer(marker)) {
           marker.openPopup();
         }
+      },
+      setUserLocation: (coordinates) => {
+        if (!coordinates) {
+          userLocationHalo?.removeFrom(map);
+          userLocationDot?.removeFrom(map);
+          return;
+        }
+
+        const latLng = L.latLng(coordinates.lat, coordinates.lng);
+        if (!userLocationHalo) {
+          userLocationHalo = L.circleMarker(latLng, {
+            color: "#1a73e8",
+            fillColor: "#1a73e8",
+            fillOpacity: 0.18,
+            interactive: false,
+            radius: 10,
+            stroke: false,
+          }).addTo(map);
+        } else {
+          userLocationHalo.setLatLng(latLng);
+          if (!map.hasLayer(userLocationHalo)) {
+            userLocationHalo.addTo(map);
+          }
+        }
+
+        if (!userLocationDot) {
+          userLocationDot = L.circleMarker(latLng, {
+            color: "#ffffff",
+            fillColor: "#1a73e8",
+            fillOpacity: 1,
+            interactive: false,
+            radius: 6,
+            weight: 3,
+          }).addTo(map);
+        } else {
+          userLocationDot.setLatLng(latLng);
+          if (!map.hasLayer(userLocationDot)) {
+            userLocationDot.addTo(map);
+          }
+        }
+
+        userLocationHalo.bringToFront();
+        userLocationDot.bringToFront();
       },
       setView: (coordinates, zoom) => {
         map.setView([coordinates.lat, coordinates.lng], zoom, { animate: true });
@@ -650,6 +697,8 @@ const mapPlaces = places
     });
     const infoWindow = new google.maps.InfoWindow();
     const markers = new Map<string, any>();
+    let userLocationHalo: any | null = null;
+    let userLocationDot: any | null = null;
 
     const markerIcon = (place: MapPlace, active = false) => {
       const size = getMapMarkerSize(place.markerIcon, place.topPick, active);
@@ -705,6 +754,56 @@ const mapPlaces = places
         infoWindow.setContent(popupHtml(place, placePhotosEnabled));
         infoWindow.open({ anchor: marker, map, shouldFocus: false });
       },
+      setUserLocation: (coordinates) => {
+        if (!coordinates) {
+          userLocationHalo?.setMap(null);
+          userLocationDot?.setMap(null);
+          return;
+        }
+
+        const position = { lat: coordinates.lat, lng: coordinates.lng };
+        if (!userLocationHalo) {
+          userLocationHalo = new google.maps.Marker({
+            clickable: false,
+            icon: {
+              fillColor: "#1a73e8",
+              fillOpacity: 0.18,
+              path: google.maps.SymbolPath.CIRCLE,
+              scale: 10,
+              strokeColor: "#1a73e8",
+              strokeOpacity: 0,
+              strokeWeight: 0,
+            },
+            map,
+            position,
+            zIndex: 1200,
+          });
+        } else {
+          userLocationHalo.setPosition(position);
+          userLocationHalo.setMap(map);
+        }
+
+        if (!userLocationDot) {
+          userLocationDot = new google.maps.Marker({
+            clickable: false,
+            icon: {
+              fillColor: "#1a73e8",
+              fillOpacity: 1,
+              path: google.maps.SymbolPath.CIRCLE,
+              scale: 6,
+              strokeColor: "#ffffff",
+              strokeOpacity: 1,
+              strokeWeight: 3,
+            },
+            map,
+            position,
+            zIndex: 1201,
+          });
+        } else {
+          userLocationDot.setPosition(position);
+          userLocationDot.setMap(map);
+        }
+      },
       setView: (coordinates, zoom) => {
         map.panTo(coordinates);
         map.setZoom(zoom);
@@ -749,6 +848,7 @@ const mapPlaces = places
     let currentLocation: Coordinates | null = null;
     let pendingLocationCenter = false;
     let locationWatchStarted = false;
+    let locationWatchId: number | null = null;
     const requestedProvider = element.dataset.mapProvider === "google" ? "google" : "leaflet";
     const apiKey = element.dataset.googleMapsApiKey || "";
     const handleMarkerSelect = (placeId: string) => selectPlace(placeId);
@@ -758,6 +858,19 @@ const mapPlaces = places
       mapResetButtons.forEach((button) => {
         button.hidden = !active;
       });
+    };
+
+    const dispatchUserLocation = (status: "idle" | "checking" | "available" | "denied" | "unavailable") => {
+      root?.dispatchEvent(
+        new CustomEvent("guide:user-location", {
+          bubbles: true,
+          detail: {
+            coordinates: currentLocation,
+            nearGuide: currentLocation ? locationIsNearGuide(currentLocation) : false,
+            status,
+          },
+        }),
+      );
     };
 
     const syncVisiblePlaces = (detail: PlacesUpdatedEvent["detail"]) => {
@@ -921,6 +1034,7 @@ const mapPlaces = places
 
     const updateLocationFromPosition = (position: GeolocationPosition) => {
       currentLocation = { lat: position.coords.latitude, lng: position.coords.longitude };
+      runtime?.setUserLocation(currentLocation);
 
       if (locationIsNearGuide(currentLocation)) {
         setLocationButtonState("near", "Center map on current location");
@@ -932,6 +1046,8 @@ const mapPlaces = places
         pendingLocationCenter = false;
         setLocationButtonState("far", "Current location is too far from this guide");
       }
+
+      dispatchUserLocation("available");
     };
 
     const startLocationAvailabilityWatch = () => {
@@ -940,16 +1056,28 @@ const mapPlaces = places
 
       if (!navigator.geolocation) {
         setLocationButtonState("unavailable", "Current location is not available");
+        currentLocation = null;
+        runtime?.setUserLocation(null);
+        dispatchUserLocation("unavailable");
         return;
       }
 
       locationWatchStarted = true;
       setLocationButtonState("checking", "Checking current location");
-      navigator.geolocation.watchPosition(
+      dispatchUserLocation("checking");
+      locationWatchId = navigator.geolocation.watchPosition(
         updateLocationFromPosition,
-        () => {
+        (error) => {
           pendingLocationCenter = false;
+          if (locationWatchId !== null) {
+            navigator.geolocation.clearWatch(locationWatchId);
+            locationWatchId = null;
+          }
+          locationWatchStarted = false;
           setLocationButtonState("unavailable", "Current location is not available");
+          currentLocation = null;
+          runtime?.setUserLocation(null);
+          dispatchUserLocation(error.code === error.PERMISSION_DENIED ? "denied" : "unavailable");
         },
         {
           enableHighAccuracy: true,
@@ -1014,6 +1142,9 @@ const mapPlaces = places
     if (locationButton) {
       locationButton.addEventListener("click", centerOnCurrentLocation);
     }
+    root?.addEventListener("guide:user-location-request", () => {
+      startLocationAvailabilityWatch();
+    });
     mapElement.guideMapFit = () => {
       runtime?.invalidateSize?.();
       runtime?.fitPlaces(currentPlaces);

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -179,9 +179,6 @@ const mapPlaces = places
       };
       Point: new (x: number, y: number) => unknown;
       Size: new (width: number, height: number) => unknown;
-      SymbolPath: {
-        CIRCLE: unknown;
-      };
     };
   }
 
@@ -254,6 +251,34 @@ const mapPlaces = places
       ...markerColors(place, active),
       topPick: place.topPick,
     });
+
+  const userLocationMarkerDataUrl = ({
+    fillColor,
+    fillOpacity,
+    haloColor,
+    haloOpacity,
+    ringColor,
+    ringWidth,
+    size,
+  }: {
+    fillColor: string;
+    fillOpacity: number;
+    haloColor?: string;
+    haloOpacity?: number;
+    ringColor?: string;
+    ringWidth?: number;
+    size: number;
+  }) => {
+    const center = 20;
+    const svg = `
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" fill="none" aria-hidden="true">
+        ${haloColor ? `<circle cx="${center}" cy="${center}" r="${size}" fill="${haloColor}" fill-opacity="${haloOpacity ?? 1}" />` : ""}
+        <circle cx="${center}" cy="${center}" r="${size}" fill="${fillColor}" fill-opacity="${fillOpacity}" ${ringColor ? `stroke="${ringColor}" stroke-width="${ringWidth ?? 0}"` : ""} />
+      </svg>
+    `.trim();
+
+    return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+  };
 
   const leafletMarkerIcon = (place: MapPlace, active = false) => {
     const size = getMapMarkerSize(place.markerIcon, place.topPick, active);
@@ -713,6 +738,39 @@ const mapPlaces = places
       };
     };
 
+    const userLocationIcon = ({
+      fillColor,
+      fillOpacity,
+      haloColor,
+      haloOpacity,
+      ringColor,
+      ringWidth,
+      size,
+    }: {
+      fillColor: string;
+      fillOpacity: number;
+      haloColor?: string;
+      haloOpacity?: number;
+      ringColor?: string;
+      ringWidth?: number;
+      size: number;
+    }) => {
+      const dimension = 40;
+      return {
+        anchor: new google.maps.Point(dimension / 2, dimension / 2),
+        scaledSize: new google.maps.Size(dimension, dimension),
+        url: userLocationMarkerDataUrl({
+          fillColor,
+          fillOpacity,
+          haloColor,
+          haloOpacity,
+          ringColor,
+          ringWidth,
+          size,
+        }),
+      };
+    };
+
     places.forEach((place) => {
       const marker = new google.maps.Marker({
         icon: markerIcon(place),
@@ -765,15 +823,13 @@ const mapPlaces = places
         if (!userLocationHalo) {
           userLocationHalo = new google.maps.Marker({
             clickable: false,
-            icon: {
+            icon: userLocationIcon({
               fillColor: "#1a73e8",
               fillOpacity: 0.18,
-              path: google.maps.SymbolPath.CIRCLE,
-              scale: 10,
-              strokeColor: "#1a73e8",
-              strokeOpacity: 0,
-              strokeWeight: 0,
-            },
+              haloColor: "#1a73e8",
+              haloOpacity: 0.18,
+              size: 10,
+            }),
             map,
             position,
             zIndex: 1200,
@@ -786,15 +842,13 @@ const mapPlaces = places
         if (!userLocationDot) {
           userLocationDot = new google.maps.Marker({
             clickable: false,
-            icon: {
+            icon: userLocationIcon({
               fillColor: "#1a73e8",
               fillOpacity: 1,
-              path: google.maps.SymbolPath.CIRCLE,
-              scale: 6,
-              strokeColor: "#ffffff",
-              strokeOpacity: 1,
-              strokeWeight: 3,
-            },
+              ringColor: "#ffffff",
+              ringWidth: 3,
+              size: 6,
+            }),
             map,
             position,
             zIndex: 1201,

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -944,9 +944,13 @@ const mapPlaces = places
     const handlePlacesUpdated = ((event: PlacesUpdatedEvent) => {
       syncVisiblePlaces(event.detail);
     }) as EventListener;
+    const handleUserLocationRequest = () => {
+      startLocationAvailabilityWatch();
+    };
 
     updateMapFrameControls(mapFrameActive());
     document.addEventListener("guide:places-updated", handlePlacesUpdated);
+    root?.addEventListener("guide:user-location-request", handleUserLocationRequest);
     try {
       runtime =
         requestedProvider === "google" && apiKey
@@ -960,6 +964,7 @@ const mapPlaces = places
       element.dataset.initialized = "true";
     } catch (error) {
       document.removeEventListener("guide:places-updated", handlePlacesUpdated);
+      root?.removeEventListener("guide:user-location-request", handleUserLocationRequest);
       throw error;
     } finally {
       delete element.dataset.initializing;
@@ -1092,7 +1097,7 @@ const mapPlaces = places
 
       if (locationIsNearGuide(currentLocation)) {
         setLocationButtonState("near", "Center map on current location");
-        if (pendingLocationCenter) {
+        if (pendingLocationCenter && runtime) {
           pendingLocationCenter = false;
           runtime.setView(currentLocation, 15);
         }
@@ -1144,7 +1149,7 @@ const mapPlaces = places
     const centerOnCurrentLocation = () => {
       pendingLocationCenter = true;
       startLocationAvailabilityWatch();
-      if (!currentLocation || !locationIsNearGuide(currentLocation)) return;
+      if (!runtime || !currentLocation || !locationIsNearGuide(currentLocation)) return;
       pendingLocationCenter = false;
       runtime.setView(currentLocation, 15);
     };
@@ -1196,9 +1201,6 @@ const mapPlaces = places
     if (locationButton) {
       locationButton.addEventListener("click", centerOnCurrentLocation);
     }
-    root?.addEventListener("guide:user-location-request", () => {
-      startLocationAvailabilityWatch();
-    });
     mapElement.guideMapFit = () => {
       runtime?.invalidateSize?.();
       runtime?.fitPlaces(currentPlaces);

--- a/src/components/PlaceCard.astro
+++ b/src/components/PlaceCard.astro
@@ -70,6 +70,8 @@ const markerSvg = buildMapMarkerSvg(
   data-rating={ratingValue !== null ? String(ratingValue) : ""}
   data-rating-count={reviewCount !== null ? String(reviewCount) : ""}
   data-rank={String(place.manual_rank)}
+  data-lat={place.lat !== null ? String(place.lat) : ""}
+  data-lng={place.lng !== null ? String(place.lng) : ""}
   data-search={[
     place.name,
     place.address ?? "",

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -73,9 +73,11 @@ export interface SiteConfig {
     allFilterLabel: string;
     resultsSortLabel: string;
     sortCuratedLabel: string;
+    sortNearMeLabel: string;
     sortRatingLabel: string;
     sortNameLabel: string;
     sortNeighborhoodLabel: string;
+    locationSortFallbackText: string;
     resetMapLabel: string;
     mapFilteredText: string;
     emptyStateText: string;
@@ -183,9 +185,11 @@ const defaultSiteConfig: SiteConfig = {
     allFilterLabel: "All",
     resultsSortLabel: "Sort",
     sortCuratedLabel: "Curated",
+    sortNearMeLabel: "Near me",
     sortRatingLabel: "Top rated",
     sortNameLabel: "Name",
     sortNeighborhoodLabel: "Area",
+    locationSortFallbackText: "Location unavailable. Showing curated order instead.",
     resetMapLabel: "Reset map",
     mapFilteredText: "Filtered to the visible map area.",
     emptyStateText: "No matches. Try a broader search or clear the tag filter.",

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -263,6 +263,7 @@ const guideSidebarFallback = siteConfig.guide.sidebarContent
     data-all-tags={JSON.stringify(allTags)}
     data-default-suggestions={JSON.stringify(defaultSuggestions)}
     data-type-seeds={JSON.stringify(typeSeedTags)}
+    data-location-sort-fallback-text={siteConfig.guide.locationSortFallbackText}
   >
     <SectionHeading eyebrow={siteConfig.guide.browseEyebrow} title={siteConfig.guide.placesHeading} />
 
@@ -357,6 +358,7 @@ const guideSidebarFallback = siteConfig.guide.sidebarContent
               <span class="results-sort-shell">
                 <select class="ui-input" id="guide-sort" name="guide-sort" data-sort-select>
                   <option value="curated">{siteConfig.guide.sortCuratedLabel}</option>
+                  <option value="nearby">{siteConfig.guide.sortNearMeLabel}</option>
                   <option value="rating">{siteConfig.guide.sortRatingLabel}</option>
                   <option value="name">{siteConfig.guide.sortNameLabel}</option>
                   <option value="neighborhood">{siteConfig.guide.sortNeighborhoodLabel}</option>
@@ -372,6 +374,7 @@ const guideSidebarFallback = siteConfig.guide.sidebarContent
           </div>
         </div>
         <p class="map-filter-status small-copy ui-copy ui-copy--sm" data-area-filter-status hidden></p>
+        <p class="map-filter-status small-copy ui-copy ui-copy--sm" data-location-sort-status hidden></p>
         <p class="map-filter-status small-copy ui-copy ui-copy--sm" data-map-filter-status hidden>{siteConfig.guide.mapFilteredText}</p>
         <div class="empty-state ui-empty-state" data-empty-state>{siteConfig.guide.emptyStateText}</div>
 

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -173,6 +173,7 @@ const guideAfterPlacesHtml = getTemplateHtml(`guide-after-places/${guide.slug}.h
 const guideSidebarFallback = siteConfig.guide.sidebarContent
   .map((content) => renderRichText(content))
   .filter((content): content is string => Boolean(content));
+const hasMappablePlaces = visiblePlaces.some((place) => place.lat !== null && place.lng !== null);
 ---
 
 <Layout title={`${guide.title} · ${siteConfig.siteName}`} description={guide.description ?? undefined}>
@@ -263,6 +264,7 @@ const guideSidebarFallback = siteConfig.guide.sidebarContent
     data-all-tags={JSON.stringify(allTags)}
     data-default-suggestions={JSON.stringify(defaultSuggestions)}
     data-type-seeds={JSON.stringify(typeSeedTags)}
+    data-has-mappable-places={hasMappablePlaces ? "true" : "false"}
     data-location-sort-fallback-text={siteConfig.guide.locationSortFallbackText}
   >
     <SectionHeading eyebrow={siteConfig.guide.browseEyebrow} title={siteConfig.guide.placesHeading} />
@@ -358,7 +360,7 @@ const guideSidebarFallback = siteConfig.guide.sidebarContent
               <span class="results-sort-shell">
                 <select class="ui-input" id="guide-sort" name="guide-sort" data-sort-select>
                   <option value="curated">{siteConfig.guide.sortCuratedLabel}</option>
-                  <option value="nearby">{siteConfig.guide.sortNearMeLabel}</option>
+                  {hasMappablePlaces && <option value="nearby">{siteConfig.guide.sortNearMeLabel}</option>}
                   <option value="rating">{siteConfig.guide.sortRatingLabel}</option>
                   <option value="name">{siteConfig.guide.sortNameLabel}</option>
                   <option value="neighborhood">{siteConfig.guide.sortNeighborhoodLabel}</option>

--- a/tests/frontend/guideFilters.test.mjs
+++ b/tests/frontend/guideFilters.test.mjs
@@ -3,17 +3,37 @@ import { describe, expect, it } from "vitest";
 import {
   buildAreaFilterStatusMessage,
   buildEmptyStateMessage,
+  buildNearbyDistanceMap,
   cardHasTag,
   cardMatchesType,
+  compareCardsByCurated,
+  compareCardsByNearby,
   countMatchingCards,
+  resolveLocationSortState,
 } from "../../public/scripts/guide-filters.js";
 
-const makeCard = ({ neighborhood = "", placeId, search = "", tags = "", vibeTags = "" }) => ({
+const makeCard = ({
+  lat = "",
+  lng = "",
+  name = "",
+  neighborhood = "",
+  placeId,
+  rank = "0",
+  search = "",
+  tags = "",
+  topPick = "false",
+  vibeTags = "",
+} = {}) => ({
   dataset: {
+    lat,
+    lng,
+    name,
     neighborhood,
     placeId,
+    rank,
     search,
     tags,
+    topPick,
     vibeTags,
   },
 });
@@ -252,5 +272,111 @@ describe("guide filters", () => {
         tag: "date-night",
       }),
     ).toBe(1);
+  });
+
+  it("sorts nearby cards by cached distance and keeps cards without coordinates last", () => {
+    const currentLocation = { lat: 35.6812, lng: 139.7671 };
+    const cards = [
+      makeCard({ placeId: "far", lat: "35.6895", lng: "139.6917", name: "Far", rank: "1" }),
+      makeCard({ placeId: "missing", name: "Missing", rank: "99", topPick: "true" }),
+      makeCard({ placeId: "near", lat: "35.6814", lng: "139.7673", name: "Near", rank: "2" }),
+    ];
+    const distanceByPlaceId = buildNearbyDistanceMap(cards, currentLocation);
+
+    const sortedCards = [...cards].sort((left, right) =>
+      compareCardsByNearby(left, right, {
+        currentLocation,
+        distanceByPlaceId,
+      }),
+    );
+
+    expect(Array.from(distanceByPlaceId.keys())).toEqual(["far", "near"]);
+    expect(sortedCards.map((card) => card.dataset.placeId)).toEqual(["near", "far", "missing"]);
+  });
+
+  it("falls back to curated sorting when nearby sorting has no current location", () => {
+    const cards = [
+      makeCard({ placeId: "rank-1", name: "Bravo", rank: "1" }),
+      makeCard({ placeId: "rank-3", name: "Alpha", rank: "3" }),
+      makeCard({ placeId: "top-pick", name: "Cafe", rank: "2", topPick: "true" }),
+    ];
+
+    const nearbySorted = [...cards].sort((left, right) =>
+      compareCardsByNearby(left, right, {
+        currentLocation: null,
+        distanceByPlaceId: new Map(),
+      }),
+    );
+    const curatedSorted = [...cards].sort(compareCardsByCurated);
+
+    expect(nearbySorted.map((card) => card.dataset.placeId)).toEqual(
+      curatedSorted.map((card) => card.dataset.placeId),
+    );
+  });
+
+  it("resets nearby sorting to curated when location is denied or unavailable", () => {
+    expect(
+      resolveLocationSortState({
+        currentLocation: null,
+        currentLocationStatus: "denied",
+        sortValue: "nearby",
+      }),
+    ).toEqual({
+      message: "Location unavailable. Showing curated order instead.",
+      shouldFallback: true,
+      sortValue: "curated",
+    });
+
+    expect(
+      resolveLocationSortState({
+        currentLocation: null,
+        currentLocationStatus: "unavailable",
+        fallbackMessage: "Location denied.",
+        fallbackSortValue: "rating",
+        sortValue: "nearby",
+      }),
+    ).toEqual({
+      message: "Location denied.",
+      shouldFallback: true,
+      sortValue: "rating",
+    });
+  });
+
+  it("does not reset nearby sorting while location is still idle, checking, or already available", () => {
+    expect(
+      resolveLocationSortState({
+        currentLocation: null,
+        currentLocationStatus: "idle",
+        sortValue: "nearby",
+      }),
+    ).toEqual({
+      message: "",
+      shouldFallback: false,
+      sortValue: "nearby",
+    });
+
+    expect(
+      resolveLocationSortState({
+        currentLocation: null,
+        currentLocationStatus: "checking",
+        sortValue: "nearby",
+      }),
+    ).toEqual({
+      message: "",
+      shouldFallback: false,
+      sortValue: "nearby",
+    });
+
+    expect(
+      resolveLocationSortState({
+        currentLocation: { lat: 35.6812, lng: 139.7671 },
+        currentLocationStatus: "available",
+        sortValue: "nearby",
+      }),
+    ).toEqual({
+      message: "",
+      shouldFallback: false,
+      sortValue: "nearby",
+    });
   });
 });

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -175,6 +175,8 @@ describe("guide map interactions", () => {
 
   it("guards the current-location map control with stored guide proximity bounds", () => {
     const guideMap = readSource("src/components/GuideMap.astro");
+    const guidePage = readSource("src/pages/guides/[slug].astro");
+    const filters = readSource("public/scripts/guide-filters.js");
     const css = readSource("src/styles/global.css");
 
     expect(guideMap).toContain('class="map-icon-button"');
@@ -192,6 +194,22 @@ describe("guide map interactions", () => {
     expect(guideMap).toContain('setLocationButtonState("checking", "Checking current location")');
     expect(guideMap).toContain('setLocationButtonState("near", "Center map on current location")');
     expect(guideMap).toContain("watchPosition");
+    expect(
+      guideMap.indexOf(
+        'root?.addEventListener("guide:user-location-request", handleUserLocationRequest)',
+      ),
+    ).toBeLessThan(guideMap.indexOf("await initGoogleRuntime"));
+    expect(guidePage).toContain("const hasMappablePlaces = visiblePlaces.some");
+    expect(guidePage).toContain('data-has-mappable-places={hasMappablePlaces ? "true" : "false"}');
+    expect(guidePage).toContain(
+      '{hasMappablePlaces && <option value="nearby">{siteConfig.guide.sortNearMeLabel}</option>}',
+    );
+    expect(filters).toContain(
+      'const hasMappablePlaces = root.dataset.hasMappablePlaces === "true";',
+    );
+    expect(filters).toContain("const requestCurrentLocationDirectly = () => {");
+    expect(filters).toContain("navigator.geolocation.getCurrentPosition(");
+    expect(filters).toContain("directLocationFallbackTimer = window.setTimeout(() => {");
     expectCssToContain(css, ".map-icon-button");
     expectCssToContain(css, '.map-icon-button[aria-disabled="true"]');
     expectCssToContain(css, '.map-icon-button[data-location-state="checking"]');


### PR DESCRIPTION
## Description
- Show the detected user position as a blue dot on guide maps for both Leaflet and Google Maps.
- Add a `Near me` sort option for guide results that requests geolocation on demand.
- Reset the sort back to curated with a status message when location access is denied or unavailable.

## Related Issue
- None found in `508-dev/favorite-places` open issues.

## How Has This Been Tested?
- `bun run check`
- `bun run build`
