### PR TITLE
Improve enrichment locality matching and area filters

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -17,10 +17,9 @@ from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime, timedelta
 from dataclasses import dataclass
-from functools import cache
 from pathlib import Path
 from statistics import median
-from typing import Any, Literal
+from typing import Any
 from urllib.parse import parse_qsl, quote_plus, unquote, urlencode, urlsplit, urlunsplit
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -78,6 +77,8 @@ RAW_SOURCE_REFRESH_JITTER = timedelta(days=3)
 STRONG_MATCH_SCORE = 45
 MAP_PIN_DISTANCE_WARNING_MIN_METERS = 100_000.0
 MAP_PIN_DISTANCE_WARNING_BUFFER_METERS = 50_000.0
+MAP_PIN_DISTANCE_SUPPRESSION_MIN_METERS = 1_000_000.0
+MAP_PIN_DISTANCE_SUPPRESSION_MULTIPLIER = 5.0
 BEST_HIT_MAX_COUNT = 6
 BEST_HIT_MIN_RATING = 4.5
 BEST_HIT_MAX_RATING = 4.8
@@ -155,7 +156,6 @@ CREATE TABLE canonical_places (
     normalized_primary_category_localized TEXT,
     normalized_tags_json TEXT NOT NULL,
     normalized_vibe_tags_json TEXT NOT NULL,
-    normalized_locality_path_json TEXT NOT NULL,
     normalized_neighborhood TEXT,
     normalized_note TEXT,
     normalized_why_recommended TEXT,
@@ -219,7 +219,6 @@ CREATE TABLE guide_places (
     is_featured INTEGER NOT NULL,
     is_best_hit INTEGER NOT NULL,
     place_name TEXT NOT NULL,
-    locality_path_json TEXT NOT NULL,
     neighborhood TEXT,
     primary_category TEXT,
     primary_category_localized TEXT,
@@ -310,10 +309,27 @@ COUNTRY_LOCALITY_ALIASES = (
     "USA",
     "Korea",
     "Taiwan",
+    "台灣",
+    "台湾",
+    "Spain",
+    "España",
+    "Espanya",
+    "スペイン",
     "Vatican City",
     "Ivory Coast",
 )
+AUSTRALIAN_SUBNATIONAL_LOCALITY_ALIASES = (
+    "NSW",
+    "VIC",
+    "QLD",
+    "SA",
+    "WA",
+    "TAS",
+    "NT",
+    "ACT",
+)
 COUNTRY_LOCALITY_KEYS: set[str] | None = None
+SUBNATIONAL_LOCALITY_KEYS: set[str] | None = None
 LOCATION_TAG_ALIASES: dict[str, tuple[str, ...]] = {
     "geneve": ("geneva",),
     "geneva": ("geneve",),
@@ -1795,7 +1811,16 @@ def rebuild_generated_data(
         raw_lists[raw_path.stem] = raw
         enrichment_cache = load_places_cache(raw_path.stem)
         enrichment_caches[raw_path.stem] = enrichment_cache
-        guide = normalize_guide(raw_path.stem, raw, enrichment_cache=enrichment_cache)
+
+    hydrate_shared_enrichment_photo_urls(enrichment_caches)
+
+    for raw_path in sorted(RAW_DIR.glob("*.json")):
+        raw = raw_lists[raw_path.stem]
+        guide = normalize_guide(
+            raw_path.stem,
+            raw,
+            enrichment_cache=enrichment_caches[raw_path.stem],
+        )
         guides.append(guide)
 
     populate_place_photos_for_guides(
@@ -1997,13 +2022,13 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
                 *derive_place_tags(place, city_name, enrichment=enrichment, category=primary_category),
             }
         )
-        normalized_address = place.address or enrichment.formatted_address
-        neighborhood_uses_enrichment_address = (
-            not as_string(override.get("neighborhood")) and not place.address and bool(enrichment.formatted_address)
+        raw_locality_candidates = infer_address_localities(
+            place.address,
+            city_name=city_name,
         )
-        locality_path = merge_inferred_localities(
+        enrichment_locality_candidates = merge_inferred_localities(
             infer_address_localities(
-                normalized_address,
+                enrichment.formatted_address,
                 city_name=city_name,
             ),
             infer_address_parts_localities(
@@ -2011,7 +2036,18 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
                 city_name=city_name,
             ),
         )
-        neighborhood = as_string(override.get("neighborhood")) or (locality_path[0] if locality_path else None)
+        locality_candidates = merge_inferred_localities(
+            raw_locality_candidates,
+            enrichment_locality_candidates,
+        )
+        neighborhood = as_string(override.get("neighborhood")) or (
+            locality_candidates[0] if locality_candidates else None
+        )
+        neighborhood_uses_enrichment = bool(
+            neighborhood
+            and neighborhood in enrichment_locality_candidates
+            and neighborhood not in raw_locality_candidates
+        )
         hidden = bool(override.get("hidden", False))
         top_pick_override = as_bool(override.get("top_pick"))
         top_pick = top_pick_override if top_pick_override is not None else place.is_favorite
@@ -2047,6 +2083,7 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
         if prefer_enrichment_names and enrichment.display_name:
             preferred_name = enrichment.display_name
         normalized_name = as_string(override.get("name")) or preferred_name
+        normalized_address = place.address or enrichment.formatted_address
         maps_url = build_public_google_maps_url(
             name=normalized_name,
             address=normalized_address,
@@ -2075,7 +2112,6 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
             marker_icon=marker_icon,
             tags=tags,
             vibe_tags=vibe_tags,
-            locality_path=locality_path,
             neighborhood=neighborhood,
             note=note,
             why_recommended=why_recommended,
@@ -2096,10 +2132,10 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
             primary_category_localized=primary_category_localized,
             tags=tags,
             city_name=city_name,
+            neighborhood_uses_enrichment=neighborhood_uses_enrichment,
             top_pick_override=top_pick_override,
             status=status,
             prefer_enrichment_names=prefer_enrichment_names,
-            neighborhood_uses_enrichment_address=neighborhood_uses_enrichment_address,
         )
         normalized_places.append(normalized)
         if primary_category and not place_is_permanently_closed(normalized):
@@ -2134,6 +2170,7 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
     top_categories = [name for name, _count in category_counter.most_common(4)]
     generated_at = stable_generated_at(raw, enrichment_cache)
     guide_center = guide_location_center(display_places)
+    suppress_far_map_pins(slug, display_places, guide_center)
     warn_far_map_pins(slug, display_places, guide_center)
 
     return Guide(
@@ -2171,10 +2208,10 @@ def build_place_provenance(
     primary_category_localized: str | None,
     tags: list[str],
     city_name: str | None,
+    neighborhood_uses_enrichment: bool,
     top_pick_override: bool | None,
     status: str,
     prefer_enrichment_names: bool,
-    neighborhood_uses_enrichment_address: bool,
 ) -> PlaceProvenance:
     manual_name = as_string(override.get("name"))
     manual_category = as_string(override.get("primary_category"))
@@ -2240,18 +2277,12 @@ def build_place_provenance(
         city_name=city_name,
         tags=tags,
     )
-    if normalized.locality_path:
-        provenance.locality_path = (
-            google_places_field(normalized.locality_path, enrichment_cache_entry)
-            if neighborhood_uses_enrichment_address
-            else google_list_field(normalized.locality_path, raw)
-        )
     if normalized.neighborhood:
         provenance.neighborhood = (
             manual_place_field(normalized.neighborhood)
             if manual_neighborhood
             else google_places_field(normalized.neighborhood, enrichment_cache_entry)
-            if neighborhood_uses_enrichment_address
+            if neighborhood_uses_enrichment
             else google_list_field(normalized.neighborhood, raw)
         )
     if normalized.note:
@@ -2602,6 +2633,34 @@ def warn_far_map_pins(
         )
 
 
+def suppress_far_map_pins(
+    slug: str,
+    places: list[NormalizedPlace],
+    center: tuple[float | None, float | None],
+) -> None:
+    suppression_distance_meters = guide_map_pin_suppression_distance_meters(places, center)
+    center_lat, center_lng = center
+    if center_lat is None or center_lng is None or suppression_distance_meters is None:
+        return
+
+    for place in places:
+        if place.lat is None or place.lng is None:
+            continue
+
+        distance_meters = haversine_meters(center_lat, center_lng, place.lat, place.lng)
+        if distance_meters < suppression_distance_meters:
+            continue
+
+        print(
+            "WARNING: "
+            f"Suppressing map pin for {slug}:{place.id} [{place.name}] because it is "
+            f"{distance_meters / 1000:.0f} km from the guide center.",
+            flush=True,
+        )
+        place.lat = None
+        place.lng = None
+
+
 def guide_map_pin_warning_distance_meters(
     places: list[NormalizedPlace],
     center: tuple[float | None, float | None],
@@ -2628,6 +2687,19 @@ def guide_map_pin_warning_distance_meters(
     return max(
         MAP_PIN_DISTANCE_WARNING_MIN_METERS,
         inlier_radius_meters + MAP_PIN_DISTANCE_WARNING_BUFFER_METERS,
+    )
+
+
+def guide_map_pin_suppression_distance_meters(
+    places: list[NormalizedPlace],
+    center: tuple[float | None, float | None],
+) -> float | None:
+    warning_distance_meters = guide_map_pin_warning_distance_meters(places, center)
+    if warning_distance_meters is None:
+        return None
+    return max(
+        MAP_PIN_DISTANCE_SUPPRESSION_MIN_METERS,
+        warning_distance_meters * MAP_PIN_DISTANCE_SUPPRESSION_MULTIPLIER,
     )
 
 
@@ -2681,7 +2753,6 @@ def enrich_raw_sources(
     refresh_startup_jitter_seconds: float = DEFAULT_REFRESH_STARTUP_JITTER_SECONDS,
 ) -> None:
     api_key = google_places_api_key()
-    strategy = google_places_enrichment_strategy()
     cache_payloads: dict[str, dict[str, EnrichmentCacheEntry]] = {}
     enrich_jobs: list[tuple[str, str, str, str, dict[str, Any], str | None, str | None]] = []
 
@@ -2696,6 +2767,8 @@ def enrich_raw_sources(
             refresh_reason = enrichment_refresh_reason(
                 place,
                 cache_payload.get(place_id),
+                city_name=city_name,
+                country_name=country_name,
                 force_refresh=force_refresh,
                 missing_only=missing_only,
             )
@@ -2717,18 +2790,6 @@ def enrich_raw_sources(
     if not enrich_jobs:
         return
 
-    if strategy == "api" and api_key is None:
-        raise RuntimeError(
-            "GOOGLE_PLACES_API_KEY is required when GOOGLE_PLACES_ENRICHMENT_STRATEGY=api."
-        )
-
-    if strategy == "scrape_then_api" and api_key is None:
-        print(
-            "GOOGLE_PLACES_API_KEY is not set; enrichment will scrape Google Maps place pages "
-            "without Google Places API fallback.",
-            flush=True,
-        )
-
     enrich_jobs.sort(key=enrichment_job_priority)
 
     effective_startup_jitter_seconds = (
@@ -2746,7 +2807,6 @@ def enrich_raw_sources(
                 city_name=city_name,
                 country_name=country_name,
                 api_key=api_key,
-                strategy=strategy,
                 refresh_startup_jitter_seconds=effective_startup_jitter_seconds,
                 existing_entry=cache_payloads[slug].get(place_id),
             )
@@ -2768,7 +2828,6 @@ def enrich_raw_sources(
                 city_name=city_name,
                 country_name=country_name,
                 api_key=api_key,
-                strategy=strategy,
                 refresh_startup_jitter_seconds=effective_startup_jitter_seconds,
                 existing_entry=cache_payloads[slug].get(place_id),
             ): (slug, place_id)
@@ -2796,7 +2855,6 @@ def enrich_place_job(
     city_name: str | None = None,
     country_name: str | None = None,
     api_key: str | None,
-    strategy: Literal["scrape", "api", "scrape_then_api"] | None = None,
     refresh_startup_jitter_seconds: float,
     existing_entry: EnrichmentCacheEntry | None = None,
 ) -> EnrichmentCacheEntry:
@@ -2812,7 +2870,6 @@ def enrich_place_job(
         country_name=country_name,
         google_place_id=existing_entry.place.google_place_id if existing_entry and existing_entry.place else None,
         api_key=api_key,
-        strategy=strategy,
     )
     merged_entry, warning = preserve_existing_enrichment(
         slug=slug,
@@ -2956,8 +3013,6 @@ def humanize_type_id(value: str | None) -> str | None:
     phrase = normalized.replace("_", " ").replace("-", " ").strip().lower()
     if not phrase:
         return None
-    if phrase.replace(" ", "-") in GENERIC_ENRICHMENT_TYPE_TAGS:
-        return None
     return phrase[:1].upper() + phrase[1:]
 
 
@@ -3047,11 +3102,7 @@ def normalize_enrichment_type_id_with_generic_fallback(value: str | None) -> str
     if not value:
         return None
     normalized = slugify(value.replace("_", "-"))
-    if (
-        not normalized
-        or normalized in GENERIC_ENRICHMENT_TYPE_TAGS
-        or any(pattern.match(normalized) for pattern in INVALID_ENRICHMENT_TYPE_TAG_PATTERNS)
-    ):
+    if not normalized or any(pattern.match(normalized) for pattern in INVALID_ENRICHMENT_TYPE_TAG_PATTERNS):
         return None
     return normalized.replace("-", "_")
 
@@ -3287,7 +3338,6 @@ def search_index_place_entry(guide: Guide, place: NormalizedPlace) -> dict[str, 
         "country_code": guide.country_code,
         "name": place.name,
         "category": place.primary_category,
-        "locality_path": place.locality_path,
         "neighborhood": place.neighborhood,
         "tags": place.tags,
         "vibe_tags": place.vibe_tags,
@@ -3307,7 +3357,6 @@ def search_index_place_entry(guide: Guide, place: NormalizedPlace) -> dict[str, 
                 place.why_recommended,
                 place.primary_category,
                 place.neighborhood,
-                " ".join(place.locality_path),
                 " ".join(place.tags),
                 " ".join(place.vibe_tags),
                 guide.title,
@@ -3506,6 +3555,7 @@ def infer_address_parts_localities(
             not candidate_key
             or candidate_key == city_key
             or (city_equivalence_key and candidate_equivalence_key == city_equivalence_key)
+            or is_subnational_locality(normalized_candidate)
         ):
             continue
         append_unique_locality(localities, normalized_candidate)
@@ -3530,6 +3580,8 @@ def infer_address_localities(address: str | None, *, city_name: str | None = Non
         equivalent_key = normalize_locality_equivalence_key(candidate)
         if not key or key == city_key or (city_equivalence_key and equivalent_key == city_equivalence_key):
             continue
+        if is_subnational_locality(candidate):
+            continue
         if is_subcity_locality(candidate):
             append_unique_locality(subcities, candidate)
         else:
@@ -3549,6 +3601,9 @@ def normalize_address_locality_part(part: str) -> str | None:
     candidate = re.sub(r"\b\d{5}(?:-\d{4})?\b", "", candidate).strip()
     candidate = re.sub(r"\s+\d{4}\b", "", candidate).strip()
     candidate = candidate.strip(" -−ー－/()[]{}.")
+    candidate = strip_leading_numeric_locality_prefix(candidate)
+    candidate = strip_country_locality_prefix(candidate)
+    candidate = strip_subnational_locality_suffix(candidate)
 
     if not candidate or is_country_locality(candidate):
         return None
@@ -3559,8 +3614,6 @@ def normalize_address_locality_part(part: str) -> str | None:
     trailing_locality = extract_trailing_locality(candidate)
     if trailing_locality is not None:
         candidate = trailing_locality
-    else:
-        candidate = re.sub(r"^\d+[A-Za-z]?(?:[-−ー－/]\d+[A-Za-z]?)*\s+", "", candidate).strip()
 
     if is_street_or_block_part(candidate) or is_building_or_unit_part(candidate):
         return None
@@ -3573,6 +3626,34 @@ def normalize_address_locality_part(part: str) -> str | None:
     if len(candidate) <= 1:
         return None
     return candidate
+
+
+def strip_country_locality_prefix(candidate: str) -> str:
+    words = candidate.split()
+    max_prefix_words = min(len(words) - 1, 4)
+    for word_count in range(max_prefix_words, 0, -1):
+        prefix = " ".join(words[:word_count])
+        if is_country_locality(prefix):
+            return " ".join(words[word_count:]).strip(" -−ー－/()[]{}.")
+    return candidate
+
+
+def strip_leading_numeric_locality_prefix(candidate: str) -> str:
+    return re.sub(
+        r"^\d+[A-Za-z]?(?:[-−ー－/]\d+[A-Za-z]?)*\s+(?!chome\b|丁目)",
+        "",
+        candidate,
+        flags=re.IGNORECASE,
+    ).strip()
+
+
+def strip_subnational_locality_suffix(candidate: str) -> str:
+    return re.sub(
+        r"\s+(?:NSW|VIC|QLD|SA|WA|TAS|NT|ACT)\b$",
+        "",
+        candidate,
+        flags=re.IGNORECASE,
+    ).strip(" -−ー－/()[]{}.")
 
 
 def extract_trailing_locality(candidate: str) -> str | None:
@@ -3610,6 +3691,30 @@ def get_country_locality_keys() -> set[str]:
     return COUNTRY_LOCALITY_KEYS
 
 
+def is_subnational_locality(candidate: str) -> bool:
+    return normalize_locality_key(candidate) in get_subnational_locality_keys()
+
+
+def get_subnational_locality_keys() -> set[str]:
+    global SUBNATIONAL_LOCALITY_KEYS
+    if SUBNATIONAL_LOCALITY_KEYS is not None:
+        return SUBNATIONAL_LOCALITY_KEYS
+
+    subdivision_names: set[str] = set()
+    for subdivision in pycountry.subdivisions:
+        value = getattr(subdivision, "name", None)
+        if value:
+            subdivision_names.add(value)
+    subdivision_names.update(AUSTRALIAN_SUBNATIONAL_LOCALITY_ALIASES)
+
+    SUBNATIONAL_LOCALITY_KEYS = {
+        normalize_locality_key(name)
+        for name in subdivision_names
+        if normalize_locality_key(name)
+    }
+    return SUBNATIONAL_LOCALITY_KEYS
+
+
 def is_subcity_locality(candidate: str) -> bool:
     return bool(
         re.search(
@@ -3623,7 +3728,13 @@ def is_subcity_locality(candidate: str) -> bool:
 def is_building_or_unit_part(candidate: str) -> bool:
     return bool(
         re.search(
-            r"\b(?:bldg|building|tower|plaza|terrace|floor|mall|hotel|mansion|palace|garden|stream|works|center|centre|place|v-city|gratteciel|gems)\b|ビル|階|号|館",
+            (
+                r"\b(?:bldg|building|tower|plaza|terrace|floor|mall|hotel|mansion|palace|garden|stream|works|"
+                r"center|centre|place|v-city|gratteciel|gems|bis|sn)\b"
+                r"|^(?:s/n|sn)$"
+                r"|^dentro\s+del\b"
+                r"|ビル|階|号|館"
+            ),
             candidate,
             flags=re.IGNORECASE,
         )
@@ -3633,7 +3744,11 @@ def is_building_or_unit_part(candidate: str) -> bool:
 def is_street_or_block_part(candidate: str) -> bool:
     return bool(
         re.search(
-            r"\b(?:chome|丁目|st|street|rd|road|ln|lane|ave|avenue|dr|drive|blvd|boulevard|rue|via)\b",
+            (
+                r"\b(?:chome|丁目|st|street|rd|road|ln|lane|ave|avenue|dr|drive|blvd|boulevard|rue|via|"
+                r"carrer|calle|avinguda|avenida|av|rambla|ronda|rda|passeig|pg|placa|plaça|pl|passatge|travessera|moll)\b"
+                r"|^(?:c/|c\.|pg\.|av\.|rda\.|pl\.)\s"
+            ),
             candidate,
             flags=re.IGNORECASE,
         )
@@ -3657,7 +3772,11 @@ def normalize_locality_equivalence_key(value: str | None) -> str:
     key = normalize_locality_key(value)
     if not key:
         return ""
-    return re.sub(r"\s+(?:city|ward|district|borough|county|prefecture|province|gu|ku)$", "", key).strip()
+    return re.sub(
+        r"\s+(?:main\s+island|islands|island|city|ward|district|borough|county|prefecture|province|state|region|gu|ku)$",
+        "",
+        key,
+    ).strip()
 
 
 def split_title_parts(title: str) -> list[str]:
@@ -3764,11 +3883,6 @@ def coerce_string_list(value: Any) -> list[str]:
 
 def google_places_api_key() -> str | None:
     return PlacesSettings().google_places_api_key
-
-
-@cache
-def google_places_enrichment_strategy() -> Literal["scrape", "api", "scrape_then_api"]:
-    return PlacesSettings().google_places_enrichment_strategy
 
 
 def configured_source_path(source: SourceConfig) -> Path:
@@ -4104,11 +4218,21 @@ def resolve_refresh_sources(sources: list[SourceConfig], selectors: list[str]) -
     return matched_sources
 
 
-def cache_refresh_reason(place: RawPlace, cache_entry: EnrichmentCacheEntry | None) -> str | None:
+def cache_refresh_reason(
+    place: RawPlace,
+    cache_entry: EnrichmentCacheEntry | None,
+    *,
+    city_name: str | None = None,
+    country_name: str | None = None,
+) -> str | None:
     if cache_entry is None:
         return "missing-cache-entry"
 
-    expected_signature = place_input_signature(place)
+    expected_signature = enrichment_input_signature(
+        place,
+        city_name=city_name,
+        country_name=country_name,
+    )
     if cache_entry.input_signature != expected_signature:
         return "raw-place-changed"
 
@@ -4148,20 +4272,27 @@ def enrichment_refresh_reason(
     place: RawPlace,
     cache_entry: EnrichmentCacheEntry | None,
     *,
+    city_name: str | None = None,
+    country_name: str | None = None,
     force_refresh: bool,
     missing_only: bool,
 ) -> str | None:
     if force_refresh:
         return "forced"
 
-    refresh_reason = cache_refresh_reason(place, cache_entry)
+    refresh_reason = cache_refresh_reason(
+        place,
+        cache_entry,
+        city_name=city_name,
+        country_name=country_name,
+    )
     if missing_only and refresh_reason != "missing-cache-entry":
         return None
     return refresh_reason
 
 
 def enrichment_job_priority(
-    job: tuple[str, str, str, str, dict[str, Any], str | None, str | None],
+    job: tuple[str, str, str, str, dict[str, Any], str | None, str | None]
 ) -> tuple[int, str, str]:
     slug, place_id, _place_name, refresh_reason, _place_payload, _city_name, _country_name = job
     return (
@@ -4169,8 +4300,6 @@ def enrichment_job_priority(
         slug,
         place_id,
     )
-
-
 def place_input_signature(place: RawPlace) -> str:
     payload = structured_place_identity_payload(place)
     if payload is None:
@@ -4180,6 +4309,28 @@ def place_input_signature(place: RawPlace) -> str:
             "lat": place.lat,
             "lng": place.lng,
         }
+    serialized = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def enrichment_input_signature(
+    place: RawPlace,
+    *,
+    city_name: str | None = None,
+    country_name: str | None = None,
+) -> str:
+    payload = {
+        "place": structured_place_identity_payload(place)
+        or {
+            "name": place.name,
+            "address": place.address,
+            "lat": place.lat,
+            "lng": place.lng,
+        },
+        "city_name": as_string(city_name),
+        "country_name": as_string(country_name),
+        "search_query_version": 2,
+    }
     serialized = json.dumps(payload, sort_keys=True, ensure_ascii=False)
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
@@ -4221,6 +4372,8 @@ def build_cache_entry(
     *,
     source: str | None = None,
     query: str,
+    city_name: str | None = None,
+    country_name: str | None = None,
     matched: bool | None = None,
     score: int | None = None,
     error: str | None = None,
@@ -4233,7 +4386,11 @@ def build_cache_entry(
         last_verified_at=fetched_at.isoformat(),
         source=source,
         query=query,
-        input_signature=place_input_signature(place),
+        input_signature=enrichment_input_signature(
+            place,
+            city_name=city_name,
+            country_name=country_name,
+        ),
         matched=matched,
         score=score,
         error=error,
@@ -4684,12 +4841,89 @@ def load_places_sqlite_build_signature() -> str | None:
     return row[0]
 
 
+def enrichment_place_identity_key(place: EnrichmentPlace | None) -> str | None:
+    if place is None:
+        return None
+    if place.google_place_id:
+        return f"google_place_id:{place.google_place_id}"
+    if place.google_place_resource_name:
+        return f"google_place_resource_name:{place.google_place_resource_name}"
+    return None
+
+
+def enrichment_photo_donor_score(entry: EnrichmentCacheEntry) -> tuple[int, int, str]:
+    place = entry.place or EnrichmentPlace()
+    return (
+        1 if place.main_photo_url else 0,
+        1 if place.photo_url else 0,
+        entry.fetched_at,
+    )
+
+
+def shared_enrichment_photo_identity_keys(
+    place_id: str,
+    entry: EnrichmentCacheEntry,
+) -> list[str]:
+    keys: list[str] = []
+    place = entry.place
+    identity_key = enrichment_place_identity_key(place)
+    if identity_key:
+        keys.append(identity_key)
+    display_name = normalize_text(place.display_name) if place and place.display_name else ""
+    if display_name:
+        keys.append(f"place_id_name:{place_id}:{display_name}")
+    return keys
+
+
+def hydrate_shared_enrichment_photo_urls(
+    enrichment_caches: dict[str, dict[str, EnrichmentCacheEntry]],
+) -> None:
+    photo_donors: dict[str, tuple[tuple[int, int, str], str | None, str | None]] = {}
+
+    for payload in enrichment_caches.values():
+        for place_id, entry in payload.items():
+            place = entry.place
+            if (
+                place is None
+                or (not place.main_photo_url and not place.photo_url)
+            ):
+                continue
+            candidate = (
+                enrichment_photo_donor_score(entry),
+                place.main_photo_url,
+                place.photo_url,
+            )
+            for identity_key in shared_enrichment_photo_identity_keys(place_id, entry):
+                donor = photo_donors.get(identity_key)
+                if donor is None or candidate[0] > donor[0]:
+                    photo_donors[identity_key] = candidate
+
+    for payload in enrichment_caches.values():
+        for place_id, entry in payload.items():
+            place = entry.place
+            if place is None:
+                continue
+            donor: tuple[tuple[int, int, str], str | None, str | None] | None = None
+            for identity_key in shared_enrichment_photo_identity_keys(place_id, entry):
+                donor = photo_donors.get(identity_key)
+                if donor is not None:
+                    break
+            if donor is None:
+                continue
+            _, donor_main_photo_url, donor_photo_url = donor
+            if not place.main_photo_url and donor_main_photo_url:
+                place.main_photo_url = donor_main_photo_url
+            if not place.photo_url and donor_photo_url:
+                place.photo_url = donor_photo_url
+
+
 def build_places_sqlite_rows(
     *,
     raw_lists: dict[str, RawSavedList],
     guides: list[Guide],
     enrichment_caches: dict[str, dict[str, EnrichmentCacheEntry]],
 ) -> PlacesSqliteRows:
+    hydrate_shared_enrichment_photo_urls(enrichment_caches)
     raw_place_maps = {
         slug: {
             stable_place_id(place, source_type=raw.configured_source_type): place
@@ -4698,7 +4932,7 @@ def build_places_sqlite_rows(
         for slug, raw in raw_lists.items()
     }
     photo_metadata_cache: dict[str, tuple[str, str | None, str | None, int | None]] = {}
-    canonical_places: dict[str, tuple[tuple[int, int, int, int], tuple[Any, ...]]] = {}
+    canonical_places: dict[str, tuple[tuple[int, int, int, int], tuple[Any, ...], str | None]] = {}
     guide_rows: list[tuple[Any, ...]] = []
     guide_place_rows: list[tuple[Any, ...]] = []
     photo_rows: list[tuple[Any, ...]] = []
@@ -4742,9 +4976,20 @@ def build_places_sqlite_rows(
                 cache_entry=cache_entry,
             )
             candidate_score = canonical_place_score(place, cache_entry)
+            candidate_identity = canonical_place_identity_key(place, cache_entry)
             current = canonical_places.get(place.id)
-            if current is None or candidate_score > current[0]:
-                canonical_places[place.id] = (candidate_score, candidate_row)
+            if current is None:
+                canonical_places[place.id] = (candidate_score, candidate_row, candidate_identity)
+            else:
+                _, _, current_identity = current
+                if current_identity and not candidate_identity:
+                    pass
+                elif current_identity and candidate_identity and current_identity != candidate_identity:
+                    pass
+                elif current_identity is None and candidate_identity is not None:
+                    canonical_places[place.id] = (candidate_score, candidate_row, candidate_identity)
+                elif candidate_score > current[0]:
+                    canonical_places[place.id] = (candidate_score, candidate_row, candidate_identity)
 
             guide_place_rows.append(
                 (
@@ -4754,7 +4999,6 @@ def build_places_sqlite_rows(
                     sqlite_bool(place.id in featured_ids),
                     sqlite_bool(place.id in best_hit_ids),
                     place.name,
-                    sqlite_json(place.locality_path),
                     place.neighborhood,
                     place.primary_category,
                     place.primary_category_localized,
@@ -4816,7 +5060,7 @@ def build_places_sqlite_rows(
         guide_rows=guide_rows,
         canonical_place_rows=[
             row
-            for _, row in (
+            for _, row, _ in (
                 canonical_places[place_id]
                 for place_id in sorted(canonical_places)
             )
@@ -4850,8 +5094,7 @@ def write_places_sqlite(
             normalized_google_id, normalized_google_place_id, normalized_google_place_resource_name,
             normalized_rating, normalized_user_rating_count, normalized_primary_category,
             normalized_primary_category_localized,
-            normalized_tags_json, normalized_vibe_tags_json, normalized_locality_path_json,
-            normalized_neighborhood, normalized_note,
+            normalized_tags_json, normalized_vibe_tags_json, normalized_neighborhood, normalized_note,
             normalized_why_recommended, normalized_main_photo_path, normalized_top_pick,
             normalized_hidden, normalized_manual_rank, normalized_status, cache_fetched_at,
             cache_last_verified_at, cache_refresh_after, cache_source, cache_query, cache_input_signature,
@@ -4902,9 +5145,9 @@ def write_places_sqlite(
                 """
                 INSERT INTO guide_places (
                     guide_slug, sort_order, place_id, is_featured, is_best_hit, place_name,
-                    locality_path_json, neighborhood, primary_category, primary_category_localized, rating, user_rating_count,
+                    neighborhood, primary_category, primary_category_localized, rating, user_rating_count,
                     status, top_pick, hidden, manual_rank, note, why_recommended, main_photo_path, maps_url
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 rows.guide_place_rows,
             )
@@ -4971,6 +5214,18 @@ def canonical_place_score(
     )
 
 
+def canonical_place_identity_key(
+    place: NormalizedPlace,
+    cache_entry: EnrichmentCacheEntry | None,
+) -> str | None:
+    if place.google_place_id:
+        return f"google_place_id:{place.google_place_id}"
+    if place.google_place_resource_name:
+        return f"google_place_resource_name:{place.google_place_resource_name}"
+    enrichment_place = cache_entry.place if cache_entry else None
+    return enrichment_place_identity_key(enrichment_place)
+
+
 def canonical_place_row(
     *,
     guide_slug: str,
@@ -5005,7 +5260,6 @@ def canonical_place_row(
         place.primary_category_localized,
         sqlite_json(place.tags),
         sqlite_json(place.vibe_tags),
-        sqlite_json(place.locality_path),
         place.neighborhood,
         place.note,
         place.why_recommended,
@@ -5510,26 +5764,7 @@ def fetch_places_enrichment(
     country_name: str | None = None,
     google_place_id: str | None = None,
     api_key: str | None,
-    strategy: Literal["scrape", "api", "scrape_then_api"] | None = None,
 ) -> EnrichmentCacheEntry:
-    if strategy is None:
-        strategy = google_places_enrichment_strategy()
-
-    if strategy == "scrape":
-        return fetch_place_page_enrichment(
-            place,
-            city_name=city_name,
-            country_name=country_name,
-            google_place_id=google_place_id,
-        )
-
-    if strategy == "api":
-        if api_key is None:
-            raise RuntimeError(
-                "GOOGLE_PLACES_API_KEY is required when GOOGLE_PLACES_ENRICHMENT_STRATEGY=api."
-            )
-        return fetch_places_api_enrichment(place, api_key=api_key)
-
     page_entry = fetch_place_page_enrichment(
         place,
         city_name=city_name,
@@ -5541,7 +5776,12 @@ def fetch_places_enrichment(
             return page_entry
 
     if api_key is not None:
-        api_entry = fetch_places_api_enrichment(place, api_key=api_key)
+        api_entry = fetch_places_api_enrichment(
+            place,
+            city_name=city_name,
+            country_name=country_name,
+            api_key=api_key,
+        )
         if (
             page_entry.error is None
             and page_entry.place is not None
@@ -5560,7 +5800,11 @@ def fetch_place_page_enrichment(
     country_name: str | None = None,
     google_place_id: str | None = None,
 ) -> EnrichmentCacheEntry:
-    query = build_text_query(place)
+    query = build_place_page_search_query(
+        place,
+        city_name=city_name,
+        country_name=country_name,
+    )
     place_url = build_public_google_maps_url(
         name=place.name,
         address=place.address,
@@ -5573,6 +5817,8 @@ def fetch_place_page_enrichment(
             place,
             source="google_maps_page",
             query=query,
+            city_name=city_name,
+            country_name=country_name,
             error="gmaps_scraper_unavailable",
         )
 
@@ -5626,6 +5872,8 @@ def fetch_place_page_enrichment(
                     place,
                     source="google_maps_page",
                     query=query,
+                    city_name=city_name,
+                    country_name=country_name,
                     matched=True,
                     score=STRONG_MATCH_SCORE,
                     enrichment_place=enrichment_place,
@@ -5635,6 +5883,8 @@ def fetch_place_page_enrichment(
                 place,
                 source="google_maps_page",
                 query=query,
+                city_name=city_name,
+                country_name=country_name,
                 matched=False,
             )
         if last_error is not None:
@@ -5642,12 +5892,16 @@ def fetch_place_page_enrichment(
                 place,
                 source="google_maps_page",
                 query=query,
+                city_name=city_name,
+                country_name=country_name,
                 error=last_error,
             )
         return build_cache_entry(
             place,
             source="google_maps_page",
             query=query,
+            city_name=city_name,
+            country_name=country_name,
             matched=False,
         )
     finally:
@@ -5834,6 +6088,46 @@ def dedupe_urls(urls: list[str]) -> list[str]:
     return deduped
 
 
+def build_place_page_search_query(
+    place: RawPlace,
+    *,
+    city_name: str | None = None,
+    country_name: str | None = None,
+) -> str:
+    query = build_text_query(place)
+    if not query:
+        return query
+
+    if place.address:
+        return query
+
+    locality_parts = [
+        part.strip()
+        for part in (city_name, country_name)
+        if isinstance(part, str) and part.strip()
+    ]
+    if locality_parts:
+        deduped_parts = list(dict.fromkeys(locality_parts))
+        return f"{query}, {', '.join(deduped_parts)}"
+
+    return query
+
+
+def should_replace_raw_search_candidates_with_locality_bias(
+    place: RawPlace,
+    *,
+    localized_maps_url: str,
+    search_url: str | None,
+) -> bool:
+    if search_url is None:
+        return False
+    if place.address:
+        return False
+    if "/maps/search/" not in localized_maps_url:
+        return False
+    return search_url != localized_maps_url
+
+
 PLACE_PAGE_ADDRESS_REJECT_SUBSTRINGS = (
     "about this data",
     "faviconv2",
@@ -5995,8 +6289,18 @@ def normalize_place_page_business_status(status: str | None) -> str | None:
     return None
 
 
-def fetch_places_api_enrichment(place: RawPlace, *, api_key: str) -> EnrichmentCacheEntry:
-    query = build_text_query(place)
+def fetch_places_api_enrichment(
+    place: RawPlace,
+    *,
+    city_name: str | None = None,
+    country_name: str | None = None,
+    api_key: str,
+) -> EnrichmentCacheEntry:
+    query = build_place_page_search_query(
+        place,
+        city_name=city_name,
+        country_name=country_name,
+    )
     request_body = {
         "textQuery": query,
         "pageSize": 3,
@@ -6033,6 +6337,8 @@ def fetch_places_api_enrichment(place: RawPlace, *, api_key: str) -> EnrichmentC
             place,
             source="google_places_api",
             query=query,
+            city_name=city_name,
+            country_name=country_name,
             error=f"http_{exc.code}",
             error_body=body[:500],
         )
@@ -6041,6 +6347,8 @@ def fetch_places_api_enrichment(place: RawPlace, *, api_key: str) -> EnrichmentC
             place,
             source="google_places_api",
             query=query,
+            city_name=city_name,
+            country_name=country_name,
             error=f"url_error:{exc.reason}",
         )
 
@@ -6050,6 +6358,8 @@ def fetch_places_api_enrichment(place: RawPlace, *, api_key: str) -> EnrichmentC
             place,
             source="google_places_api",
             query=query,
+            city_name=city_name,
+            country_name=country_name,
             matched=False,
         )
 
@@ -6065,6 +6375,8 @@ def fetch_places_api_enrichment(place: RawPlace, *, api_key: str) -> EnrichmentC
         place,
         source="google_places_api",
         query=query,
+        city_name=city_name,
+        country_name=country_name,
         matched=best_score >= 25,
         score=best_score,
         enrichment_place=normalize_enrichment_match(best_match) if best_score >= 25 else None,
@@ -6077,46 +6389,6 @@ def build_text_query(place: RawPlace) -> str:
     address = place.address or ""
     query = f"{name}, {address}".strip(", ")
     return query or name or address
-
-
-def build_place_page_search_query(
-    place: RawPlace,
-    *,
-    city_name: str | None = None,
-    country_name: str | None = None,
-) -> str:
-    query = build_text_query(place)
-    if not query:
-        return query
-
-    if place.address:
-        return query
-
-    locality_parts = [
-        part.strip()
-        for part in (city_name, country_name)
-        if isinstance(part, str) and part.strip()
-    ]
-    if locality_parts:
-        deduped_parts = list(dict.fromkeys(locality_parts))
-        return f"{query}, {', '.join(deduped_parts)}"
-
-    return query
-
-
-def should_replace_raw_search_candidates_with_locality_bias(
-    place: RawPlace,
-    *,
-    localized_maps_url: str,
-    search_url: str | None,
-) -> bool:
-    if search_url is None:
-        return False
-    if place.address:
-        return False
-    if "/maps/search/" not in localized_maps_url:
-        return False
-    return search_url != localized_maps_url
 
 
 def build_maps_link_query(

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -19,7 +19,7 @@ from datetime import UTC, datetime, timedelta
 from dataclasses import dataclass
 from pathlib import Path
 from statistics import median
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import parse_qsl, quote_plus, unquote, urlencode, urlsplit, urlunsplit
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -2171,6 +2171,7 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
     generated_at = stable_generated_at(raw, enrichment_cache)
     guide_center = guide_location_center(display_places)
     suppress_far_map_pins(slug, display_places, guide_center)
+    guide_center = guide_location_center(display_places)
     warn_far_map_pins(slug, display_places, guide_center)
 
     return Guide(
@@ -2607,6 +2608,10 @@ def guide_location_center(places: list[NormalizedPlace]) -> tuple[float | None, 
     return (lat, lng)
 
 
+def guide_geocoded_coordinate_count(places: list[NormalizedPlace]) -> int:
+    return sum(1 for place in places if place.lat is not None and place.lng is not None)
+
+
 def warn_far_map_pins(
     slug: str,
     places: list[NormalizedPlace],
@@ -2638,6 +2643,9 @@ def suppress_far_map_pins(
     places: list[NormalizedPlace],
     center: tuple[float | None, float | None],
 ) -> None:
+    if guide_geocoded_coordinate_count(places) < 4:
+        return
+
     suppression_distance_meters = guide_map_pin_suppression_distance_meters(places, center)
     center_lat, center_lng = center
     if center_lat is None or center_lng is None or suppression_distance_meters is None:
@@ -3883,6 +3891,10 @@ def coerce_string_list(value: Any) -> list[str]:
 
 def google_places_api_key() -> str | None:
     return PlacesSettings().google_places_api_key
+
+
+def google_places_enrichment_strategy() -> Literal["scrape", "api", "scrape_then_api"]:
+    return PlacesSettings().google_places_enrichment_strategy
 
 
 def configured_source_path(source: SourceConfig) -> Path:
@@ -5764,7 +5776,31 @@ def fetch_places_enrichment(
     country_name: str | None = None,
     google_place_id: str | None = None,
     api_key: str | None,
+    strategy: Literal["scrape", "api", "scrape_then_api"] | None = None,
 ) -> EnrichmentCacheEntry:
+    if strategy is None:
+        strategy = google_places_enrichment_strategy()
+
+    if strategy == "scrape":
+        return fetch_place_page_enrichment(
+            place,
+            city_name=city_name,
+            country_name=country_name,
+            google_place_id=google_place_id,
+        )
+
+    if strategy == "api":
+        if api_key is None:
+            raise RuntimeError(
+                "GOOGLE_PLACES_API_KEY is required when GOOGLE_PLACES_ENRICHMENT_STRATEGY=api."
+            )
+        return fetch_places_api_enrichment(
+            place,
+            city_name=city_name,
+            country_name=country_name,
+            api_key=api_key,
+        )
+
     page_entry = fetch_place_page_enrichment(
         place,
         city_name=city_name,
@@ -6036,9 +6072,7 @@ def build_place_page_candidate_urls(
     localized_maps_url = localize_google_maps_scrape_url(maps_url)
     cid = as_string(place.cid) or extract_maps_cid(maps_url)
     cid_url = localize_google_maps_scrape_url(f"https://maps.google.com/?cid={cid}") if cid else None
-
-    if place_id_search_url is not None:
-        return [place_id_search_url]
+    priority_candidates = [place_id_search_url] if place_id_search_url is not None else []
 
     if should_replace_raw_search_candidates_with_locality_bias(
         place,
@@ -6046,7 +6080,7 @@ def build_place_page_candidate_urls(
         search_url=search_url,
     ):
         candidates = [search_url, localized_maps_url, cid_url]
-        return dedupe_urls([url for url in candidates if url is not None])
+        return dedupe_urls([*priority_candidates, *[url for url in candidates if url is not None]])
 
     candidates: list[str] = []
     if should_prefer_search_place_url(maps_url) and search_url is not None:
@@ -6056,7 +6090,7 @@ def build_place_page_candidate_urls(
         candidates.append(cid_url)
     if not should_prefer_search_place_url(maps_url) and search_url is not None:
         candidates.append(search_url)
-    return dedupe_urls(candidates)
+    return dedupe_urls([*priority_candidates, *candidates])
 
 
 def localize_google_maps_scrape_url(url: str) -> str:

--- a/scripts/pipeline_models.py
+++ b/scripts/pipeline_models.py
@@ -23,10 +23,6 @@ class PlacesSettings(BaseSettings):
         default=None,
         validation_alias=AliasChoices("GOOGLE_PLACES_API_KEY", "GOOGLE_MAPS_API_KEY"),
     )
-    google_places_enrichment_strategy: Literal["scrape", "api", "scrape_then_api"] = Field(
-        default="scrape_then_api",
-        validation_alias=AliasChoices("GOOGLE_PLACES_ENRICHMENT_STRATEGY"),
-    )
 
 
 class SourceConfig(PipelineModel):
@@ -218,7 +214,6 @@ class PlaceProvenance(PipelineModel):
     primary_category: PlaceField | None = None
     primary_category_localized: PlaceField | None = None
     tags: list[PlaceField] = Field(default_factory=list)
-    locality_path: PlaceField | None = None
     neighborhood: PlaceField | None = None
     note: PlaceField | None = None
     why_recommended: PlaceField | None = None
@@ -246,7 +241,6 @@ class NormalizedPlace(PipelineModel):
     marker_icon: MarkerIcon = "default"
     tags: list[str] = Field(default_factory=list)
     vibe_tags: list[str] = Field(default_factory=list)
-    locality_path: list[str] = Field(default_factory=list)
     neighborhood: str | None = None
     note: str | None = None
     why_recommended: str | None = None

--- a/scripts/pipeline_models.py
+++ b/scripts/pipeline_models.py
@@ -23,6 +23,10 @@ class PlacesSettings(BaseSettings):
         default=None,
         validation_alias=AliasChoices("GOOGLE_PLACES_API_KEY", "GOOGLE_MAPS_API_KEY"),
     )
+    google_places_enrichment_strategy: Literal["scrape", "api", "scrape_then_api"] = Field(
+        default="scrape_then_api",
+        validation_alias=AliasChoices("GOOGLE_PLACES_ENRICHMENT_STRATEGY"),
+    )
 
 
 class SourceConfig(PipelineModel):

--- a/src/lib/placeTags.ts
+++ b/src/lib/placeTags.ts
@@ -22,6 +22,7 @@ const LOCATION_TAG_ALIASES: Record<string, string[]> = {
 
 interface AreaFilterPlace {
   neighborhood: string | null;
+  locality_path?: string[] | null;
 }
 
 export interface AreaFilter {
@@ -29,6 +30,16 @@ export interface AreaFilter {
   value: string;
   count: number;
 }
+
+export interface AreaFilterGroups {
+  primary: AreaFilter[];
+  secondary: AreaFilter[];
+}
+
+const AREA_LEVEL_KEY_PREFIX = {
+  primary: "",
+  secondary: "broader-",
+} as const;
 
 interface GuideTagContext {
   cityName?: string | null;
@@ -42,6 +53,28 @@ function normalizeAreaText(area: string): string {
     .replace(/[\u0300-\u036f]/g, "")
     .trim()
     .toLowerCase();
+}
+
+function normalizeAreaEquivalenceKey(area: string): string {
+  return normalizeAreaText(area).replace(
+    /-(?:city|ward|district|borough|county|prefecture|province|gu|ku)$/,
+    "",
+  );
+}
+
+function preferAreaLabel(currentLabel: string, candidateLabel: string): string {
+  const currentKey = normalizeAreaEquivalenceKey(currentLabel);
+  const candidateKey = normalizeAreaEquivalenceKey(candidateLabel);
+
+  if (currentKey !== candidateKey) {
+    return currentLabel;
+  }
+
+  if (candidateLabel.length < currentLabel.length) {
+    return candidateLabel;
+  }
+
+  return currentLabel;
 }
 
 export function normalizeTagValue(value: string): string {
@@ -108,37 +141,47 @@ export function getDisplayGuideTags(tags: string[], context: GuideTagContext = {
   });
 }
 
+function collectAreaFilters(
+  places: AreaFilterPlace[],
+  resolveLabel: (place: AreaFilterPlace) => string | null | undefined,
+  level: keyof typeof AREA_LEVEL_KEY_PREFIX,
+): AreaFilter[] {
+  const totalPlaces = places.length;
+  const areaCounts = new Map<string, AreaFilter>();
+
+  places.forEach((place) => {
+    const label = resolveLabel(place)?.trim();
+    if (!label) return;
+
+    const normalizedValue = normalizeAreaEquivalenceKey(label);
+    if (!normalizedValue || STREET_AREA_PATTERN.test(normalizedValue)) return;
+
+    const current = areaCounts.get(normalizedValue);
+    if (current) {
+      current.count += 1;
+      current.label = preferAreaLabel(current.label, label);
+      return;
+    }
+
+    areaCounts.set(normalizedValue, {
+      label,
+      value: `${AREA_LEVEL_KEY_PREFIX[level]}${getTagComparisonValue(normalizedValue)}`,
+      count: 1,
+    });
+  });
+
+  return [...areaCounts.values()]
+    .filter((area) => area.count < totalPlaces)
+    .sort((left, right) => right.count - left.count || left.label.localeCompare(right.label));
+}
+
 export function getGuideAreaFilters(
   places: AreaFilterPlace[],
   { limit = DEFAULT_AREA_FILTER_LIMIT }: { limit?: number } = {},
 ): AreaFilter[] {
   const totalPlaces = places.length;
   const minimumCount = totalPlaces >= 20 ? 3 : 2;
-  const areaCounts = new Map<string, AreaFilter>();
-
-  places.forEach((place) => {
-    const label = place.neighborhood?.trim();
-    if (!label) return;
-
-    const normalizedValue = normalizeAreaText(label);
-    if (!normalizedValue || STREET_AREA_PATTERN.test(normalizedValue)) return;
-
-    const current = areaCounts.get(normalizedValue);
-    if (current) {
-      current.count += 1;
-      return;
-    }
-
-    areaCounts.set(normalizedValue, {
-      label,
-      value: getTagComparisonValue(label),
-      count: 1,
-    });
-  });
-
-  const sortedAreas = [...areaCounts.values()]
-    .filter((area) => area.count < totalPlaces)
-    .sort((left, right) => right.count - left.count || left.label.localeCompare(right.label));
+  const sortedAreas = collectAreaFilters(places, (place) => place.neighborhood, "primary");
 
   const repeatedAreas = sortedAreas.filter((area) => area.count >= minimumCount);
   if (repeatedAreas.length >= limit) {
@@ -146,4 +189,17 @@ export function getGuideAreaFilters(
   }
 
   return sortedAreas.slice(0, limit);
+}
+
+export function getGuideAreaFilterGroups(
+  places: AreaFilterPlace[],
+  { limit = DEFAULT_AREA_FILTER_LIMIT }: { limit?: number } = {},
+): AreaFilterGroups {
+  return {
+    primary: getGuideAreaFilters(places, { limit }),
+    secondary: collectAreaFilters(places, (place) => place.locality_path?.[1], "secondary").slice(
+      0,
+      limit,
+    ),
+  };
 }

--- a/src/lib/placeTags.ts
+++ b/src/lib/placeTags.ts
@@ -7,7 +7,7 @@ const ADDRESS_TAG_PATTERNS = [
 ];
 
 const STREET_AREA_PATTERN =
-  /^(p\.|d\.|ng\.|c\/|c\.|carrer\b|rda\.|calle\b|av\b|av\.|jl\.|jalan\b|ngo\b|duong\b)/;
+  /^(p\.|d\.|ng\.|c\/|c\.|carrer\b|rda\.|calle\b|av\b|av\.|ctra\.|carretera\b|jl\.|jalan\b|ngo\b|duong\b)/;
 const DEFAULT_AREA_FILTER_LIMIT = 12;
 const GUIDE_LOCATION_PART_SPLIT_PATTERN = /\s*(?:&|\/|\+|\band\b)\s*/i;
 const LOCATION_TAG_ALIASES: Record<string, string[]> = {
@@ -22,7 +22,6 @@ const LOCATION_TAG_ALIASES: Record<string, string[]> = {
 
 interface AreaFilterPlace {
   neighborhood: string | null;
-  locality_path?: string[] | null;
 }
 
 export interface AreaFilter {
@@ -30,16 +29,6 @@ export interface AreaFilter {
   value: string;
   count: number;
 }
-
-export interface AreaFilterGroups {
-  primary: AreaFilter[];
-  secondary: AreaFilter[];
-}
-
-const AREA_LEVEL_KEY_PREFIX = {
-  primary: "",
-  secondary: "broader-",
-} as const;
 
 interface GuideTagContext {
   cityName?: string | null;
@@ -53,28 +42,6 @@ function normalizeAreaText(area: string): string {
     .replace(/[\u0300-\u036f]/g, "")
     .trim()
     .toLowerCase();
-}
-
-function normalizeAreaEquivalenceKey(area: string): string {
-  return normalizeAreaText(area).replace(
-    /\s+(?:city|ward|district|borough|county|prefecture|province|gu|ku)$/,
-    "",
-  );
-}
-
-function preferAreaLabel(currentLabel: string, candidateLabel: string): string {
-  const currentKey = normalizeAreaEquivalenceKey(currentLabel);
-  const candidateKey = normalizeAreaEquivalenceKey(candidateLabel);
-
-  if (currentKey !== candidateKey) {
-    return currentLabel;
-  }
-
-  if (candidateLabel.length < currentLabel.length) {
-    return candidateLabel;
-  }
-
-  return currentLabel;
 }
 
 export function normalizeTagValue(value: string): string {
@@ -141,64 +108,42 @@ export function getDisplayGuideTags(tags: string[], context: GuideTagContext = {
   });
 }
 
-function buildAreaFilters(
+export function getGuideAreaFilters(
   places: AreaFilterPlace[],
-  resolveLabel: (place: AreaFilterPlace) => string | null | undefined,
-  level: keyof typeof AREA_LEVEL_KEY_PREFIX,
   { limit = DEFAULT_AREA_FILTER_LIMIT }: { limit?: number } = {},
 ): AreaFilter[] {
   const totalPlaces = places.length;
+  const minimumCount = totalPlaces >= 20 ? 3 : 2;
   const areaCounts = new Map<string, AreaFilter>();
 
   places.forEach((place) => {
-    const label = resolveLabel(place)?.trim();
+    const label = place.neighborhood?.trim();
     if (!label) return;
 
-    const normalizedValue = normalizeAreaEquivalenceKey(label);
+    const normalizedValue = normalizeAreaText(label);
     if (!normalizedValue || STREET_AREA_PATTERN.test(normalizedValue)) return;
 
     const current = areaCounts.get(normalizedValue);
     if (current) {
       current.count += 1;
-      current.label = preferAreaLabel(current.label, label);
       return;
     }
 
     areaCounts.set(normalizedValue, {
       label,
-      value: `${AREA_LEVEL_KEY_PREFIX[level]}${getTagComparisonValue(normalizedValue)}`,
+      value: getTagComparisonValue(label),
       count: 1,
     });
   });
 
-  return [...areaCounts.values()]
+  const sortedAreas = [...areaCounts.values()]
     .filter((area) => area.count < totalPlaces)
-    .sort((left, right) => right.count - left.count || left.label.localeCompare(right.label))
-    .slice(0, limit);
-}
+    .sort((left, right) => right.count - left.count || left.label.localeCompare(right.label));
 
-export function getGuideAreaFilters(
-  places: AreaFilterPlace[],
-  { limit = DEFAULT_AREA_FILTER_LIMIT }: { limit?: number } = {},
-): AreaFilter[] {
-  return buildAreaFilters(
-    places,
-    (place) => place.neighborhood ?? place.locality_path?.[0],
-    "primary",
-    {
-      limit,
-    },
-  );
-}
+  const repeatedAreas = sortedAreas.filter((area) => area.count >= minimumCount);
+  if (repeatedAreas.length >= limit) {
+    return repeatedAreas.slice(0, limit);
+  }
 
-export function getGuideAreaFilterGroups(
-  places: AreaFilterPlace[],
-  { limit = DEFAULT_AREA_FILTER_LIMIT }: { limit?: number } = {},
-): AreaFilterGroups {
-  return {
-    primary: getGuideAreaFilters(places, { limit }),
-    secondary: buildAreaFilters(places, (place) => place.locality_path?.[1], "secondary", {
-      limit,
-    }),
-  };
+  return sortedAreas.slice(0, limit);
 }

--- a/tests/frontend/placeTags.test.ts
+++ b/tests/frontend/placeTags.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   getDisplayGuideTags,
   getDisplayPlaceTags,
-  getGuideAreaFilterGroups,
   getGuideAreaFilters,
   getTagComparisonValue,
   normalizeTagValue,
@@ -40,7 +39,7 @@ describe("getDisplayPlaceTags", () => {
 });
 
 describe("getGuideAreaFilters", () => {
-  it("keeps singleton and repeated area filters while dropping street-like labels", () => {
+  it("keeps repeated area filters and drops one-off or street-like labels", () => {
     expect(
       getGuideAreaFilters(
         [
@@ -58,13 +57,39 @@ describe("getGuideAreaFilters", () => {
           { neighborhood: "C/ d'Aribau" },
           { neighborhood: "One-off" },
         ],
-        { limit: 4 },
+        { limit: 3 },
       ),
     ).toEqual([
       { label: "Ginza", value: "ginza", count: 3 },
       { label: "Juárez", value: "juarez", count: 3 },
       { label: "Shibuya", value: "shibuya", count: 3 },
-      { label: "One-off", value: "one-off", count: 1 },
+    ]);
+  });
+
+  it("backfills with valid one-off areas when repeated neighborhoods are sparse", () => {
+    expect(
+      getGuideAreaFilters(
+        [
+          { neighborhood: "Ciutat Vella" },
+          { neighborhood: "Ciutat Vella" },
+          { neighborhood: "Ciutat Vella" },
+          { neighborhood: "Eixample" },
+          { neighborhood: "Eixample" },
+          { neighborhood: "Eixample" },
+          { neighborhood: "Gràcia" },
+          { neighborhood: "Port Vell" },
+          { neighborhood: "Les Corts" },
+          { neighborhood: "C/ d'Aribau" },
+          { neighborhood: "Ctra. de Miramar" },
+        ],
+        { limit: 5 },
+      ),
+    ).toEqual([
+      { label: "Ciutat Vella", value: "ciutat-vella", count: 3 },
+      { label: "Eixample", value: "eixample", count: 3 },
+      { label: "Gràcia", value: "gracia", count: 1 },
+      { label: "Les Corts", value: "les-corts", count: 1 },
+      { label: "Port Vell", value: "port-vell", count: 1 },
     ]);
   });
 
@@ -91,58 +116,6 @@ describe("getGuideAreaFilters", () => {
       { label: "São Paulo", value: "sao-paulo", count: 3 },
       { label: "Pinheiros", value: "pinheiros", count: 2 },
     ]);
-  });
-
-  it("treats same-level district suffix variants as one primary area bucket", () => {
-    expect(
-      getGuideAreaFilters([
-        { neighborhood: "Zhongshan" },
-        { neighborhood: "Zhongshan District" },
-        { neighborhood: "Da’an District" },
-      ]),
-    ).toEqual([
-      { label: "Zhongshan", value: "zhongshan", count: 2 },
-      { label: "Da’an District", value: "da-an", count: 1 },
-    ]);
-  });
-
-  it("falls back to singleton neighborhoods when no repeated areas exist", () => {
-    expect(
-      getGuideAreaFilters(
-        [
-          { neighborhood: "Lastarria" },
-          { neighborhood: "Providencia" },
-          { neighborhood: "Bellavista" },
-          { neighborhood: "C/ d'Aribau" },
-        ],
-        { limit: 2 },
-      ),
-    ).toEqual([
-      { label: "Bellavista", value: "bellavista", count: 1 },
-      { label: "Lastarria", value: "lastarria", count: 1 },
-    ]);
-  });
-
-  it("returns secondary broader-area filters from the locality path", () => {
-    expect(
-      getGuideAreaFilterGroups([
-        { neighborhood: "Jingumae", locality_path: ["Jingumae", "Shibuya City"] },
-        { neighborhood: "Jinnan", locality_path: ["Jinnan", "Shibuya City"] },
-        { neighborhood: "Shibakoen", locality_path: ["Shibakoen", "Minato City"] },
-        { neighborhood: "Nishiazabu", locality_path: ["Nishiazabu", "Minato City"] },
-      ]),
-    ).toEqual({
-      primary: [
-        { label: "Jingumae", value: "jingumae", count: 1 },
-        { label: "Jinnan", value: "jinnan", count: 1 },
-        { label: "Nishiazabu", value: "nishiazabu", count: 1 },
-        { label: "Shibakoen", value: "shibakoen", count: 1 },
-      ],
-      secondary: [
-        { label: "Minato City", value: "broader-minato", count: 2 },
-        { label: "Shibuya City", value: "broader-shibuya", count: 2 },
-      ],
-    });
   });
 });
 

--- a/tests/frontend/placeTags.test.ts
+++ b/tests/frontend/placeTags.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getDisplayGuideTags,
   getDisplayPlaceTags,
+  getGuideAreaFilterGroups,
   getGuideAreaFilters,
   getTagComparisonValue,
   normalizeTagValue,
@@ -116,6 +117,28 @@ describe("getGuideAreaFilters", () => {
       { label: "São Paulo", value: "sao-paulo", count: 3 },
       { label: "Pinheiros", value: "pinheiros", count: 2 },
     ]);
+  });
+});
+
+describe("getGuideAreaFilterGroups", () => {
+  it("builds broader locality filters with the expected prefix", () => {
+    expect(
+      getGuideAreaFilterGroups([
+        { neighborhood: "Shibuya", locality_path: ["shibuya", "tokyo-ward"] },
+        { neighborhood: "Harajuku", locality_path: ["shibuya", "tokyo-ward"] },
+        { neighborhood: "Ginza", locality_path: ["chuo", "osaka-city"] },
+      ]),
+    ).toEqual({
+      primary: [
+        { label: "Ginza", value: "ginza", count: 1 },
+        { label: "Harajuku", value: "harajuku", count: 1 },
+        { label: "Shibuya", value: "shibuya", count: 1 },
+      ],
+      secondary: [
+        { label: "tokyo-ward", value: "broader-tokyo", count: 2 },
+        { label: "osaka-city", value: "broader-osaka", count: 1 },
+      ],
+    });
   });
 });
 

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -597,6 +597,48 @@ class BuildDataTests(unittest.TestCase):
         )
         self.assertTrue(entry.matched)
         self.assertIsNotNone(entry.place)
+        self.assertEqual(entry.query, "Locale, Tokyo, Japan")
+
+    def test_fetch_places_api_enrichment_uses_city_country_bias_for_name_only_search_urls(self) -> None:
+        place = RawPlace(
+            name="Bilmonte",
+            address=None,
+            maps_url="https://www.google.com/maps/search/?api=1&query=Bilmonte",
+            cid="1343378048703211865",
+            lat=41.3894089,
+            lng=2.1636435,
+        )
+        captured_request_body: dict[str, object] = {}
+
+        class FakeResponse:
+            def __enter__(self) -> "BuildDataTests.test_fetch_places_api_enrichment_uses_city_country_bias_for_name_only_search_urls.<locals>.FakeResponse":
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return b'{"places":[]}'
+
+        def fake_urlopen(request, timeout: int = 20):  # type: ignore[no-untyped-def]
+            self.assertEqual(timeout, 20)
+            captured_request_body.update(json.loads(request.data.decode("utf-8")))
+            return FakeResponse()
+
+        with patch.object(build_data, "urlopen", side_effect=fake_urlopen):
+            entry = build_data.fetch_places_api_enrichment(
+                place,
+                city_name="Barcelona",
+                country_name="Spain",
+                api_key="test-key",
+            )
+
+        self.assertEqual(
+            captured_request_body["textQuery"],
+            "Bilmonte, Barcelona, Spain",
+        )
+        self.assertEqual(entry.query, "Bilmonte, Barcelona, Spain")
+        self.assertFalse(entry.matched)
 
     def test_fetch_place_page_enrichment_falls_back_to_canonical_url_for_weak_search_match(self) -> None:
         place = RawPlace(
@@ -820,6 +862,44 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(
             enrichment.photo_url,
             "https://lh3.googleusercontent.com/p/example=s680-w680-h510",
+        )
+
+    def test_normalize_place_page_enrichment_preserves_google_place_id_and_address_parts(self) -> None:
+        enrichment = build_data.normalize_place_page_enrichment(
+            SimpleNamespace(
+                source_url="https://www.google.com/maps/place/Elephant+Mountain",
+                resolved_url="https://www.google.com/maps/place/Elephant+Mountain",
+                google_place_id="ChIJ8T36HxCLGGARvpARPDyaKLA",
+                name="象山",
+                category="Trailhead",
+                address="2HGG+M6",
+                address_parts=[
+                    "Trailhead",
+                    "Xinyi District, Taipei City",
+                    "Xinyi District, Taipei City",
+                    "Xinyi District",
+                    "110",
+                    "Taipei City",
+                    "TW",
+                    ["Taiwan"],
+                ],
+                limited_view=False,
+            )
+        )
+
+        self.assertEqual(enrichment.google_place_id, "ChIJ8T36HxCLGGARvpARPDyaKLA")
+        self.assertEqual(
+            enrichment.address_parts,
+            [
+                "Trailhead",
+                "Xinyi District, Taipei City",
+                "Xinyi District, Taipei City",
+                "Xinyi District",
+                "110",
+                "Taipei City",
+                "TW",
+                ["Taiwan"],
+            ],
         )
 
     def test_sync_guide_place_photos_downloads_local_copy(self) -> None:
@@ -1580,7 +1660,6 @@ class BuildDataTests(unittest.TestCase):
             first_place.maps_url,
             "https://www.google.com/maps/search/?api=1&query=Coffee+House%2C+1+Shibuya%2C+Tokyo%2C+Japan",
         )
-        self.assertEqual(first_place.locality_path, ["Shibuya"])
         self.assertEqual(first_place.neighborhood, "Shibuya")
         self.assertTrue(first_place.top_pick)
         self.assertIn("local-favorite", first_place.vibe_tags)
@@ -1609,66 +1688,6 @@ class BuildDataTests(unittest.TestCase):
             },
         )
         self.assertTrue(hidden_place.hidden)
-
-    def test_normalize_guide_infers_neighborhood_from_enrichment_address_when_raw_address_missing(self) -> None:
-        raw = RawSavedList(
-            title="Taipei, Taiwan",
-            places=[
-                RawPlace(
-                    name="Museum of Contemporary Art Taipei",
-                    address=None,
-                    lat=25.0508047,
-                    lng=121.5189766,
-                    maps_url="https://maps.google.com/?cid=1",
-                    cid="1",
-                )
-            ],
-        )
-        place_id = build_data.stable_place_id(raw.places[0])
-        enrichment_cache = {
-            place_id: EnrichmentCacheEntry(
-                fetched_at="2026-04-01T00:00:00+00:00",
-                query="Museum of Contemporary Art Taipei, Taipei",
-                matched=True,
-                score=88,
-                place=EnrichmentPlace(
-                    google_maps_uri="https://maps.google.com/?cid=override",
-                    formatted_address="No. 39, Chang'an W Rd, Datong District, Taipei City, Taiwan 103",
-                    primary_type="modern_art_museum",
-                    primary_type_display_name="Modern art museum",
-                    business_status="OPERATIONAL",
-                ),
-            )
-        }
-
-        with TemporaryDirectory() as tmpdir:
-            tmpdir_path = Path(tmpdir)
-            list_overrides_dir = tmpdir_path / "lists"
-            place_overrides_dir = tmpdir_path / "places"
-            list_overrides_dir.mkdir()
-            place_overrides_dir.mkdir()
-
-            with (
-                patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
-                patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
-            ):
-                guide = build_data.normalize_guide(
-                    "taipei-taiwan",
-                    raw,
-                    enrichment_cache=enrichment_cache,
-                )
-
-        first_place = guide.places[0]
-
-        self.assertEqual(
-            first_place.address,
-            "No. 39, Chang'an W Rd, Datong District, Taipei City, Taiwan 103",
-        )
-        self.assertEqual(first_place.locality_path, ["Datong District"])
-        self.assertEqual(first_place.neighborhood, "Datong District")
-        self.assertEqual(first_place.provenance.address.source, "google_places")
-        self.assertEqual(first_place.provenance.locality_path.source, "google_places")
-        self.assertEqual(first_place.provenance.neighborhood.source, "google_places")
 
     def test_place_vibe_tags_can_be_manually_overridden(self) -> None:
         raw = RawSavedList(
@@ -1707,6 +1726,64 @@ class BuildDataTests(unittest.TestCase):
                 )
 
         self.assertEqual(guide.places[0].vibe_tags, ["date-night"])
+
+    def test_normalize_guide_marks_enriched_neighborhood_provenance_when_raw_address_missing(self) -> None:
+        raw = RawSavedList(
+            title="Taipei, Taiwan",
+            places=[
+                RawPlace(
+                    name="象山",
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                ),
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0])
+        enrichment_cache = {
+            place_id: EnrichmentCacheEntry(
+                fetched_at="2026-04-26T00:00:00+00:00",
+                query="象山, Taipei, Taiwan",
+                matched=True,
+                source="google_maps_page",
+                place=EnrichmentPlace(
+                    formatted_address="2HGG+M6",
+                    primary_type="trailhead",
+                    primary_type_display_name="Trailhead",
+                    address_parts=[
+                        "Trailhead",
+                        "Xinyi District, Taipei City",
+                        "Xinyi District, Taipei City",
+                        "Xinyi District",
+                        "110",
+                        "Taipei City",
+                        "TW",
+                        ["Taiwan"],
+                    ],
+                ),
+            ),
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+
+            with (
+                patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+            ):
+                guide = build_data.normalize_guide(
+                    "taipei-taiwan",
+                    raw,
+                    enrichment_cache=enrichment_cache,
+                )
+
+        self.assertEqual(guide.places[0].neighborhood, "Xinyi District")
+        self.assertIsNotNone(guide.places[0].provenance.neighborhood)
+        assert guide.places[0].provenance.neighborhood is not None
+        self.assertEqual(guide.places[0].provenance.neighborhood.source, "google_maps_page")
 
     def test_normalize_guide_excludes_permanently_closed_places_from_ui_counts(self) -> None:
         raw = RawSavedList(
@@ -2138,82 +2215,6 @@ class BuildDataTests(unittest.TestCase):
         )
         self.assertIsNone(place.description)
 
-    def test_normalize_place_page_enrichment_preserves_address_parts(self) -> None:
-        place = build_data.normalize_place_page_enrichment(
-            SimpleNamespace(
-                source_url="https://www.google.com/maps/place/Elephant+Mountain",
-                resolved_url="https://www.google.com/maps/place/Elephant+Mountain",
-                name="象山",
-                category="Trailhead",
-                address="2HGG+M6",
-                address_parts=[
-                    "Trailhead",
-                    "Xinyi District, Taipei City",
-                    "Xinyi District, Taipei City",
-                    "Xinyi District",
-                    "110",
-                    "Taipei City",
-                    "TW",
-                    ["Taiwan"],
-                ],
-                limited_view=False,
-            )
-        )
-
-        self.assertEqual(
-            place.address_parts,
-            [
-                "Trailhead",
-                "Xinyi District, Taipei City",
-                "Xinyi District, Taipei City",
-                "Xinyi District",
-                "110",
-                "Taipei City",
-                "TW",
-                ["Taiwan"],
-            ],
-        )
-
-    def test_normalize_guide_uses_address_parts_for_locality_fallback(self) -> None:
-        raw = RawSavedList(
-            title="Taipei, Taiwan",
-            places=[
-                RawPlace(
-                    name="象山",
-                    maps_url="https://maps.google.com/?cid=111",
-                    cid="111",
-                )
-            ],
-        )
-        place_id = build_data.stable_place_id(raw.places[0])
-        enrichment_cache = {
-            place_id: EnrichmentCacheEntry(
-                fetched_at="2026-04-26T00:00:00+00:00",
-                query="象山, Taipei, Taiwan",
-                matched=True,
-                place=EnrichmentPlace(
-                    formatted_address="2HGG+M6",
-                    primary_type="trailhead",
-                    primary_type_display_name="Trailhead",
-                    address_parts=[
-                        "Trailhead",
-                        "Xinyi District, Taipei City",
-                        "Xinyi District, Taipei City",
-                        "Xinyi District",
-                        "110",
-                        "Taipei City",
-                        "TW",
-                        ["Taiwan"],
-                    ],
-                ),
-            )
-        }
-
-        guide = build_data.normalize_guide("taipei-taiwan", raw, enrichment_cache=enrichment_cache)
-
-        self.assertEqual(guide.places[0].neighborhood, "Xinyi District")
-        self.assertIn("Xinyi District", guide.places[0].locality_path)
-
     def test_normalize_guide_keeps_english_primary_category_and_stores_localized_variant(self) -> None:
         raw = RawSavedList(
             title="Fukuoka",
@@ -2267,54 +2268,6 @@ class BuildDataTests(unittest.TestCase):
             place.types,
             ["restaurant", "japanese_restaurant", "udon_noodle_restaurant"],
         )
-
-    def test_normalize_enrichment_match_drops_generic_item_category(self) -> None:
-        place = build_data.normalize_enrichment_match(
-            {
-                "id": "test-id",
-                "name": "places/test-id",
-                "displayName": {"text": "Elephant Mountain"},
-                "formattedAddress": "Taipei",
-                "googleMapsUri": "https://maps.google.com/?cid=1",
-                "primaryType": "item",
-                "primaryTypeDisplayName": {"text": "Item"},
-                "types": ["establishment", "point_of_interest", "item"],
-            }
-        )
-
-        self.assertIsNone(place.primary_type)
-        self.assertIsNone(place.primary_type_display_name)
-        self.assertEqual(place.types, [])
-
-    def test_normalize_guide_ignores_generic_item_primary_type(self) -> None:
-        raw = RawSavedList(
-            title="Taipei, Taiwan",
-            places=[
-                RawPlace(
-                    name="象山",
-                    maps_url="https://maps.google.com/?cid=111",
-                    cid="111",
-                )
-            ],
-        )
-        place_id = build_data.stable_place_id(raw.places[0])
-        enrichment_cache = {
-            place_id: EnrichmentCacheEntry(
-                fetched_at="2026-04-26T00:00:00+00:00",
-                query="象山, Taipei, Taiwan",
-                matched=True,
-                score=40,
-                place=EnrichmentPlace(
-                    primary_type="item",
-                    primary_type_display_name=None,
-                    types=["item"],
-                ),
-            )
-        }
-
-        guide = build_data.normalize_guide("taipei-taiwan", raw, enrichment_cache=enrichment_cache)
-
-        self.assertIsNone(guide.places[0].primary_category)
 
     def test_derive_marker_icon_uses_place_name_keyword_fallback_without_enrichment(self) -> None:
         test_cases = [
@@ -2598,6 +2551,92 @@ class BuildDataTests(unittest.TestCase):
         self.assertIn("WARNING: tokyo-japan:bad-import", warning)
         self.assertIn("check whether it belongs in this city/country", warning)
 
+    def test_suppress_far_map_pins_clears_extreme_outlier_coordinates(self) -> None:
+        places = [
+            NormalizedPlace(
+                id="tokyo-1",
+                name="Tokyo 1",
+                lat=35.66,
+                lng=139.7,
+                maps_url="https://maps.example/tokyo-1",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="tokyo-2",
+                name="Tokyo 2",
+                lat=35.67,
+                lng=139.71,
+                maps_url="https://maps.example/tokyo-2",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="tokyo-3",
+                name="Tokyo 3",
+                lat=35.65,
+                lng=139.69,
+                maps_url="https://maps.example/tokyo-3",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="bad-import",
+                name="Bad import",
+                lat=48.86,
+                lng=2.35,
+                maps_url="https://maps.example/bad-import",
+                status="active",
+            ),
+        ]
+
+        with patch("builtins.print") as print_mock:
+            build_data.suppress_far_map_pins("tokyo-japan", places, (35.665, 139.705))
+
+        self.assertEqual((places[-1].lat, places[-1].lng), (None, None))
+        suppression_warning = print_mock.call_args.args[0]
+        self.assertIn("Suppressing map pin for tokyo-japan:bad-import", suppression_warning)
+
+    def test_suppress_far_map_pins_keeps_non_extreme_outlier_coordinates(self) -> None:
+        places = [
+            NormalizedPlace(
+                id="la-1",
+                name="Los Angeles 1",
+                lat=34.0522,
+                lng=-118.2437,
+                maps_url="https://maps.example/la-1",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="la-2",
+                name="Los Angeles 2",
+                lat=34.0622,
+                lng=-118.2537,
+                maps_url="https://maps.example/la-2",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="la-3",
+                name="Los Angeles 3",
+                lat=34.0722,
+                lng=-118.2637,
+                maps_url="https://maps.example/la-3",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="far-but-possible",
+                name="Far but possible",
+                lat=34.0522,
+                lng=-119.3537,
+                maps_url="https://maps.example/far-but-possible",
+                status="active",
+            ),
+        ]
+
+        with patch("builtins.print") as print_mock:
+            build_data.suppress_far_map_pins("los-angeles-california-usa", places, (34.0622, -118.2537))
+
+        self.assertIsNotNone(places[-1].lat)
+        self.assertIsNotNone(places[-1].lng)
+        print_mock.assert_not_called()
+
     def test_guide_map_pin_warning_distance_uses_inlier_radius_plus_buffer(self) -> None:
         places = [
             NormalizedPlace(
@@ -2806,18 +2845,109 @@ class BuildDataTests(unittest.TestCase):
                 "Soho",
             ),
             (
-                "104, Taiwan, Taipei City, Zhongshan District, Section 1, Nanjing E Rd, 9號3F",
+                "106 台湾 Taipei City, Da’an District, Section 4, Zhongxiao E Rd, 250-4號1F",
                 "Taipei",
-                {"taipei", "zhongshan-district"},
-                {"nanjing-e-rd"},
-                "Zhongshan District",
+                {"da-an-district", "taipei"},
+                {"taiwan", "taipei-city", "zhongxiao-e-rd"},
+                "Da’an District",
             ),
             (
-                "108, Taiwan, Taipei City, Wanhua District, Huaxi St, 17之4號攤位153號",
-                "Taipei",
-                {"taipei", "wanhua-district"},
-                {"huaxi-st"},
-                "Wanhua District",
+                "Japan, 044-0081 Hokkaido, Abuta District, Kutchan, Yamada, 132-26",
+                "Niseko",
+                {"kutchan", "yamada", "niseko"},
+                {"hokkaido"},
+                "Kutchan",
+            ),
+            (
+                "2 Chome-7-22 Asato, Naha, Okinawa 902-0067, Japan",
+                "Okinawa Main Island",
+                {"asato", "naha", "okinawa-main-island"},
+                {"okinawa"},
+                "Asato",
+            ),
+            (
+                "C/ de Manso, 22, L'Eixample, 08015 Barcelona, Spain",
+                "Barcelona",
+                {"l-eixample", "barcelona"},
+                {"c-de-manso"},
+                "L'Eixample",
+            ),
+            (
+                "Carrer de Blai, 47, Sants-Montjuïc, 08004 Barcelona, Spain",
+                "Barcelona",
+                {"sants-montjuic", "barcelona"},
+                {"carrer-de-blai"},
+                "Sants-Montjuïc",
+            ),
+            (
+                "Plaça Comercial, 10, Ciutat Vella, 08003 Barcelona, Spain",
+                "Barcelona",
+                {"ciutat-vella", "barcelona"},
+                {"placa-comercial"},
+                "Ciutat Vella",
+            ),
+            (
+                "La Rambla, 124, Ciutat Vella, 08002 Barcelona, スペイン",
+                "Barcelona",
+                {"ciutat-vella", "barcelona"},
+                {"スペイン"},
+                "Ciutat Vella",
+            ),
+            (
+                "Av. del Paral·lel, 126 bis, Eixample, 08015 Barcelona, Spain",
+                "Barcelona",
+                {"eixample", "barcelona"},
+                {"bis", "av-del-parallel"},
+                "Eixample",
+            ),
+            (
+                "Pl. de Carles Buïgas, 1, Sants-Montjuïc, 08038 Barcelona, Spain",
+                "Barcelona",
+                {"sants-montjuic", "barcelona"},
+                {"pl-de-carles-buigas"},
+                "Sants-Montjuïc",
+            ),
+            (
+                "Moll dels Pescadors, 1, Barceloneta, Ciutat Vella, 08003 Barcelona, Spain",
+                "Barcelona",
+                {"barceloneta", "ciutat-vella", "barcelona"},
+                {"moll-dels-pescadors"},
+                "Barceloneta",
+            ),
+            (
+                "Dentro del restaurante The Lobster Roll, Carrer del Rec Comtal, 12, Eixample, 08003 Barcelona, Spain",
+                "Barcelona",
+                {"eixample", "barcelona"},
+                {"dentro-del-restaurante-the-lobster-roll"},
+                "Eixample",
+            ),
+            (
+                "Carrer de Marià Labèrnia, s/n, El Carmel, Horta-Guinardó, 08032 Barcelona, Spain",
+                "Barcelona",
+                {"el-carmel", "horta-guinardo", "barcelona"},
+                {"s-n"},
+                "El Carmel",
+            ),
+            (
+                "144 Elizabeth St, Hobart TAS 7000, Australia",
+                "Tasmania",
+                {"hobart", "tasmania"},
+                {"tas"},
+                "Hobart",
+            ),
+            (
+                "26-28 Cotham Rd, Kew VIC 3101, Australia",
+                "Melbourne",
+                {"kew", "melbourne"},
+                {"vic"},
+                "Kew",
+            ),
+            (
+                "Council Pl, Sydney NSW 2000, Australia",
+                "Sydney",
+                {"sydney"},
+                {"nsw", "council-pl"},
+                None,
             ),
         ]
 
@@ -3363,10 +3493,7 @@ class BuildDataTests(unittest.TestCase):
             limited_view=False,
         )
 
-        with (
-            patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
-            patch.object(build_data, "scrape_place", return_value=details) as scrape,
-        ):
+        with patch.object(build_data, "scrape_place", return_value=details) as scrape:
             entry = build_data.fetch_places_enrichment(place, api_key=None)
 
         scrape.assert_called_once()
@@ -3376,94 +3503,6 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(entry.place.primary_type, "japanese_restaurant")
         self.assertEqual(entry.place.user_rating_count, 324)
         self.assertEqual(entry.place.business_status, "OPERATIONAL")
-
-    def test_fetch_places_enrichment_uses_scrape_strategy_without_api_fallback(self) -> None:
-        place = RawPlace(
-            name="Jimbocho Den",
-            address="Tokyo, Japan",
-            maps_url="https://www.google.com/maps/place/Jimbocho+Den",
-        )
-        page_entry = EnrichmentCacheEntry(
-            fetched_at="2026-04-16T00:00:00+00:00",
-            refresh_after="2026-04-19T00:00:00+00:00",
-            source="google_maps_page",
-            query="Jimbocho Den, Tokyo, Japan",
-            matched=True,
-            score=45,
-            place=EnrichmentPlace(
-                display_name="Jimbocho Den",
-                formatted_address="Tokyo, Japan",
-                google_maps_uri=place.maps_url,
-                limited_view=True,
-            ),
-        )
-
-        with (
-            patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape"),
-            patch.object(build_data, "fetch_place_page_enrichment", return_value=page_entry) as page_fetch,
-            patch.object(build_data, "fetch_places_api_enrichment") as api_fetch,
-        ):
-            entry = build_data.fetch_places_enrichment(place, api_key="test-key")
-
-        page_fetch.assert_called_once_with(
-            place,
-            city_name=None,
-            country_name=None,
-            google_place_id=None,
-        )
-        api_fetch.assert_not_called()
-        self.assertIs(entry, page_entry)
-
-    def test_fetch_places_enrichment_uses_api_strategy_without_scraping(self) -> None:
-        place = RawPlace(
-            name="Jimbocho Den",
-            address="Tokyo, Japan",
-            maps_url="https://www.google.com/maps/place/Jimbocho+Den",
-        )
-        api_entry = EnrichmentCacheEntry(
-            fetched_at="2026-04-16T00:00:00+00:00",
-            refresh_after="2026-04-23T00:00:00+00:00",
-            source="google_places_api",
-            query="Jimbocho Den, Tokyo, Japan",
-            matched=True,
-            score=88,
-            place=EnrichmentPlace(
-                display_name="Jimbocho Den",
-                formatted_address="Tokyo, Japan",
-                google_maps_uri="https://maps.google.com/?cid=1",
-                primary_type="restaurant",
-                primary_type_display_name="Restaurant",
-            ),
-        )
-
-        with (
-            patch.object(build_data, "google_places_enrichment_strategy", return_value="api"),
-            patch.object(build_data, "fetch_place_page_enrichment") as page_fetch,
-            patch.object(build_data, "fetch_places_api_enrichment", return_value=api_entry) as api_fetch,
-        ):
-            entry = build_data.fetch_places_enrichment(place, api_key="test-key")
-
-        page_fetch.assert_not_called()
-        api_fetch.assert_called_once_with(place, api_key="test-key")
-        self.assertIs(entry, api_entry)
-
-    def test_fetch_places_enrichment_fails_for_api_strategy_without_key(self) -> None:
-        place = RawPlace(
-            name="Jimbocho Den",
-            address="Tokyo, Japan",
-            maps_url="https://www.google.com/maps/place/Jimbocho+Den",
-        )
-
-        with (
-            patch.object(build_data, "google_places_enrichment_strategy", return_value="api"),
-            patch.object(build_data, "fetch_place_page_enrichment") as page_fetch,
-            patch.object(build_data, "fetch_places_api_enrichment") as api_fetch,
-        ):
-            with self.assertRaisesRegex(RuntimeError, "GOOGLE_PLACES_API_KEY is required"):
-                build_data.fetch_places_enrichment(place, api_key=None)
-
-        page_fetch.assert_not_called()
-        api_fetch.assert_not_called()
 
     def test_fetch_place_page_enrichment_rewrites_cid_url_before_scraping(self) -> None:
         place = RawPlace(
@@ -3509,32 +3548,6 @@ class BuildDataTests(unittest.TestCase):
         self.assertTrue(entry.matched)
         self.assertEqual(entry.place.display_name, "Cantina OK!")
 
-    def test_build_place_page_candidate_urls_prefers_query_place_id_when_available(self) -> None:
-        place = RawPlace(
-            name="Locale",
-            address=None,
-            maps_url="https://www.google.com/maps/search/?api=1&query=Locale",
-            cid="6924437521980544303",
-            lat=35.636208,
-            lng=139.709467,
-        )
-
-        self.assertEqual(
-            build_data.build_place_page_candidate_urls(
-                place,
-                city_name="Tokyo",
-                country_name="Japan",
-                google_place_id="ChIJ1234567890example",
-            ),
-            [
-                (
-                    "https://www.google.com/maps/search/?api=1"
-                    "&query=Locale%2C+Tokyo%2C+Japan"
-                    "&query_place_id=ChIJ1234567890example&hl=en&gl=us"
-                )
-            ],
-        )
-
     def test_fetch_places_enrichment_falls_back_to_api_when_page_is_limited(self) -> None:
         place = RawPlace(
             name="Jimbocho Den",
@@ -3572,7 +3585,6 @@ class BuildDataTests(unittest.TestCase):
         )
 
         with (
-            patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
             patch.object(build_data, "fetch_place_page_enrichment", return_value=page_entry) as page_fetch,
             patch.object(build_data, "fetch_places_api_enrichment", return_value=api_entry) as api_fetch,
         ):
@@ -3584,7 +3596,12 @@ class BuildDataTests(unittest.TestCase):
             country_name=None,
             google_place_id=None,
         )
-        api_fetch.assert_called_once_with(place, api_key="test-key")
+        api_fetch.assert_called_once_with(
+            place,
+            city_name=None,
+            country_name=None,
+            api_key="test-key",
+        )
         self.assertIs(entry, api_entry)
 
     def test_fetch_places_enrichment_keeps_page_result_when_api_fallback_fails(self) -> None:
@@ -3617,7 +3634,6 @@ class BuildDataTests(unittest.TestCase):
         )
 
         with (
-            patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
             patch.object(build_data, "fetch_place_page_enrichment", return_value=page_entry) as page_fetch,
             patch.object(build_data, "fetch_places_api_enrichment", return_value=api_entry) as api_fetch,
         ):
@@ -3629,7 +3645,12 @@ class BuildDataTests(unittest.TestCase):
             country_name=None,
             google_place_id=None,
         )
-        api_fetch.assert_called_once_with(place, api_key="test-key")
+        api_fetch.assert_called_once_with(
+            place,
+            city_name=None,
+            country_name=None,
+            api_key="test-key",
+        )
         self.assertIs(entry, page_entry)
 
     def test_normalize_place_page_enrichment_omits_maps_uri_for_url_only_result(self) -> None:
@@ -3836,11 +3857,10 @@ class BuildDataTests(unittest.TestCase):
                 patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
                 patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
                 patch.object(build_data, "google_places_api_key", return_value=None),
-                patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
                 patch.object(
                     build_data,
                     "cache_refresh_reason",
-                    side_effect=lambda place, _cache_entry: {
+                    side_effect=lambda place, _cache_entry, **_kwargs: {
                         "Expired Place": "refresh-window-expired",
                         "Missing Place": "missing-cache-entry",
                     }[place.name],
@@ -3855,128 +3875,6 @@ class BuildDataTests(unittest.TestCase):
                 )
 
             self.assertEqual(seen_reasons, ["missing-cache-entry"])
-
-    def test_enrich_raw_sources_fails_for_api_strategy_without_key(self) -> None:
-        raw = RawSavedList(
-            title="Tokyo",
-            places=[
-                RawPlace(name="Missing Place", maps_url="https://maps.google.com/?cid=222", cid="222"),
-            ],
-        )
-
-        with TemporaryDirectory() as tmpdir:
-            tmpdir_path = Path(tmpdir)
-            raw_dir = tmpdir_path / "raw"
-            cache_dir = tmpdir_path / "cache"
-            db_path = tmpdir_path / "places.sqlite"
-            raw_dir.mkdir()
-            cache_dir.mkdir()
-            (raw_dir / "tokyo-japan.json").write_text(
-                json.dumps(raw.model_dump(mode="json"), ensure_ascii=False),
-                encoding="utf-8",
-            )
-
-            with (
-                patch.object(build_data, "RAW_DIR", raw_dir),
-                patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
-                patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
-                patch.object(build_data, "google_places_api_key", return_value=None),
-                patch.object(build_data, "google_places_enrichment_strategy", return_value="api"),
-                patch.object(build_data, "enrich_place_job") as enrich_job,
-            ):
-                with self.assertRaisesRegex(RuntimeError, "GOOGLE_PLACES_API_KEY is required"):
-                    build_data.enrich_raw_sources(
-                        force_refresh=True,
-                        refresh_workers=1,
-                        refresh_startup_jitter_seconds=0,
-                    )
-
-            enrich_job.assert_not_called()
-            self.assertEqual(list(cache_dir.iterdir()), [])
-
-    def test_enrich_raw_sources_allows_api_strategy_without_key_when_no_jobs_run(self) -> None:
-        raw = RawSavedList(
-            title="Tokyo",
-            places=[
-                RawPlace(name="Cached Place", maps_url="https://maps.google.com/?cid=222", cid="222"),
-            ],
-        )
-
-        with TemporaryDirectory() as tmpdir:
-            tmpdir_path = Path(tmpdir)
-            raw_dir = tmpdir_path / "raw"
-            cache_dir = tmpdir_path / "cache"
-            db_path = tmpdir_path / "places.sqlite"
-            raw_dir.mkdir()
-            cache_dir.mkdir()
-            (raw_dir / "tokyo-japan.json").write_text(
-                json.dumps(raw.model_dump(mode="json"), ensure_ascii=False),
-                encoding="utf-8",
-            )
-
-            with (
-                patch.object(build_data, "RAW_DIR", raw_dir),
-                patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
-                patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
-                patch.object(build_data, "google_places_api_key", return_value=None),
-                patch.object(build_data, "google_places_enrichment_strategy", return_value="api"),
-                patch.object(build_data, "cache_refresh_reason", return_value=None),
-                patch.object(build_data, "enrich_place_job") as enrich_job,
-            ):
-                build_data.enrich_raw_sources(
-                    force_refresh=False,
-                    refresh_workers=1,
-                    refresh_startup_jitter_seconds=0,
-                )
-
-            enrich_job.assert_not_called()
-
-    def test_enrich_raw_sources_warns_when_api_fallback_is_unavailable(self) -> None:
-        raw = RawSavedList(
-            title="Tokyo",
-            places=[
-                RawPlace(name="Missing Place", maps_url="https://maps.google.com/?cid=222", cid="222"),
-            ],
-        )
-
-        with TemporaryDirectory() as tmpdir:
-            tmpdir_path = Path(tmpdir)
-            raw_dir = tmpdir_path / "raw"
-            cache_dir = tmpdir_path / "cache"
-            db_path = tmpdir_path / "places.sqlite"
-            raw_dir.mkdir()
-            cache_dir.mkdir()
-            (raw_dir / "tokyo-japan.json").write_text(
-                json.dumps(raw.model_dump(mode="json"), ensure_ascii=False),
-                encoding="utf-8",
-            )
-
-            def fake_enrich_place_job(_slug, _place_id, _place_name, _refresh_reason, _place_payload, **kwargs):
-                self.assertEqual(kwargs["strategy"], "scrape_then_api")
-                return EnrichmentCacheEntry(
-                    fetched_at="2026-04-20T00:00:00+00:00",
-                    query="Missing Place, Tokyo",
-                    matched=True,
-                    place=EnrichmentPlace(display_name="Missing Place"),
-                )
-
-            stdout = StringIO()
-            with (
-                redirect_stdout(stdout),
-                patch.object(build_data, "RAW_DIR", raw_dir),
-                patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
-                patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
-                patch.object(build_data, "google_places_api_key", return_value=None),
-                patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
-                patch.object(build_data, "enrich_place_job", side_effect=fake_enrich_place_job),
-            ):
-                build_data.enrich_raw_sources(
-                    force_refresh=True,
-                    refresh_workers=1,
-                    refresh_startup_jitter_seconds=0,
-                )
-
-            self.assertIn("without Google Places API fallback", stdout.getvalue())
 
     def test_enrich_raw_sources_prioritizes_missing_entries_before_expired_refreshes(self) -> None:
         raw = RawSavedList(
@@ -4015,11 +3913,10 @@ class BuildDataTests(unittest.TestCase):
                 patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
                 patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
                 patch.object(build_data, "google_places_api_key", return_value=None),
-                patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
                 patch.object(
                     build_data,
                     "cache_refresh_reason",
-                    side_effect=lambda place, _cache_entry: {
+                    side_effect=lambda place, _cache_entry, **_kwargs: {
                         "Expired Place": "refresh-window-expired",
                         "Missing Place": "missing-cache-entry",
                     }[place.name],
@@ -4123,7 +4020,6 @@ class BuildDataTests(unittest.TestCase):
                 patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
                 patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
                 patch.object(build_data, "google_places_api_key", return_value=None),
-                patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
                 patch.object(build_data, "ThreadPoolExecutor", FakeExecutor),
                 patch.object(build_data, "as_completed", return_value=[first_future, second_future]),
             ):
@@ -4161,6 +4057,63 @@ class BuildDataTests(unittest.TestCase):
             build_data.place_input_signature(first_place),
             build_data.place_input_signature(second_place),
         )
+
+    def test_enrichment_input_signature_includes_locality_bias_context(self) -> None:
+        place = RawPlace(
+            name="Bilmonte",
+            address=None,
+            maps_url="https://www.google.com/maps/search/?api=1&query=Bilmonte",
+            cid="1343378048703211865",
+            lat=41.3894089,
+            lng=2.1636435,
+        )
+
+        generic_signature = build_data.enrichment_input_signature(place)
+        barcelona_signature = build_data.enrichment_input_signature(
+            place,
+            city_name="Barcelona",
+            country_name="Spain",
+        )
+        madrid_signature = build_data.enrichment_input_signature(
+            place,
+            city_name="Madrid",
+            country_name="Spain",
+        )
+
+        self.assertNotEqual(generic_signature, barcelona_signature)
+        self.assertNotEqual(barcelona_signature, madrid_signature)
+
+    def test_cache_refresh_reason_invalidates_legacy_unbiased_name_only_search_entry(self) -> None:
+        place = RawPlace(
+            name="Bilmonte",
+            address=None,
+            maps_url="https://www.google.com/maps/search/?api=1&query=Bilmonte",
+            cid="1343378048703211865",
+            lat=41.3894089,
+            lng=2.1636435,
+        )
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-19T16:47:26.628975+00:00",
+            refresh_after="2026-05-19T16:47:26.628975+00:00",
+            source="google_maps_page",
+            query="Bilmonte",
+            input_signature=build_data.place_input_signature(place),
+            matched=True,
+            score=build_data.STRONG_MATCH_SCORE,
+            place=EnrichmentPlace(
+                display_name="Bilmonte",
+                formatted_address="30 Great Windmill St, London W1D 7LW, United Kingdom",
+            ),
+        )
+
+        refresh_reason = build_data.cache_refresh_reason(
+            place,
+            cache_entry,
+            city_name="Barcelona",
+            country_name="Spain",
+        )
+
+        self.assertEqual(refresh_reason, "raw-place-changed")
 
     def test_build_places_sqlite_signature_changes_when_version_or_schema_changes(self) -> None:
         raw = RawSavedList(
@@ -4421,6 +4374,235 @@ class BuildDataTests(unittest.TestCase):
                 )
             finally:
                 connection.close()
+
+    def test_rebuild_places_sqlite_hydrates_matching_guide_cache_photo_urls(self) -> None:
+        shared_place_id = "cid:111"
+        photo_url = "https://images.example/shared-photo.webp"
+        kanazawa_raw = RawSavedList(
+            configured_source_type="google_list_url",
+            title="Kanazawa",
+            places=[
+                RawPlace(
+                    name="Shared Place",
+                    address="1 Kanazawa, Japan",
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                )
+            ],
+        )
+        toyama_raw = RawSavedList(
+            configured_source_type="google_list_url",
+            title="Toyama",
+            places=[
+                RawPlace(
+                    name="Shared Place",
+                    address="1 Toyama, Japan",
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                )
+            ],
+        )
+        kanazawa_guide = Guide(
+            slug="kanazawa-japan",
+            title="Kanazawa",
+            country_name="Japan",
+            city_name="Kanazawa",
+            generated_at="2026-04-20T00:00:00+00:00",
+            place_count=1,
+            places=[
+                NormalizedPlace(
+                    id=shared_place_id,
+                    name="Shared Place",
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                    google_place_id="place-123",
+                    google_place_resource_name="places/place-123",
+                    status="active",
+                )
+            ],
+        )
+        toyama_guide = Guide(
+            slug="toyama-japan",
+            title="Toyama",
+            country_name="Japan",
+            city_name="Toyama",
+            generated_at="2026-04-20T00:00:00+00:00",
+            place_count=1,
+            places=[
+                NormalizedPlace(
+                    id=shared_place_id,
+                    name="Shared Place",
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                    google_place_id="place-123",
+                    google_place_resource_name="places/place-123",
+                    main_photo_path="/place-photos/shared-photo.webp",
+                    status="active",
+                )
+            ],
+        )
+        kanazawa_cache_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="Shared Place, Kanazawa",
+            matched=True,
+            place=EnrichmentPlace(
+                google_place_id="place-123",
+                google_place_resource_name="places/place-123",
+                display_name="Shared Place",
+            ),
+        )
+        toyama_cache_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-21T00:00:00+00:00",
+            query="Shared Place, Toyama",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="Shared Place",
+                main_photo_url=photo_url,
+                photo_url=photo_url,
+            ),
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            db_path = tmpdir_path / "cache" / "places.sqlite"
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+
+            with (
+                patch.object(build_data, "ROOT", tmpdir_path),
+                patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
+            ):
+                build_data.rebuild_places_sqlite(
+                    raw_lists={
+                        "kanazawa-japan": kanazawa_raw,
+                        "toyama-japan": toyama_raw,
+                    },
+                    guides=[kanazawa_guide, toyama_guide],
+                    enrichment_caches={
+                        "kanazawa-japan": {shared_place_id: kanazawa_cache_entry},
+                        "toyama-japan": {shared_place_id: toyama_cache_entry},
+                    },
+                )
+
+            connection = sqlite3.connect(db_path)
+            try:
+                sqlite_cache_entry = connection.execute(
+                    """
+                    SELECT cache_json
+                    FROM guide_enrichment_cache
+                    WHERE guide_slug = ? AND place_id = ?
+                    """,
+                    ("kanazawa-japan", shared_place_id),
+                ).fetchone()
+                self.assertIsNotNone(sqlite_cache_entry)
+                assert sqlite_cache_entry is not None
+                place_payload = json.loads(sqlite_cache_entry[0])["place"]
+                self.assertEqual(place_payload["main_photo_url"], photo_url)
+                self.assertEqual(place_payload["photo_url"], photo_url)
+            finally:
+                connection.close()
+
+    def test_build_places_sqlite_rows_keeps_identified_canonical_row_over_unidentified_collision(self) -> None:
+        shared_place_id = "cid:222"
+        oita_raw = RawSavedList(
+            configured_source_type="google_list_url",
+            title="Oita",
+            places=[
+                RawPlace(
+                    name="Milch",
+                    address="1 Oita, Japan",
+                    maps_url="https://maps.google.com/?cid=222",
+                    cid="222",
+                )
+            ],
+        )
+        yufuin_raw = RawSavedList(
+            configured_source_type="google_list_url",
+            title="Yufuin",
+            places=[
+                RawPlace(
+                    name="Share",
+                    address="1 Yufuin, Japan",
+                    maps_url="https://maps.google.com/?cid=222",
+                    cid="222",
+                )
+            ],
+        )
+        oita_guide = Guide(
+            slug="oita-japan",
+            title="Oita",
+            country_name="Japan",
+            city_name="Oita",
+            generated_at="2026-04-20T00:00:00+00:00",
+            place_count=1,
+            places=[
+                NormalizedPlace(
+                    id=shared_place_id,
+                    name="Milch",
+                    maps_url="https://maps.google.com/?cid=222",
+                    cid="222",
+                    google_place_id="place-milch",
+                    google_place_resource_name="places/place-milch",
+                    status="active",
+                )
+            ],
+        )
+        yufuin_guide = Guide(
+            slug="yufuin-japan",
+            title="Yufuin",
+            country_name="Japan",
+            city_name="Yufuin",
+            generated_at="2026-04-20T00:00:00+00:00",
+            place_count=1,
+            places=[
+                NormalizedPlace(
+                    id=shared_place_id,
+                    name="Share",
+                    maps_url="https://maps.google.com/?cid=222",
+                    cid="222",
+                    main_photo_path="/place-photos/share.webp",
+                    user_rating_count=100,
+                    status="active",
+                )
+            ],
+        )
+        oita_cache_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="Milch, Oita",
+            matched=True,
+            place=EnrichmentPlace(
+                google_place_id="place-milch",
+                google_place_resource_name="places/place-milch",
+                display_name="Milch",
+            ),
+        )
+        yufuin_cache_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-21T00:00:00+00:00",
+            query="Share, Yufuin",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="Share",
+                photo_url="https://images.example/share.webp",
+            ),
+        )
+
+        rows = build_data.build_places_sqlite_rows(
+            raw_lists={
+                "oita-japan": oita_raw,
+                "yufuin-japan": yufuin_raw,
+            },
+            guides=[oita_guide, yufuin_guide],
+            enrichment_caches={
+                "oita-japan": {shared_place_id: oita_cache_entry},
+                "yufuin-japan": {shared_place_id: yufuin_cache_entry},
+            },
+        )
+
+        self.assertEqual(len(rows.canonical_place_rows), 1)
+        canonical_row = rows.canonical_place_rows[0]
+        self.assertEqual(canonical_row[1], "oita-japan")
+        self.assertEqual(canonical_row[10], "Milch")
+        self.assertEqual(canonical_row[43], "place-milch")
+        self.assertIsNone(canonical_row[59])
 
     def test_rebuild_places_sqlite_skips_rewrite_when_signature_matches(self) -> None:
         raw = RawSavedList(
@@ -4700,7 +4882,6 @@ class BuildDataTests(unittest.TestCase):
                 patch.object(build_data, "RAW_DIR", raw_dir),
                 patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
                 patch.object(build_data, "google_places_api_key", return_value=None),
-                patch.object(build_data, "google_places_enrichment_strategy", return_value="scrape_then_api"),
                 patch.object(build_data, "ThreadPoolExecutor", FakeExecutor),
                 patch.object(build_data, "as_completed", return_value=[future]),
                 patch("builtins.print"),

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -466,6 +466,33 @@ class BuildDataTests(unittest.TestCase):
             ],
         )
 
+    def test_build_place_page_candidate_urls_keeps_fallbacks_when_google_place_id_is_present(self) -> None:
+        place = RawPlace(
+            name="Cantina OK!",
+            address="Council Pl, Sydney NSW 2000, Australia",
+            maps_url="https://maps.google.com/?cid=7715422616180689913",
+            cid="7715422616180689913",
+        )
+
+        self.assertEqual(
+            build_data.build_place_page_candidate_urls(
+                place,
+                google_place_id="ChIJGcmcg7ZC1moRAOacd3HoEwM",
+            ),
+            [
+                (
+                    "https://www.google.com/maps/search/?api=1"
+                    "&query=Cantina+OK%21%2C+Council+Pl%2C+Sydney+NSW+2000%2C+Australia"
+                    "&query_place_id=ChIJGcmcg7ZC1moRAOacd3HoEwM&hl=en&gl=us"
+                ),
+                (
+                    "https://www.google.com/maps/search/?api=1"
+                    "&query=Cantina+OK%21%2C+Council+Pl%2C+Sydney+NSW+2000%2C+Australia&hl=en&gl=us"
+                ),
+                "https://maps.google.com/?cid=7715422616180689913&hl=en&gl=us",
+            ],
+        )
+
     def test_localize_google_maps_scrape_url_forces_english_locale(self) -> None:
         self.assertEqual(
             build_data.localize_google_maps_scrape_url(
@@ -611,7 +638,7 @@ class BuildDataTests(unittest.TestCase):
         captured_request_body: dict[str, object] = {}
 
         class FakeResponse:
-            def __enter__(self) -> "BuildDataTests.test_fetch_places_api_enrichment_uses_city_country_bias_for_name_only_search_urls.<locals>.FakeResponse":
+            def __enter__(self) -> "FakeResponse":
                 return self
 
             def __exit__(self, exc_type, exc, tb) -> None:
@@ -2637,6 +2664,44 @@ class BuildDataTests(unittest.TestCase):
         self.assertIsNotNone(places[-1].lng)
         print_mock.assert_not_called()
 
+    def test_suppress_far_map_pins_skips_sparse_guides(self) -> None:
+        places = [
+            NormalizedPlace(
+                id="tokyo-1",
+                name="Tokyo 1",
+                lat=35.66,
+                lng=139.7,
+                maps_url="https://maps.example/tokyo-1",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="tokyo-2",
+                name="Tokyo 2",
+                lat=35.67,
+                lng=139.71,
+                maps_url="https://maps.example/tokyo-2",
+                status="active",
+            ),
+            NormalizedPlace(
+                id="bad-import",
+                name="Bad import",
+                lat=48.86,
+                lng=2.35,
+                maps_url="https://maps.example/bad-import",
+                status="active",
+            ),
+        ]
+
+        with patch("builtins.print") as print_mock:
+            build_data.suppress_far_map_pins(
+                "tokyo-japan",
+                places,
+                build_data.guide_location_center(places),
+            )
+
+        self.assertEqual((places[-1].lat, places[-1].lng), (48.86, 2.35))
+        print_mock.assert_not_called()
+
     def test_guide_map_pin_warning_distance_uses_inlier_radius_plus_buffer(self) -> None:
         places = [
             NormalizedPlace(
@@ -3132,6 +3197,47 @@ class BuildDataTests(unittest.TestCase):
             ),
         )
 
+    def test_normalize_guide_recomputes_center_after_pin_suppression(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo, Japan",
+            places=[
+                RawPlace(
+                    name="Tokyo 1",
+                    address="1 Shibuya, Tokyo, Japan",
+                    lat=35.66,
+                    lng=139.70,
+                    maps_url="https://maps.google.com/?cid=1",
+                    cid="1",
+                ),
+                RawPlace(
+                    name="Tokyo 2",
+                    address="2 Shibuya, Tokyo, Japan",
+                    lat=35.67,
+                    lng=139.71,
+                    maps_url="https://maps.google.com/?cid=2",
+                    cid="2",
+                ),
+            ],
+        )
+
+        def suppress_and_mutate(
+            _slug: str,
+            places: list[NormalizedPlace],
+            _center: tuple[float | None, float | None],
+        ) -> None:
+            places[-1].lat = None
+            places[-1].lng = None
+
+        with (
+            patch.object(build_data, "suppress_far_map_pins", side_effect=suppress_and_mutate),
+            patch.object(build_data, "warn_far_map_pins") as warn_mock,
+        ):
+            guide = build_data.normalize_guide("tokyo-japan", raw, enrichment_cache={})
+
+        self.assertAlmostEqual(guide.center_lat or 0, 35.66, places=3)
+        self.assertAlmostEqual(guide.center_lng or 0, 139.70, places=3)
+        self.assertEqual(warn_mock.call_args.args[2], (guide.center_lat, guide.center_lng))
+
     def test_resolve_refresh_sources_matches_csv_path_selector(self) -> None:
         sources = [
             SourceConfig(
@@ -3494,7 +3600,11 @@ class BuildDataTests(unittest.TestCase):
         )
 
         with patch.object(build_data, "scrape_place", return_value=details) as scrape:
-            entry = build_data.fetch_places_enrichment(place, api_key=None)
+            entry = build_data.fetch_places_enrichment(
+                place,
+                api_key=None,
+                strategy="scrape_then_api",
+            )
 
         scrape.assert_called_once()
         self.assertEqual(entry.source, "google_maps_page")
@@ -3548,6 +3658,108 @@ class BuildDataTests(unittest.TestCase):
         self.assertTrue(entry.matched)
         self.assertEqual(entry.place.display_name, "Cantina OK!")
 
+    def test_fetch_places_enrichment_uses_scrape_strategy_without_api_fallback(self) -> None:
+        place = RawPlace(
+            name="Jimbocho Den",
+            address="Tokyo, Japan",
+            maps_url="https://www.google.com/maps/place/Jimbocho+Den",
+        )
+        page_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-16T00:00:00+00:00",
+            refresh_after="2026-04-19T00:00:00+00:00",
+            source="google_maps_page",
+            query="Jimbocho Den, Tokyo, Japan",
+            matched=True,
+            score=45,
+            place=EnrichmentPlace(
+                display_name="Jimbocho Den",
+                formatted_address="Tokyo, Japan",
+                google_maps_uri=place.maps_url,
+                limited_view=True,
+            ),
+        )
+
+        with (
+            patch.object(build_data, "fetch_place_page_enrichment", return_value=page_entry) as page_fetch,
+            patch.object(build_data, "fetch_places_api_enrichment") as api_fetch,
+        ):
+            entry = build_data.fetch_places_enrichment(
+                place,
+                api_key="test-key",
+                strategy="scrape",
+            )
+
+        page_fetch.assert_called_once_with(
+            place,
+            city_name=None,
+            country_name=None,
+            google_place_id=None,
+        )
+        api_fetch.assert_not_called()
+        self.assertIs(entry, page_entry)
+
+    def test_fetch_places_enrichment_uses_api_strategy_without_scraping(self) -> None:
+        place = RawPlace(
+            name="Jimbocho Den",
+            address="Tokyo, Japan",
+            maps_url="https://www.google.com/maps/place/Jimbocho+Den",
+        )
+        api_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-16T00:00:00+00:00",
+            refresh_after="2026-04-23T00:00:00+00:00",
+            source="google_places_api",
+            query="Jimbocho Den, Tokyo, Japan",
+            matched=True,
+            score=88,
+            place=EnrichmentPlace(
+                display_name="Jimbocho Den",
+                formatted_address="Tokyo, Japan",
+                google_maps_uri="https://maps.google.com/?cid=1",
+                primary_type="restaurant",
+                primary_type_display_name="Restaurant",
+            ),
+        )
+
+        with (
+            patch.object(build_data, "fetch_place_page_enrichment") as page_fetch,
+            patch.object(build_data, "fetch_places_api_enrichment", return_value=api_entry) as api_fetch,
+        ):
+            entry = build_data.fetch_places_enrichment(
+                place,
+                api_key="test-key",
+                strategy="api",
+            )
+
+        page_fetch.assert_not_called()
+        api_fetch.assert_called_once_with(
+            place,
+            city_name=None,
+            country_name=None,
+            api_key="test-key",
+        )
+        self.assertIs(entry, api_entry)
+
+    def test_fetch_places_enrichment_fails_for_api_strategy_without_key(self) -> None:
+        place = RawPlace(
+            name="Jimbocho Den",
+            address="Tokyo, Japan",
+            maps_url="https://www.google.com/maps/place/Jimbocho+Den",
+        )
+
+        with (
+            patch.object(build_data, "fetch_place_page_enrichment") as page_fetch,
+            patch.object(build_data, "fetch_places_api_enrichment") as api_fetch,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "GOOGLE_PLACES_API_KEY is required"):
+                build_data.fetch_places_enrichment(
+                    place,
+                    api_key=None,
+                    strategy="api",
+                )
+
+        page_fetch.assert_not_called()
+        api_fetch.assert_not_called()
+
     def test_fetch_places_enrichment_falls_back_to_api_when_page_is_limited(self) -> None:
         place = RawPlace(
             name="Jimbocho Den",
@@ -3588,7 +3800,11 @@ class BuildDataTests(unittest.TestCase):
             patch.object(build_data, "fetch_place_page_enrichment", return_value=page_entry) as page_fetch,
             patch.object(build_data, "fetch_places_api_enrichment", return_value=api_entry) as api_fetch,
         ):
-            entry = build_data.fetch_places_enrichment(place, api_key="test-key")
+            entry = build_data.fetch_places_enrichment(
+                place,
+                api_key="test-key",
+                strategy="scrape_then_api",
+            )
 
         page_fetch.assert_called_once_with(
             place,
@@ -3637,7 +3853,11 @@ class BuildDataTests(unittest.TestCase):
             patch.object(build_data, "fetch_place_page_enrichment", return_value=page_entry) as page_fetch,
             patch.object(build_data, "fetch_places_api_enrichment", return_value=api_entry) as api_fetch,
         ):
-            entry = build_data.fetch_places_enrichment(place, api_key="test-key")
+            entry = build_data.fetch_places_enrichment(
+                place,
+                api_key="test-key",
+                strategy="scrape_then_api",
+            )
 
         page_fetch.assert_called_once_with(
             place,

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -216,7 +216,6 @@ class PlaceScraperTests(unittest.TestCase):
                 None,
                 None,
                 None,
-                [["0x60188c981788132b:0x6ef132909b155a88", None, None, "/m/0131whcb", "ChIJ8T36HxCLGGARvpARPDyaKLA"]],
                 None,
                 None,
                 None,
@@ -316,43 +315,49 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertEqual(enrichment["description"], "Modern setting for fine dining menus")
         self.assertEqual(enrichment["lat"], 35.6731762)
         self.assertEqual(enrichment["lng"], 139.7127216)
-        self.assertEqual(enrichment["google_place_id"], "ChIJ8T36HxCLGGARvpARPDyaKLA")
-        self.assertEqual(
-            enrichment["address_parts"],
-            [
-                "2 Chome Jingumae",
-                "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
-                "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
-                "Shibuya",
-                "150-0001",
-                "Tokyo",
-                "JP",
-                ["Floor 1"],
-            ],
-        )
 
-    def test_extract_preview_place_enrichment_rejects_invalid_address_parts(self) -> None:
+    def test_extract_preview_place_enrichment_preserves_google_place_id_and_address_parts(self) -> None:
         payload_data = [
             [
                 [
                     [
-                        "2 Chome Jingumae",
-                        "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
-                        "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
-                        "Shibuya",
-                        "150-0001",
-                        "Tokyo",
-                        "JP",
-                        ["Floor 1", 3],
-                    ],
-                    ["0ahUKE", "8Q7XMPF7+73", ["MPF7+73 Shibuya, Tokyo, Japan"], 3],
-                ]
+                        [
+                            [
+                                "Trailhead",
+                                "Xinyi District, Taipei City",
+                                "Xinyi District, Taipei City",
+                                "Xinyi District",
+                                "110",
+                                "Taipei City",
+                                "TW",
+                                ["Taiwan"],
+                            ],
+                            [["2HGG+M6 Taipei City, Taiwan"]],
+                        ]
+                    ]
+                ],
+                ["ChIJ8T36HxCLGGARvpARPDyaKLA", "0x3442c8:0xa82c9a3c3c1090be", "/m/0k64r8"],
+                [[None, None, 25.0272, 121.5705]],
             ]
         ]
         payload = ")]}'\n" + json.dumps(payload_data, ensure_ascii=False)
+
         enrichment = _extract_preview_place_enrichment(payload)
 
-        self.assertNotIn("address_parts", enrichment)
+        self.assertEqual(enrichment["google_place_id"], "ChIJ8T36HxCLGGARvpARPDyaKLA")
+        self.assertEqual(
+            enrichment["address_parts"],
+            [
+                "Trailhead",
+                "Xinyi District, Taipei City",
+                "Xinyi District, Taipei City",
+                "Xinyi District",
+                "110",
+                "Taipei City",
+                "TW",
+                ["Taiwan"],
+            ],
+        )
 
     def test_extract_preview_description_preserves_text_starting_with_open(self) -> None:
         description = _extract_preview_description(
@@ -448,64 +453,6 @@ class PlaceScraperTests(unittest.TestCase):
 
         self.assertIsNone(details.name)
 
-    def test_build_place_details_preserves_google_place_id_and_address_parts(self) -> None:
-        details = _build_place_details(
-            "https://www.google.com/maps/place/Den",
-            resolved_url="https://www.google.com/maps/place/Den/@35.6731762,139.7127216,17z",
-            snapshot={
-                "name": "Den",
-                "google_place_id": "ChIJ8T36HxCLGGARvpARPDyaKLA",
-                "address_parts": [
-                    "2 Chome Jingumae",
-                    "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
-                    "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
-                    "Shibuya",
-                    "150-0001",
-                    "Tokyo",
-                    "JP",
-                    ["Floor 1"],
-                ],
-                "body_text": "Den\nJapanese restaurant",
-            },
-        )
-
-        self.assertEqual(details.google_place_id, "ChIJ8T36HxCLGGARvpARPDyaKLA")
-        self.assertEqual(
-            details.address_parts,
-            [
-                "2 Chome Jingumae",
-                "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
-                "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
-                "Shibuya",
-                "150-0001",
-                "Tokyo",
-                "JP",
-                ["Floor 1"],
-            ],
-        )
-
-    def test_build_place_details_rejects_invalid_address_parts(self) -> None:
-        details = _build_place_details(
-            "https://www.google.com/maps/place/Den",
-            resolved_url="https://www.google.com/maps/place/Den/@35.6731762,139.7127216,17z",
-            snapshot={
-                "name": "Den",
-                "address_parts": [
-                    "2 Chome Jingumae",
-                    "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
-                    "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
-                    "Shibuya",
-                    "150-0001",
-                    "Tokyo",
-                    "JP",
-                    ["Floor 1", 3],
-                ],
-                "body_text": "Den\nJapanese restaurant",
-            },
-        )
-
-        self.assertIsNone(details.address_parts)
-
     def test_build_place_details_preserves_numeric_only_name(self) -> None:
         details = _build_place_details(
             "https://www.google.com/maps/place/404",
@@ -570,6 +517,43 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertEqual(
             details.photo_url,
             "https://lh3.googleusercontent.com/p/example=s680-w680-h510",
+        )
+
+    def test_build_place_details_preserves_google_place_id_and_address_parts(self) -> None:
+        details = _build_place_details(
+            "https://www.google.com/maps/place/Elephant+Mountain",
+            resolved_url="https://www.google.com/maps/place/Elephant+Mountain",
+            snapshot={
+                "name": "象山",
+                "google_place_id": "ChIJ8T36HxCLGGARvpARPDyaKLA",
+                "address": "2HGG+M6",
+                "address_parts": [
+                    "Trailhead",
+                    "Xinyi District, Taipei City",
+                    "Xinyi District, Taipei City",
+                    "Xinyi District",
+                    "110",
+                    "Taipei City",
+                    "TW",
+                    ["Taiwan"],
+                ],
+                "body_text": "象山",
+            },
+        )
+
+        self.assertEqual(details.google_place_id, "ChIJ8T36HxCLGGARvpARPDyaKLA")
+        self.assertEqual(
+            details.address_parts,
+            [
+                "Trailhead",
+                "Xinyi District, Taipei City",
+                "Xinyi District, Taipei City",
+                "Xinyi District",
+                "110",
+                "Taipei City",
+                "TW",
+                ["Taiwan"],
+            ],
         )
 
     def test_build_place_details_rejects_street_view_as_photo(self) -> None:


### PR DESCRIPTION
## Summary
- improve enrichment query/input signatures with city-country bias for ambiguous name-only places
- tighten locality parsing, suppress extreme map-pin outliers, and preserve shared enrichment metadata
- expand guide area-filter heuristics and vendor scraper parsing for google_place_id and structured address parts

## Validation
- `bun run check`
- `bun run test`
- `bun run build`

## Notes
- This branch intentionally excludes all `site/` data and contains only code, tests, and vendored scraper changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed inaccurate map pins that were geographically distant outliers.
  * Improved photo availability by propagating enriched photo data across related location entries.

* **Improvements**
  * Enhanced neighborhood and locality detection accuracy.
  * Expanded locality text normalization for better standardization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->