### PR TITLE
Make guide map Near me switch list sorting

### DIFF
--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -774,6 +774,24 @@ if (root) {
     nearbyDistanceByPlaceId = buildNearbyDistanceMap(cards, currentLocation);
   };
 
+  const applySortSelection = (
+    sortValue,
+    { requestLocationIfNeeded = false, source = "list-filter" } = {},
+  ) => {
+    if (!sortSelect) {
+      return;
+    }
+
+    sortSelect.value = sortValue;
+    setLocationSortMessage("");
+
+    if (sortValue === LOCATION_SORT_VALUE && requestLocationIfNeeded && !currentLocation) {
+      requestCurrentLocation();
+    }
+
+    update(source);
+  };
+
   const update = (source = "list-filter") => {
     const query = searchInput ? getSanitizedQuery(searchInput.value) : "";
     const normalizedQuery = query.toLowerCase();
@@ -1014,16 +1032,10 @@ if (root) {
   });
 
   sortSelect?.addEventListener("change", () => {
-    if (sortSelect.value === LOCATION_SORT_VALUE) {
-      setLocationSortMessage("");
-      if (!currentLocation) {
-        requestCurrentLocation();
-      }
-    } else {
-      setLocationSortMessage("");
-    }
-
-    update();
+    applySortSelection(sortSelect.value, {
+      requestLocationIfNeeded: true,
+      source: "sort-change",
+    });
   });
 
   typeButtons.forEach((button) => {
@@ -1111,6 +1123,17 @@ if (root) {
   });
 
   root.addEventListener("guide:map-frame-reset-request", clearMapFrameFilter);
+
+  root.addEventListener("guide:sort-request", (event) => {
+    const sortValue = event.detail?.sortValue || "";
+    if (sortValue !== LOCATION_SORT_VALUE) {
+      return;
+    }
+
+    applySortSelection(sortValue, {
+      source: "map-sort-request",
+    });
+  });
 
   root.addEventListener("guide:user-location", (event) => {
     hasHandledLocationRequest = true;

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -902,6 +902,7 @@ const mapPlaces = places
     let hoveredPlaceId = "";
     let currentLocation: Coordinates | null = null;
     let pendingLocationCenter = false;
+    let pendingLocationSortRequest = false;
     let locationWatchStarted = false;
     let locationWatchId: number | null = null;
     const requestedProvider = element.dataset.mapProvider === "google" ? "google" : "leaflet";
@@ -923,6 +924,17 @@ const mapPlaces = places
             coordinates: currentLocation,
             nearGuide: currentLocation ? locationIsNearGuide(currentLocation) : false,
             status,
+          },
+        }),
+      );
+    };
+
+    const requestNearbySort = () => {
+      root?.dispatchEvent(
+        new CustomEvent("guide:sort-request", {
+          bubbles: true,
+          detail: {
+            sortValue: "nearby",
           },
         }),
       );
@@ -1095,8 +1107,9 @@ const mapPlaces = places
     const updateLocationFromPosition = (position: GeolocationPosition) => {
       currentLocation = { lat: position.coords.latitude, lng: position.coords.longitude };
       runtime?.setUserLocation(currentLocation);
+      const locationNearGuide = locationIsNearGuide(currentLocation);
 
-      if (locationIsNearGuide(currentLocation)) {
+      if (locationNearGuide) {
         setLocationButtonState("near", "Center map on current location");
         if (pendingLocationCenter && runtime) {
           pendingLocationCenter = false;
@@ -1104,10 +1117,16 @@ const mapPlaces = places
         }
       } else {
         pendingLocationCenter = false;
+        pendingLocationSortRequest = false;
         setLocationButtonState("far", "Current location is too far from this guide");
       }
 
       dispatchUserLocation("available");
+
+      if (locationNearGuide && pendingLocationSortRequest) {
+        pendingLocationSortRequest = false;
+        requestNearbySort();
+      }
     };
 
     const startLocationAvailabilityWatch = () => {
@@ -1117,6 +1136,8 @@ const mapPlaces = places
       if (!navigator.geolocation) {
         setLocationButtonState("unavailable", "Current location is not available");
         currentLocation = null;
+        pendingLocationCenter = false;
+        pendingLocationSortRequest = false;
         runtime?.setUserLocation(null);
         dispatchUserLocation("unavailable");
         return;
@@ -1129,6 +1150,7 @@ const mapPlaces = places
         updateLocationFromPosition,
         (error) => {
           pendingLocationCenter = false;
+          pendingLocationSortRequest = false;
           if (locationWatchId !== null) {
             navigator.geolocation.clearWatch(locationWatchId);
             locationWatchId = null;
@@ -1148,19 +1170,23 @@ const mapPlaces = places
     };
 
     const centerOnCurrentLocation = () => {
-      root?.dispatchEvent(
-        new CustomEvent("guide:sort-request", {
-          bubbles: true,
-          detail: {
-            sortValue: "nearby",
-          },
-        }),
-      );
+      if (runtime && currentLocation) {
+        if (!locationIsNearGuide(currentLocation)) {
+          pendingLocationCenter = false;
+          pendingLocationSortRequest = false;
+          return;
+        }
+
+        pendingLocationCenter = false;
+        pendingLocationSortRequest = false;
+        requestNearbySort();
+        runtime.setView(currentLocation, 15);
+        return;
+      }
+
       pendingLocationCenter = true;
+      pendingLocationSortRequest = true;
       startLocationAvailabilityWatch();
-      if (!runtime || !currentLocation || !locationIsNearGuide(currentLocation)) return;
-      pendingLocationCenter = false;
-      runtime.setView(currentLocation, 15);
     };
 
     const resetToFullArea = () => {

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -1148,6 +1148,14 @@ const mapPlaces = places
     };
 
     const centerOnCurrentLocation = () => {
+      root?.dispatchEvent(
+        new CustomEvent("guide:sort-request", {
+          bubbles: true,
+          detail: {
+            sortValue: "nearby",
+          },
+        }),
+      );
       pendingLocationCenter = true;
       startLocationAvailabilityWatch();
       if (!runtime || !currentLocation || !locationIsNearGuide(currentLocation)) return;

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -212,7 +212,11 @@ describe("guide map interactions", () => {
     expect(filters).toContain('root.addEventListener("guide:sort-request"');
     expect(filters).toContain("navigator.geolocation.getCurrentPosition(");
     expect(filters).toContain("directLocationFallbackTimer = window.setTimeout(() => {");
-    expect(guideMap).toContain('new CustomEvent("guide:sort-request"');
+    expect(guideMap).toContain("let pendingLocationSortRequest = false;");
+    expect(guideMap).toContain("const requestNearbySort = () => {");
+    expect(guideMap).toContain("if (locationNearGuide && pendingLocationSortRequest) {");
+    expect(guideMap).toContain("pendingLocationSortRequest = true;");
+    expect(guideMap).toContain("requestNearbySort();");
     expectCssToContain(css, ".map-icon-button");
     expectCssToContain(css, '.map-icon-button[aria-disabled="true"]');
     expectCssToContain(css, '.map-icon-button[data-location-state="checking"]');

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -208,8 +208,11 @@ describe("guide map interactions", () => {
       'const hasMappablePlaces = root.dataset.hasMappablePlaces === "true";',
     );
     expect(filters).toContain("const requestCurrentLocationDirectly = () => {");
+    expect(filters).toContain("const applySortSelection = (");
+    expect(filters).toContain('root.addEventListener("guide:sort-request"');
     expect(filters).toContain("navigator.geolocation.getCurrentPosition(");
     expect(filters).toContain("directLocationFallbackTimer = window.setTimeout(() => {");
+    expect(guideMap).toContain('new CustomEvent("guide:sort-request"');
     expectCssToContain(css, ".map-icon-button");
     expectCssToContain(css, '.map-icon-button[aria-disabled="true"]');
     expectCssToContain(css, '.map-icon-button[data-location-state="checking"]');


### PR DESCRIPTION
## Description
- Make the guide map current-location control switch the place list to `Near me` sorting when used.
- Route both the sort dropdown and the map control through the same sort-selection path so location lookup and fallback behavior stay consistent.
- Add coverage for the new map-to-sort event contract.

## Related Issue
- None found.

## How Has This Been Tested?
- `bun run test:frontend`
- `bun run check`
- `bun run build`
