### PR TITLE
[codex] Tighten guide browse filters and cards

### DIFF
--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -77,6 +77,12 @@ export function buildNearbyDistanceMap(cards, currentLocation) {
 }
 
 export function compareCardsByCurated(left, right) {
+  const leftFeatured = left.dataset.featured === "true" ? 1 : 0;
+  const rightFeatured = right.dataset.featured === "true" ? 1 : 0;
+  if (leftFeatured !== rightFeatured) return rightFeatured - leftFeatured;
+  const leftBestHit = left.dataset.bestHit === "true" ? 1 : 0;
+  const rightBestHit = right.dataset.bestHit === "true" ? 1 : 0;
+  if (leftBestHit !== rightBestHit) return rightBestHit - leftBestHit;
   const leftTopPick = left.dataset.topPick === "true" ? 1 : 0;
   const rightTopPick = right.dataset.topPick === "true" ? 1 : 0;
   if (leftTopPick !== rightTopPick) return rightTopPick - leftTopPick;

--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -347,6 +347,31 @@ export function buildAreaFilterStatusMessage({
   return `Showing ${visibleCount} place${visibleCount === 1 ? "" : "s"} in ${activeAreaLabel}. ${overflowCount} more match${overflowCount === 1 ? "" : "es"} elsewhere in this guide.`;
 }
 
+export function getInitialSelectedTags({ allTags = [], params = new URLSearchParams() } = {}) {
+  const allowedTags = new Set(
+    allTags.map((tag) => getTagComparisonValue(String(tag || ""))).filter(Boolean),
+  );
+  const selectedTags = [];
+  const seen = new Set();
+
+  const rawTags = params
+    .getAll("tag")
+    .flatMap((value) => String(value || "").split(","))
+    .map((value) => getTagComparisonValue(value))
+    .filter(Boolean);
+
+  for (const tag of rawTags) {
+    if (!allowedTags.has(tag) || seen.has(tag)) {
+      continue;
+    }
+
+    seen.add(tag);
+    selectedTags.push(tag);
+  }
+
+  return selectedTags;
+}
+
 export function buildEmptyStateMessage({ activeAreaLabel = "", overflowCount = 0, query = "" }) {
   const matchWord = overflowCount === 1 ? "match" : "matches";
 
@@ -1178,6 +1203,11 @@ if (root) {
     if (initialQuery && searchInput) {
       searchInput.value = initialQuery;
     }
+
+    getInitialSelectedTags({
+      allTags,
+      params: initialParams,
+    }).forEach((tag) => addTag(tag));
   };
 
   const scrollToHighlightedPlace = () => {

--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -334,8 +334,13 @@ export function sortFilterOptions(options) {
   });
 }
 
-export function buildAreaFilterStatusMessage({ activeAreaLabel, visibleCount, overflowCount }) {
-  if (!activeAreaLabel || overflowCount <= 0 || visibleCount <= 0) {
+export function buildAreaFilterStatusMessage({
+  activeAreaLabel,
+  hasAdditionalFilters = false,
+  visibleCount,
+  overflowCount,
+}) {
+  if (!hasAdditionalFilters || !activeAreaLabel || overflowCount <= 0 || visibleCount <= 0) {
     return "";
   }
 
@@ -851,6 +856,11 @@ if (root) {
       ? countAreaOptionCards(cards, areaCountFilters, activeArea)
       : visibleCards.length;
     const areaOverflowCount = activeArea ? Math.max(0, broaderAreaCount - areaMatchCount) : 0;
+    const hasAdditionalFilters =
+      Boolean(normalizedQuery) ||
+      Boolean(activeType) ||
+      selectedTags.length > 0 ||
+      Boolean(mapFramePlaceIds);
 
     const areaOptions = areaButtons.map((button, index) => {
       const areaValue = normalizeTag(button.dataset.area || "");
@@ -949,6 +959,7 @@ if (root) {
     if (areaFilterStatus) {
       const message = buildAreaFilterStatusMessage({
         activeAreaLabel,
+        hasAdditionalFilters,
         visibleCount: visibleCards.length,
         overflowCount: areaOverflowCount,
       });

--- a/site.example/config.ts
+++ b/site.example/config.ts
@@ -41,7 +41,6 @@ export const siteConfig = {
     showTags: true,
     maxTags: 4,
     showPlaceCount: true,
-    showTopCategory: true,
   },
   placeCard: {
     showPhoto: true,

--- a/src/components/GuideCard.astro
+++ b/src/components/GuideCard.astro
@@ -1,7 +1,7 @@
 ---
 
 import { siteConfig } from "../data/site";
-import { getDisplayGuideTags } from "../lib/placeTags";
+import { getDisplayGuideTags, normalizeTagValue } from "../lib/placeTags";
 import { renderRichText } from "../lib/renderRichText";
 import type { GuideManifest } from "../lib/types";
 
@@ -86,18 +86,21 @@ const guideDisplayTitle = trimCountryFromTitle(guide.title);
   {siteConfig.guideCard.showTags && displayGuideTags.length > 0 && (
     <div class="tag-row ui-tag-row">
       {displayGuideTags.slice(0, siteConfig.guideCard.maxTags).map((tag) => (
-        <span class="tag-pill ui-tag-pill">#{tag}</span>
+        <a
+          class="tag-pill ui-tag-pill guide-card-tag-link"
+          href={`/guides/${guide.slug}/?tag=${encodeURIComponent(normalizeTagValue(tag))}`}
+          aria-label={`Open ${guideDisplayTitle} filtered by #${tag}`}
+        >
+          #{tag}
+        </a>
       ))}
     </div>
   )}
 
-  {(siteConfig.guideCard.showPlaceCount || siteConfig.guideCard.showTopCategory) && (
+  {siteConfig.guideCard.showPlaceCount && (
     <div class="guide-card-footer ui-card-footer">
       <div class="stats-row ui-meta-row">
         {siteConfig.guideCard.showPlaceCount && <span class="stat-pill ui-pill">{guide.place_count} places</span>}
-        {siteConfig.guideCard.showTopCategory && guide.top_categories[0] && (
-          <span class="stat-pill ui-pill">{guide.top_categories[0]}</span>
-        )}
       </div>
     </div>
   )}

--- a/src/components/PlaceCard.astro
+++ b/src/components/PlaceCard.astro
@@ -54,13 +54,11 @@ const metaParts = [
 ].filter(Boolean);
 const markerSvg = buildMapMarkerSvg(
   place.marker_icon,
-  getMapMarkerColors(place.marker_icon, { topPick: place.top_pick }),
+  getMapMarkerColors(place.marker_icon, { topPick: featured || place.top_pick }),
 );
 const showTopPickBadge = siteConfig.placeCard.showTopPickBadge && (featured || place.top_pick);
 const badges = [
-  ...(showTopPickBadge
-    ? [{ className: "badge badge--featured", label: siteConfig.placeCard.topPickLabel }]
-    : []),
+  ...(showTopPickBadge ? [{ className: "badge", label: siteConfig.placeCard.topPickLabel }] : []),
   ...(bestHit ? [{ className: "badge badge--best-hit", label: siteConfig.placeCard.bestHitLabel }] : []),
 ];
 ---

--- a/src/components/PlaceCard.astro
+++ b/src/components/PlaceCard.astro
@@ -7,6 +7,8 @@ import { renderRichText } from "../lib/renderRichText";
 import type { Place } from "../lib/types";
 
 interface Props {
+  bestHit?: boolean;
+  featured?: boolean;
   guideContext?: {
     cityName?: string | null;
     countryCode?: string | null;
@@ -15,7 +17,7 @@ interface Props {
   place: Place;
 }
 
-const { guideContext = {}, place } = Astro.props;
+const { bestHit = false, featured = false, guideContext = {}, place } = Astro.props;
 const placeTags = place.tags ?? [];
 const placeVibeTags = place.vibe_tags ?? [];
 const displayTags = getDisplayGuideTags(getDisplayPlaceTags(placeTags), guideContext);
@@ -54,12 +56,21 @@ const markerSvg = buildMapMarkerSvg(
   place.marker_icon,
   getMapMarkerColors(place.marker_icon, { topPick: place.top_pick }),
 );
+const showTopPickBadge = siteConfig.placeCard.showTopPickBadge && (featured || place.top_pick);
+const badges = [
+  ...(showTopPickBadge
+    ? [{ className: "badge badge--featured", label: siteConfig.placeCard.topPickLabel }]
+    : []),
+  ...(bestHit ? [{ className: "badge badge--best-hit", label: siteConfig.placeCard.bestHitLabel }] : []),
+];
 ---
 
 <article
   class="place-card ui-card"
   tabindex="0"
   data-place-card
+  data-best-hit={bestHit ? "true" : "false"}
+  data-featured={featured ? "true" : "false"}
   data-place-id={place.id}
   data-has-photo={hasPhoto ? "true" : "false"}
   data-name={place.name.toLowerCase()}
@@ -149,7 +160,13 @@ const markerSvg = buildMapMarkerSvg(
         )}
       </div>
     </div>
-    {siteConfig.placeCard.showTopPickBadge && place.top_pick && <span class="badge">{siteConfig.placeCard.topPickLabel}</span>}
+    {badges.length > 0 && (
+      <div class="place-card-badges">
+        {badges.map((badge) => (
+          <span class={badge.className}>{badge.label}</span>
+        ))}
+      </div>
+    )}
   </div>
 
   {siteConfig.placeCard.showWhyRecommended && whyRecommendedHtml && <p class="rich-copy ui-copy" set:html={whyRecommendedHtml} />}

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -89,7 +89,6 @@ export interface SiteConfig {
     showTags: boolean;
     maxTags: number;
     showPlaceCount: boolean;
-    showTopCategory: boolean;
     trimCountryFromTitle: boolean;
   };
   placeCard: {
@@ -203,7 +202,6 @@ const defaultSiteConfig: SiteConfig = {
     showTags: true,
     maxTags: 4,
     showPlaceCount: true,
-    showTopCategory: true,
     trimCountryFromTitle: true,
   },
   placeCard: {

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -105,6 +105,7 @@ export interface SiteConfig {
     showAddress: boolean;
     showTags: boolean;
     showStatus: boolean;
+    bestHitLabel: string;
     topPickLabel: string;
     mapsLabel: string;
     savedPlaceLabel: string;
@@ -218,6 +219,7 @@ const defaultSiteConfig: SiteConfig = {
     showAddress: true,
     showTags: true,
     showStatus: true,
+    bestHitLabel: "Popular",
     topPickLabel: "Top pick",
     mapsLabel: "Maps",
     savedPlaceLabel: "Saved place",

--- a/src/lib/placeTags.ts
+++ b/src/lib/placeTags.ts
@@ -56,7 +56,7 @@ function normalizeAreaText(area: string): string {
 }
 
 function normalizeAreaEquivalenceKey(area: string): string {
-  return normalizeAreaText(area).replace(
+  return normalizeTagValue(normalizeAreaText(area)).replace(
     /-(?:city|ward|district|borough|county|prefecture|province|gu|ku)$/,
     "",
   );
@@ -153,8 +153,11 @@ function collectAreaFilters(
     const label = resolveLabel(place)?.trim();
     if (!label) return;
 
+    const normalizedText = normalizeAreaText(label);
+    if (!normalizedText || STREET_AREA_PATTERN.test(normalizedText)) return;
+
     const normalizedValue = normalizeAreaEquivalenceKey(label);
-    if (!normalizedValue || STREET_AREA_PATTERN.test(normalizedValue)) return;
+    if (!normalizedValue) return;
 
     const current = areaCounts.get(normalizedValue);
     if (current) {

--- a/src/lib/placeTags.ts
+++ b/src/lib/placeTags.ts
@@ -56,7 +56,8 @@ function normalizeAreaText(area: string): string {
 }
 
 function normalizeAreaEquivalenceKey(area: string): string {
-  return normalizeTagValue(normalizeAreaText(area)).replace(
+  const normalizedText = normalizeAreaText(area);
+  return (normalizeTagValue(normalizedText) || normalizedText).replace(
     /-(?:city|ward|district|borough|county|prefecture|province|gu|ku)$/,
     "",
   );

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -110,25 +110,11 @@ const placeTagGuideContext = {
   countryName: guide.country_name,
 };
 const featuredPlaceIds = new Set(guide.featured_place_ids ?? []);
-const topPicks = visiblePlaces.filter((place) => featuredPlaceIds.has(place.id)).slice(0, 3);
-const visiblePlacesById = new Map(visiblePlaces.map((place) => [place.id, place] as const));
-const bestHits = (guide.best_hit_place_ids ?? [])
-  .map((placeId) => visiblePlacesById.get(placeId))
-  .filter((place): place is Place => Boolean(place));
+const bestHitPlaceIds = new Set(guide.best_hit_place_ids ?? []);
 const areaFilterGroups = getGuideAreaFilterGroups(visiblePlaces);
 const areaFilters = areaFilterGroups.primary;
 const broaderAreaFilters = areaFilterGroups.secondary;
 const displayGuideTags = getDisplayGuideTags(guide.list_tags, placeTagGuideContext);
-const reviewCountFormatter = new Intl.NumberFormat("en-US");
-const bestHitsDescription = [
-  "Highly rated Google Maps standouts",
-  typeof guide.best_hit_min_rating === "number" ? `at ${guide.best_hit_min_rating.toFixed(1)}+ stars` : null,
-  typeof guide.best_hit_min_reviews === "number"
-    ? `with at least ${reviewCountFormatter.format(guide.best_hit_min_reviews)} reviews for this guide`
-    : null,
-]
-  .filter(Boolean)
-  .join(" ");
 const explicitTypes = [
   ...visiblePlaces.reduce((typeCounts, place) => {
     if (place.primary_category) {
@@ -273,34 +259,6 @@ const hasMappablePlaces = visiblePlaces.some((place) => place.lat !== null && pl
       )}
     </div>
   </section>
-
-  {siteConfig.guide.showTopPicks && topPicks.length > 0 && (
-    <section class="section ui-section">
-      <SectionHeading eyebrow={siteConfig.guide.topPicksEyebrow} title={siteConfig.guide.topPicksHeading} />
-
-      <div class="top-picks-grid ui-card-grid">
-        {topPicks.map((place) => (
-          <PlaceCard place={place} guideContext={placeTagGuideContext} />
-        ))}
-      </div>
-    </section>
-  )}
-
-  {siteConfig.guide.showBestHits && bestHits.length > 0 && (
-    <section class="section ui-section">
-      <SectionHeading
-        eyebrow={siteConfig.guide.bestHitsEyebrow}
-        title={siteConfig.guide.bestHitsHeading}
-        copy={`${bestHitsDescription}.`}
-      />
-
-      <div class="top-picks-grid ui-card-grid">
-        {bestHits.map((place) => (
-          <PlaceCard place={place} guideContext={placeTagGuideContext} />
-        ))}
-      </div>
-    </section>
-  )}
 
   {guideBeforePlacesHtml && <div class="template-block rich-copy" set:html={guideBeforePlacesHtml} />}
 
@@ -453,7 +411,12 @@ const hasMappablePlaces = visiblePlaces.some((place) => place.lat !== null && pl
 
         <div class="card-grid ui-card-grid" data-kind="places" data-place-list>
           {visiblePlaces.map((place) => (
-            <PlaceCard place={place} guideContext={placeTagGuideContext} />
+            <PlaceCard
+              place={place}
+              guideContext={placeTagGuideContext}
+              featured={featuredPlaceIds.has(place.id)}
+              bestHit={bestHitPlaceIds.has(place.id)}
+            />
           ))}
         </div>
       </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -919,6 +919,14 @@
     flex: 1 1 auto;
   }
 
+  .place-card-badges {
+    display: inline-flex;
+    flex: 0 0 auto;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.45rem;
+  }
+
   .place-card-name-row {
     width: 100%;
     display: flex;
@@ -1031,6 +1039,11 @@
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
+  }
+
+  .badge--best-hit {
+    background: rgba(39, 47, 56, 0.08);
+    color: var(--ink);
   }
 
   .controls-panel {
@@ -1170,6 +1183,15 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.55rem;
+  }
+
+  .tag-row-mobile-scroll {
+    max-height: min(14rem, 28svh);
+    overflow-y: auto;
+    align-content: flex-start;
+    padding-right: 0.2rem;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
   }
 
   .selected-tag-chip {
@@ -1846,12 +1868,7 @@
     }
 
     .tag-row-mobile-scroll {
-      max-height: min(14rem, 28svh);
-      overflow-y: auto;
-      align-content: flex-start;
-      padding-right: 0.2rem;
-      overscroll-behavior: contain;
-      scrollbar-gutter: stable;
+      max-height: min(16rem, 34svh);
     }
 
     .card-grid,
@@ -1918,6 +1935,22 @@
     .tag-row,
     .stats-row {
       gap: 0.5rem;
+    }
+
+    .tag-row-mobile-scroll {
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      overflow-y: hidden;
+      max-height: none;
+      padding-right: 0;
+      padding-bottom: 0.2rem;
+      align-content: normal;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-gutter: auto;
+    }
+
+    .tag-row-mobile-scroll > * {
+      flex: 0 0 auto;
     }
 
     .stat-pill,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -604,6 +604,11 @@
     z-index: 2;
   }
 
+  .guide-card .guide-card-tag-link {
+    position: relative;
+    z-index: 2;
+  }
+
   .guide-card h3,
   .place-card h3 {
     margin: 0;

--- a/tests/frontend/guideFilters.test.mjs
+++ b/tests/frontend/guideFilters.test.mjs
@@ -12,6 +12,7 @@ import {
   countMatchingCards,
   countTagOptionCards,
   countTypeOptionCards,
+  getInitialSelectedTags,
   resolveLocationSortState,
   sortFilterOptions,
 } from "../../public/scripts/guide-filters.js";
@@ -185,6 +186,15 @@ describe("guide filters", () => {
         overflowCount: 8,
       }),
     ).toBe("");
+  });
+
+  it("hydrates initial selected tags from repeated tag params", () => {
+    expect(
+      getInitialSelectedTags({
+        allTags: ["seafood", "date-night", "quiet"],
+        params: new URLSearchParams("tag=seafood&tag=date-night&tag=unknown&tag=seafood"),
+      }),
+    ).toEqual(["seafood", "date-night"]);
   });
 
   it("keeps the area label in query empty-state copy even with no overflow matches", () => {

--- a/tests/frontend/guideFilters.test.mjs
+++ b/tests/frontend/guideFilters.test.mjs
@@ -117,6 +117,7 @@ describe("guide filters", () => {
     expect(
       buildAreaFilterStatusMessage({
         activeAreaLabel: "South Brisbane",
+        hasAdditionalFilters: true,
         visibleCount: 1,
         overflowCount: 3,
       }),
@@ -147,6 +148,7 @@ describe("guide filters", () => {
     expect(
       buildAreaFilterStatusMessage({
         activeAreaLabel: "South Brisbane",
+        hasAdditionalFilters: true,
         visibleCount: 1,
         overflowCount: 1,
       }),
@@ -167,8 +169,20 @@ describe("guide filters", () => {
     expect(
       buildAreaFilterStatusMessage({
         activeAreaLabel: "South Brisbane",
+        hasAdditionalFilters: true,
         visibleCount: 0,
         overflowCount: 2,
+      }),
+    ).toBe("");
+  });
+
+  it("suppresses the area status line when area is the only active filter", () => {
+    expect(
+      buildAreaFilterStatusMessage({
+        activeAreaLabel: "Zhongshan",
+        hasAdditionalFilters: false,
+        visibleCount: 3,
+        overflowCount: 8,
       }),
     ).toBe("");
   });

--- a/tests/frontend/guideFilters.test.mjs
+++ b/tests/frontend/guideFilters.test.mjs
@@ -17,7 +17,9 @@ import {
 } from "../../public/scripts/guide-filters.js";
 
 const makeCard = ({
+  bestHit = "false",
   category = "",
+  featured = "false",
   lat = "",
   lng = "",
   localityPath = "",
@@ -31,7 +33,9 @@ const makeCard = ({
   vibeTags = "",
 } = {}) => ({
   dataset: {
+    bestHit,
     category,
+    featured,
     lat,
     lng,
     localityPath,
@@ -496,6 +500,22 @@ describe("guide filters", () => {
     expect(nearbySorted.map((card) => card.dataset.placeId)).toEqual(
       curatedSorted.map((card) => card.dataset.placeId),
     );
+  });
+
+  it("prioritizes featured and best-hit cards in curated sorting", () => {
+    const cards = [
+      makeCard({ placeId: "rank-10", name: "Bravo", rank: "10" }),
+      makeCard({ placeId: "best-hit", name: "Alpha", rank: "1", bestHit: "true" }),
+      makeCard({ placeId: "top-pick", name: "Cafe", rank: "99", topPick: "true" }),
+      makeCard({ placeId: "featured", name: "Delta", rank: "0", featured: "true" }),
+    ];
+
+    expect([...cards].sort(compareCardsByCurated).map((card) => card.dataset.placeId)).toEqual([
+      "featured",
+      "best-hit",
+      "top-pick",
+      "rank-10",
+    ]);
   });
 
   it("resets nearby sorting to curated when location is denied or unavailable", () => {

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -75,6 +75,9 @@ describe("guide map interactions", () => {
     expect(placeCard).toContain(
       'import { buildMapMarkerSvg, getMapMarkerColors } from "../lib/mapMarkerIcons";',
     );
+    expect(placeCard).toContain(
+      "getMapMarkerColors(place.marker_icon, { topPick: featured || place.top_pick })",
+    );
     expect(placeCard).toContain('class="place-card-name-row"');
     expect(placeCard).toContain('class="place-card-marker"');
     expect(placeCard).toContain('class="place-card-map-link"');
@@ -82,6 +85,7 @@ describe("guide map interactions", () => {
     expect(placeCard).toContain('<img src="/icons/google-maps.svg" alt="" width="18" height="26"');
     expect(placeCard).toContain('class="place-card-map-link-label"');
     expect(placeCard).toContain("{siteConfig.placeCard.mapsLabel}</span>");
+    expect(placeCard).not.toContain("badge badge--featured");
     expect(placeCard).not.toContain(">Open in Google Maps<");
     expect(placeCard).toContain("set:html={markerSvg}");
     expectCssToContain(css, ".place-card-map-link");

--- a/tests/frontend/placeTags.test.ts
+++ b/tests/frontend/placeTags.test.ts
@@ -118,6 +118,21 @@ describe("getGuideAreaFilters", () => {
       { label: "Pinheiros", value: "pinheiros", count: 2 },
     ]);
   });
+
+  it("normalizes district suffix variants to the same canonical area value", () => {
+    expect(
+      getGuideAreaFilters([
+        { neighborhood: "Da’an District" },
+        { neighborhood: "Da'an District" },
+        { neighborhood: "Da’an" },
+        { neighborhood: "Zhongshan District" },
+        { neighborhood: "Zhongshan" },
+      ]),
+    ).toEqual([
+      { label: "Da’an", value: "da-an", count: 3 },
+      { label: "Zhongshan", value: "zhongshan", count: 2 },
+    ]);
+  });
 });
 
 describe("getGuideAreaFilterGroups", () => {

--- a/tests/frontend/placeTags.test.ts
+++ b/tests/frontend/placeTags.test.ts
@@ -133,6 +133,19 @@ describe("getGuideAreaFilters", () => {
       { label: "Zhongshan", value: "zhongshan", count: 2 },
     ]);
   });
+
+  it("preserves repeated non-latin area labels when slugification is empty", () => {
+    expect(
+      getGuideAreaFilters([
+        { neighborhood: "中山区" },
+        { neighborhood: "中山区" },
+        { neighborhood: "大安区" },
+      ]),
+    ).toEqual([
+      { label: "中山区", value: "中山区", count: 2 },
+      { label: "大安区", value: "大安区", count: 1 },
+    ]);
+  });
 });
 
 describe("getGuideAreaFilterGroups", () => {


### PR DESCRIPTION
## Description
- Fold featured and best-hit places into the main guide browse list, add badges for them on place cards, and prioritize them in curated sorting.
- Restore guide filter overflow containment on larger screens and switch mobile guide filter rows to horizontal chip scrollers so the map browse panel stays compact.

## Related Issue
None found after searching the open GitHub issues for this guide filter and card behavior.

## How Has This Been Tested?
- `bun run check`
- `bun run build`
