### PR TITLE
Fix guide area filtering and Taipei locality parsing

### DIFF
--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -117,6 +117,13 @@ export function compareCardsByNearby(
   return leftDistance - rightDistance || compareCardsByCurated(left, right);
 }
 
+export function compareCardsByNeighborhood(left, right) {
+  return (
+    (left.dataset.neighborhood || "").localeCompare(right.dataset.neighborhood || "") ||
+    (left.dataset.name || "").localeCompare(right.dataset.name || "")
+  );
+}
+
 export function resolveLocationSortState({
   fallbackMessage = "Location unavailable. Showing curated order instead.",
   fallbackSortValue = "curated",
@@ -169,7 +176,6 @@ export function normalizeUserLocationDetail({ coordinates = null } = {}) {
 
   return normalizedLocation;
 }
-
 export function cardHasTag(card, tag) {
   const normalizedTag = getTagComparisonValue(tag);
   if (!normalizedTag) {
@@ -189,10 +195,9 @@ export function matchesCardSearch(card, { normalizedQuery = "", searchResultIds 
 }
 
 function getCardAreaComparisonValues(card) {
-  const neighborhoodValue = getTagComparisonValue(card.dataset.neighborhood || "").replace(
-    /-(?:city|ward|district|borough|county|prefecture|province|gu|ku)$/,
-    "",
-  );
+  const neighborhoodValue = (
+    card.dataset.neighborhoodToken || getTagComparisonValue(card.dataset.neighborhood || "")
+  ).replace(/-(?:city|ward|district|borough|county|prefecture|province|gu|ku)$/, "");
   const localityPathValues = parseCardTagValues(card.dataset.localityPath);
   const broaderLocalityValue = localityPathValues[1]
     ? `broader-${localityPathValues[1].replace(/-(?:city|ward|district|borough|county|prefecture|province|gu|ku)$/, "")}`
@@ -370,6 +375,27 @@ export function buildAreaFilterStatusMessage({
   }
 
   return `Showing ${visibleCount} place${visibleCount === 1 ? "" : "s"} in ${activeAreaLabel}. ${overflowCount} more match${overflowCount === 1 ? "" : "es"} elsewhere in this guide.`;
+}
+
+export function hasAdditionalGuideFilters({
+  activeType = "",
+  activeTypeValue = "",
+  mapFramePlaceIds = null,
+  normalizedQuery = "",
+  selectedTags = [],
+  selectedTagValues = [],
+  totalCardCount = 0,
+} = {}) {
+  const nextActiveType = activeTypeValue || activeType;
+  const nextSelectedTags = selectedTagValues.length > 0 ? selectedTagValues : selectedTags;
+
+  if (Boolean(normalizedQuery) || Boolean(nextActiveType) || nextSelectedTags.length > 0) {
+    return true;
+  }
+
+  return Boolean(
+    mapFramePlaceIds && (totalCardCount <= 0 || mapFramePlaceIds.size !== totalCardCount),
+  );
 }
 
 export function getInitialSelectedTags({ allTags = [], params = new URLSearchParams() } = {}) {
@@ -685,9 +711,7 @@ if (root) {
       Number(right.dataset.ratingCount || 0) - Number(left.dataset.ratingCount || 0) ||
       sorters.curated(left, right),
     name: (left, right) => (left.dataset.name || "").localeCompare(right.dataset.name || ""),
-    neighborhood: (left, right) =>
-      (left.dataset.neighborhood || "").localeCompare(right.dataset.neighborhood || "") ||
-      (left.dataset.name || "").localeCompare(right.dataset.name || ""),
+    neighborhood: compareCardsByNeighborhood,
   };
   const setFilterCount = (button, count) => {
     const countLabel = button.querySelector("[data-filter-count]");
@@ -944,11 +968,13 @@ if (root) {
       ? countAreaOptionCards(cards, areaCountFilters, activeArea)
       : visibleCards.length;
     const areaOverflowCount = activeArea ? Math.max(0, broaderAreaCount - areaMatchCount) : 0;
-    const hasAdditionalFilters =
-      Boolean(normalizedQuery) ||
-      Boolean(activeType) ||
-      selectedTags.length > 0 ||
-      Boolean(mapFramePlaceIds);
+    const hasAdditionalFilters = hasAdditionalGuideFilters({
+      activeTypeValue: activeType,
+      mapFramePlaceIds,
+      normalizedQuery,
+      selectedTagValues: selectedTags,
+      totalCardCount: cards.length,
+    });
 
     const areaOptions = areaButtons.map((button, index) => {
       const areaValue = normalizeTag(button.dataset.area || "");
@@ -1221,7 +1247,6 @@ if (root) {
       source: "map-sort-request",
     });
   });
-
   root.addEventListener("guide:user-location", (event) => {
     hasHandledLocationRequest = true;
     clearDirectLocationFallbackTimer();

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -3740,6 +3740,7 @@ def is_building_or_unit_part(candidate: str) -> bool:
                 r"\b(?:bldg|building|tower|plaza|terrace|floor|mall|hotel|mansion|palace|garden|stream|works|"
                 r"center|centre|place|v-city|gratteciel|gems|bis|sn)\b"
                 r"|^(?:s/n|sn)$"
+                r"|^(?:no|no\.)$"
                 r"|^dentro\s+del\b"
                 r"|ビル|階|号|館"
             ),

--- a/src/components/PlaceCard.astro
+++ b/src/components/PlaceCard.astro
@@ -25,6 +25,7 @@ const displayVibeTags = getDisplayPlaceTags(placeVibeTags);
 const filterTagTokens = JSON.stringify(displayTags.map(getTagComparisonValue));
 const filterVibeTagTokens = JSON.stringify(displayVibeTags.map(getTagComparisonValue));
 const localityPathTokens = JSON.stringify((place.locality_path ?? []).map(getTagComparisonValue));
+const neighborhoodToken = getTagComparisonValue(place.neighborhood ?? "");
 const whyRecommendedHtml = renderRichText(place.why_recommended);
 const noteHtml = renderRichText(place.note);
 const placePhotosEnabled = (import.meta.env.PUBLIC_PLACE_PHOTOS || "on").toLowerCase() !== "off";
@@ -76,7 +77,8 @@ const badges = [
   data-vibe-tags={filterVibeTagTokens}
   data-locality-path={localityPathTokens}
   data-category={(place.primary_category ?? "").toLowerCase()}
-  data-neighborhood={(place.neighborhood ?? "").toLowerCase()}
+  data-neighborhood={place.neighborhood ?? ""}
+  data-neighborhood-token={neighborhoodToken}
   data-top-pick={place.top_pick ? "true" : "false"}
   data-rating={ratingValue !== null ? String(ratingValue) : ""}
   data-rating-count={reviewCount !== null ? String(reviewCount) : ""}

--- a/tests/frontend/guideFilters.test.mjs
+++ b/tests/frontend/guideFilters.test.mjs
@@ -8,11 +8,13 @@ import {
   cardMatchesType,
   compareCardsByCurated,
   compareCardsByNearby,
+  compareCardsByNeighborhood,
   countAreaOptionCards,
   countMatchingCards,
   countTagOptionCards,
   countTypeOptionCards,
   getInitialSelectedTags,
+  hasAdditionalGuideFilters,
   locationFallbackMessage,
   normalizeUserLocationDetail,
   resolveLocationSortState,
@@ -28,6 +30,7 @@ const makeCard = ({
   localityPath = "",
   name = "",
   neighborhood = "",
+  neighborhoodToken = "",
   placeId,
   rank = "0",
   search = "",
@@ -44,6 +47,7 @@ const makeCard = ({
     localityPath,
     name,
     neighborhood,
+    neighborhoodToken,
     placeId,
     rank,
     search,
@@ -190,6 +194,42 @@ describe("guide filters", () => {
     ).toBe("");
   });
 
+  it("treats a full-map frame as no additional guide filter", () => {
+    expect(
+      hasAdditionalGuideFilters({
+        mapFramePlaceIds: new Set(["1", "2", "3"]),
+        totalCardCount: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats a narrowed map frame as an additional guide filter", () => {
+    expect(
+      hasAdditionalGuideFilters({
+        mapFramePlaceIds: new Set(["1", "2"]),
+        totalCardCount: 3,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats an empty active map frame as an additional guide filter", () => {
+    expect(
+      hasAdditionalGuideFilters({
+        mapFramePlaceIds: new Set(),
+        totalCardCount: 3,
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts the module's active filter argument names", () => {
+    expect(
+      hasAdditionalGuideFilters({
+        activeTypeValue: "restaurant",
+        selectedTagValues: ["date-night"],
+      }),
+    ).toBe(true);
+  });
+
   it("hydrates initial selected tags from repeated tag params", () => {
     expect(
       getInitialSelectedTags({
@@ -310,6 +350,45 @@ describe("guide filters", () => {
         tag: "date-night",
       }),
     ).toBe(1);
+  });
+
+  it("matches normalized neighborhood dataset values against district-style area filters", () => {
+    const cards = [
+      makeCard({
+        placeId: "1",
+        neighborhood: "Da’an District",
+        neighborhoodToken: "da-an-district",
+        search: "dessert",
+      }),
+    ];
+
+    expect(
+      countMatchingCards(cards, {
+        activeArea: "da-an",
+        normalizedQuery: "dessert",
+      }),
+    ).toBe(1);
+  });
+
+  it("keeps neighborhood sorting on the human-readable label", () => {
+    const cards = [
+      makeCard({
+        placeId: "1",
+        name: "Cafe B",
+        neighborhood: "Évora",
+        neighborhoodToken: "evora",
+      }),
+      makeCard({
+        placeId: "2",
+        name: "Cafe A",
+        neighborhood: "Zurich",
+        neighborhoodToken: "zurich",
+      }),
+    ];
+
+    expect([...cards].sort(compareCardsByNeighborhood).map((card) => card.dataset.placeId)).toEqual(
+      ["1", "2"],
+    );
   });
 
   it("matches broader-area filters against any locality in the card path", () => {
@@ -543,7 +622,6 @@ describe("guide filters", () => {
       "rank-10",
     ]);
   });
-
   it("resets nearby sorting to curated when location is denied or unavailable", () => {
     expect(
       resolveLocationSortState({
@@ -629,7 +707,6 @@ describe("guide filters", () => {
       lng: 139.7671,
     });
   });
-
   it("does not reset nearby sorting while location is still idle, checking, or already available", () => {
     expect(
       resolveLocationSortState({

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2917,6 +2917,13 @@ class BuildDataTests(unittest.TestCase):
                 "Da’an District",
             ),
             (
+                "No, No. 60, Section 2, Hankou St, Wanhua District, Taipei City, 108",
+                "Taipei",
+                {"wanhua-district", "taipei"},
+                {"no", "taipei-city", "hankou-st"},
+                "Wanhua District",
+            ),
+            (
                 "Japan, 044-0081 Hokkaido, Abuta District, Kutchan, Yamada, 132-26",
                 "Niseko",
                 {"kutchan", "yamada", "niseko"},


### PR DESCRIPTION
## Description
Fix guide area filtering in two places: suppress the extra area status copy when area is the only effective filter, and normalize place-card neighborhood tokens so area pills like `Da’an District` match consistently in the browser. It also fixes Taipei locality parsing by rejecting bare `No` / `No.` address fragments so `No, No. 60, Section 2, Hankou St, Wanhua District, Taipei City, 108` resolves to `Wanhua District` instead of `No`.

## Related Issue

## How Has This Been Tested?
- `bun run test:frontend`
- `bun run check`
- `bun run build`
- `uv run python3 -m unittest discover -s tests/python -p 'test_*.py'`
- `bun run build:data`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined map-based filtering logic to more accurately determine when area filters are active versus showing the complete dataset
  * Enhanced address parsing to correctly identify and exclude building and unit identifiers from location classification and derivation
  * Improved neighborhood attribute handling to ensure consistent normalization for accurate filtering and search matching across place listings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->