### PR TITLE
[codex] Revendor gmaps-scraper for photo filtering

### DIFF
--- a/vendor/gmaps-scraper/README.md
+++ b/vendor/gmaps-scraper/README.md
@@ -17,7 +17,7 @@ panel, and returns structured JSON.
 This project is intended to be consumed directly from source rather than from PyPI.
 
 ```bash
-uv add git+https://github.com/508-dev/gmaps-scraper.git
+uv add git+https://github.com/michaelmwu/gmaps-scraper.git
 ```
 
 If you vendor the package, also add the runtime dependency:

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -78,17 +78,6 @@ _ADDRESS_KEYWORD_PATTERN = re.compile(
     r"court|ct|square|sq|suite|ste|unit|floor|fl|plaza|parkway|pkwy|highway|hwy)\b",
     re.IGNORECASE,
 )
-_ADDRESS_REJECT_SUBSTRINGS = (
-    "about this data",
-    "faviconv2",
-    "imagery ©",
-    "map data ©",
-    "send product feedback",
-    "street view",
-    "termsprivacy",
-)
-_ADDRESS_REJECT_HOST_FRAGMENTS = ("gstatic.com", "googleusercontent.com")
-_ADDRESS_ENTITY_TOKEN_PATTERN = re.compile(r"^/(?:g|m)/[A-Za-z0-9_-]+$")
 _PLACE_JS_EXTRACTOR = r"""
 () => {
   const titleSelectors = ["h1.DUwDvf", "h1.lfPIob", "div[role='main'] h1"];
@@ -135,14 +124,29 @@ _PLACE_JS_EXTRACTOR = r"""
     return null;
   };
 
+  const isReviewScoped = (element) => {
+    if (!element) {
+      return false;
+    }
+    if (element.closest("[data-review-id]")) {
+      return true;
+    }
+    const label = element.getAttribute?.("aria-label") || "";
+    return /(^|\W)reviews?(\W|$)/i.test(label);
+  };
+
   const firstImageUrl = (selectors, root = panel) => {
     for (const selector of selectors) {
-      const element = root.querySelector(selector);
-      const value = element?.currentSrc
-        || element?.getAttribute("src")?.trim()
-        || element?.getAttribute("data-src")?.trim();
-      if (value) {
-        return value;
+      for (const element of root.querySelectorAll(selector)) {
+        if (isReviewScoped(element)) {
+          continue;
+        }
+        const value = element?.currentSrc
+          || element?.getAttribute("src")?.trim()
+          || element?.getAttribute("data-src")?.trim();
+        if (value) {
+          return value;
+        }
       }
     }
     return null;
@@ -150,14 +154,15 @@ _PLACE_JS_EXTRACTOR = r"""
 
   const firstBackgroundImageUrl = (selectors, root = panel) => {
     for (const selector of selectors) {
-      const element = root.querySelector(selector);
-      if (!element) {
-        continue;
-      }
-      const style = getComputedStyle(element).backgroundImage || "";
-      const match = style.match(/url\((['"]?)(.*?)\1\)/);
-      if (match?.[2]) {
-        return match[2].trim();
+      for (const element of root.querySelectorAll(selector)) {
+        if (isReviewScoped(element)) {
+          continue;
+        }
+        const style = getComputedStyle(element).backgroundImage || "";
+        const match = style.match(/url\((['"]?)(.*?)\1\)/);
+        if (match?.[2]) {
+          return match[2].trim();
+        }
       }
     }
     return null;
@@ -258,10 +263,6 @@ _PLACE_JS_EXTRACTOR = r"""
     "button[jsaction*='image'] img",
     "button[jsaction*='photo'] img",
     "[data-photo-index] img",
-    "img[src*='googleusercontent.com']",
-    "img[src*='ggpht.com']",
-    "img[data-src*='googleusercontent.com']",
-    "img[data-src*='ggpht.com']",
   ], document)
     || firstBackgroundImageUrl([
       "button[jsaction*='image']",
@@ -499,14 +500,13 @@ def _build_place_details(
         category=category,
         rating=_parse_rating(snapshot.get("rating")),
         review_count=_parse_review_count(snapshot.get("review_count")),
-        address=_clean_address_text(snapshot.get("address"))
-        or _extract_address_from_lines(combined_lines),
+        address=_clean_text(snapshot.get("address")) or _extract_address_from_lines(combined_lines),
         located_in=_clean_text(snapshot.get("located_in")),
         status=_clean_text(snapshot.get("status")) or _extract_status_from_lines(combined_lines),
         website=_normalize_website(snapshot.get("website")),
         phone=_normalize_phone_candidate(snapshot.get("phone"))
         or _extract_phone_from_lines(combined_lines),
-        plus_code=_clean_address_text(snapshot.get("plus_code"))
+        plus_code=_clean_text(snapshot.get("plus_code"))
         or _extract_plus_code_from_lines(combined_lines),
         address_parts=_extract_address_parts(snapshot.get("address_parts")),
         description=_extract_description(snapshot, combined_lines),
@@ -678,40 +678,6 @@ def _clean_text(value: object) -> str | None:
     return normalized
 
 
-def _clean_address_text(value: object) -> str | None:
-    normalized = _clean_text(value)
-    if normalized is None:
-        return None
-
-    lowered = normalized.lower()
-    if lowered.startswith(("http://", "https://", "www.")):
-        return None
-    if any(fragment in lowered for fragment in _ADDRESS_REJECT_SUBSTRINGS):
-        return None
-    if any(fragment in lowered for fragment in _ADDRESS_REJECT_HOST_FRAGMENTS):
-        return None
-    if _ADDRESS_ENTITY_TOKEN_PATTERN.fullmatch(normalized):
-        return None
-    if any(keyword in lowered for keyword in _REVIEW_LABEL_KEYWORDS) and any(
-        character.isdigit() for character in normalized
-    ):
-        return None
-    if normalized.endswith(".") and _PLUS_CODE_PATTERN.search(normalized) is None:
-        return None
-
-    if "·" in normalized:
-        segments = [segment.strip() for segment in normalized.split("·") if segment.strip()]
-        for candidate in reversed(segments):
-            if candidate == normalized:
-                continue
-            if _looks_like_address_line(candidate):
-                return candidate
-
-    if _looks_like_address_line(normalized):
-        return normalized
-    return None
-
-
 def _clean_name_text(value: object) -> str | None:
     normalized = _clean_text(value)
     if normalized is None:
@@ -798,45 +764,33 @@ def _extract_category_from_lines(lines: list[str]) -> str | None:
 
 def _extract_address_from_lines(lines: list[str]) -> str | None:
     for line in lines:
-        normalized = _clean_address_text(line)
-        if normalized is not None:
-            return normalized
+        if _looks_like_address_line(line):
+            return line
     return None
 
 
 def _looks_like_address_line(line: str) -> bool:
-    normalized = _clean_text(line)
-    if normalized is None:
-        return False
-    lowered = normalized.lower()
+    lowered = line.lower()
     if lowered.startswith(("http://", "https://", "www.")):
         return False
     if _looks_like_status_text(line):
         return False
-    if _PHONE_PATTERN.match(normalized):
+    if _PHONE_PATTERN.match(line):
         return False
-    if _ADDRESS_ENTITY_TOKEN_PATTERN.fullmatch(normalized):
+    if _PLUS_CODE_PATTERN.search(line):
         return False
-    if any(fragment in lowered for fragment in _ADDRESS_REJECT_SUBSTRINGS):
-        return False
-    if any(fragment in lowered for fragment in _ADDRESS_REJECT_HOST_FRAGMENTS):
-        return False
-    if _parse_rating(normalized) is not None and "★" not in normalized and "star" not in lowered:
-        if re.fullmatch(r"[0-9]+(?:[.,][0-9]+)?", normalized.strip()):
+    if _parse_rating(line) is not None and "★" not in line and "star" not in lowered:
+        if re.fullmatch(r"[0-9]+(?:[.,][0-9]+)?", line.strip()):
             return False
-    if "〒" in normalized or normalized.startswith("Japan, "):
+    if "〒" in line or line.startswith("Japan, "):
         return True
-    if _PLUS_CODE_PATTERN.search(normalized):
+    if _POSTAL_CODE_PATTERN.search(line) and any(character.isalpha() for character in line):
         return True
-    if _POSTAL_CODE_PATTERN.search(normalized) and any(character.isalpha() for character in normalized):
-        return True
-    if re.search(r"\d", normalized) is None:
+    if re.search(r"\d", line) is None:
         return False
-    if "," in normalized and any(character.isalpha() for character in normalized):
+    if "," in line and any(character.isalpha() for character in line):
         return True
-    if " - " in normalized and any(character.isalpha() for character in normalized):
-        return True
-    return _ADDRESS_KEYWORD_PATTERN.search(normalized) is not None
+    return _ADDRESS_KEYWORD_PATTERN.search(line) is not None
 
 
 def _extract_status_from_lines(lines: list[str]) -> str | None:
@@ -941,6 +895,10 @@ def _normalize_photo_url(value: object) -> str | None:
         return None
     if "streetviewpixels-pa.googleapis.com" in host:
         return None
+    if (
+        "googleusercontent.com" in host or host.endswith("ggpht.com")
+    ) and path.startswith(("/a-", "/a/")):
+        return None
     return normalized
 
 
@@ -951,7 +909,7 @@ def _normalize_google_place_id(value: object) -> str | None:
     return normalized if _GOOGLE_PLACE_ID_PATTERN.fullmatch(normalized) else None
 
 
-_GOOGLE_PLACE_ID_PATTERN = re.compile(r"\bChIJ[0-9A-Za-z_-]{10,}\b")
+_GOOGLE_PLACE_ID_PATTERN = re.compile(r"ChIJ[0-9A-Za-z_-]{10,}")
 _MAPS_ENTITY_TOKEN_PATTERN = re.compile(r"0x[0-9a-fA-F]+:0x[0-9a-fA-F]+")
 _KNOWLEDGE_GRAPH_MID_PATTERN = re.compile(r"^/m/[A-Za-z0-9_-]+$")
 
@@ -960,7 +918,7 @@ def _extract_preview_google_place_id(root: list[object]) -> str | None:
     unique_place_ids: list[str] = []
     seen_place_ids: set[str] = set()
 
-    for node in _iter_preview_lists(root):
+    for node in _iter_lists(root):
         strings = [value for value in node if isinstance(value, str)]
         if not strings:
             continue
@@ -984,13 +942,6 @@ def _extract_preview_google_place_id(root: list[object]) -> str | None:
     return None
 
 
-def _iter_preview_lists(value: object) -> Iterable[list[object]]:
-    if isinstance(value, list):
-        yield value
-        for item in value:
-            yield from _iter_preview_lists(item)
-
-
 def _extract_address_parts(value: object) -> AddressParts | None:
     if not isinstance(value, list):
         return None
@@ -1009,30 +960,6 @@ def _normalize_address_parts(value: list[object]) -> AddressParts | None:
             return None
         normalized.append([cast(str, item) for item in extra])
     return normalized
-
-
-def _extract_preview_address_parts(root: list[object]) -> AddressParts | None:
-    for node in _iter_lists(root):
-        if len(node) < 2:
-            continue
-        raw_parts = node[0]
-        raw_plus_code = node[1]
-        if not isinstance(raw_parts, list) or not isinstance(raw_plus_code, list):
-            continue
-        normalized_parts = _normalize_address_parts(raw_parts)
-        if normalized_parts is None:
-            continue
-        if not any(
-            isinstance(value, list)
-            and any(
-                isinstance(item, str) and _PLUS_CODE_PATTERN.search(item) is not None
-                for item in value
-            )
-            for value in raw_plus_code
-        ):
-            continue
-        return normalized_parts
-    return None
 
 
 def _extract_preview_phone(strings: list[str]) -> str | None:
@@ -1061,15 +988,40 @@ def _extract_preview_plus_code(strings: list[str]) -> str | None:
     return compound_match
 
 
+def _extract_preview_address_parts(root: list[object]) -> AddressParts | None:
+    for node in _iter_lists(root):
+        if len(node) < 2:
+            continue
+        raw_parts = node[0]
+        raw_plus_code = node[1]
+        if not isinstance(raw_parts, list) or not isinstance(raw_plus_code, list):
+            continue
+        normalized_parts = _normalize_address_parts(raw_parts)
+        if normalized_parts is None:
+            continue
+        if not any(
+            isinstance(value, list)
+            and any(
+                isinstance(item, str) and _PLUS_CODE_PATTERN.search(item) is not None
+                for item in value
+            )
+            for value in raw_plus_code
+        ):
+            continue
+        return normalized_parts
+    return None
+
+
 def _extract_preview_address(strings: list[str]) -> str | None:
     candidates: list[str] = []
     for value in strings:
-        normalized = _clean_text(value)
-        if normalized is None:
-            continue
+        normalized = value.strip()
         if "maps/preview/place" in normalized or normalized.startswith("/g/"):
             continue
-        if _clean_address_text(normalized) is not None:
+        if "〒" in normalized or normalized.startswith("Japan, "):
+            candidates.append(normalized)
+            continue
+        if normalized.count(",") >= 2 and re.search(r"\d", normalized):
             candidates.append(normalized)
     if not candidates:
         return None
@@ -1132,8 +1084,6 @@ def _normalize_phone_candidate(value: object) -> str | None:
         return None
     digit_count = sum(character.isdigit() for character in normalized)
     if digit_count < 8 or digit_count > 15:
-        return None
-    if normalized.isdigit() and digit_count == 13 and normalized.startswith("17"):
         return None
     return normalized
 

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -4,8 +4,8 @@ import json
 import unittest
 
 from gmaps_scraper.place_scraper import (
+    _PLACE_JS_EXTRACTOR,
     _build_place_details,
-    _clean_address_text,
     _clean_category_text,
     _clean_name_text,
     _extract_address_from_lines,
@@ -15,7 +15,9 @@ from gmaps_scraper.place_scraper import (
     _extract_preview_place_enrichment,
     _extract_secondary_name,
     _merge_place_sources,
+    _normalize_google_place_id,
     _normalize_phone_candidate,
+    _normalize_photo_url,
     _normalize_preview_website,
     _parse_review_count,
     _seed_google_consent_cookies,
@@ -23,15 +25,17 @@ from gmaps_scraper.place_scraper import (
 
 
 class PlaceScraperTests(unittest.TestCase):
+    def test_place_js_extractor_skips_review_scoped_photo_nodes(self) -> None:
+        self.assertIn('element.closest("[data-review-id]")', _PLACE_JS_EXTRACTOR)
+        self.assertIn("root.querySelectorAll(selector)", _PLACE_JS_EXTRACTOR)
+        self.assertIn(r"return /(^|\W)reviews?(\W|$)/i.test(label);", _PLACE_JS_EXTRACTOR)
+
     def test_parse_review_count_handles_suffixes(self) -> None:
         self.assertEqual(_parse_review_count("324"), 324)
         self.assertEqual(_parse_review_count("1,296"), 1296)
         self.assertEqual(_parse_review_count("1.296"), 1296)
         self.assertEqual(_parse_review_count("3.6K"), 3600)
         self.assertEqual(_parse_review_count("9.4万"), 94000)
-
-    def test_normalize_phone_candidate_rejects_plain_numeric_ids(self) -> None:
-        self.assertIsNone(_normalize_phone_candidate("1777026232472"))
 
     def test_build_place_details_uses_dom_fields_and_body_fallbacks(self) -> None:
         details = _build_place_details(
@@ -112,57 +116,6 @@ class PlaceScraperTests(unittest.TestCase):
             "1600 Amphitheatre Parkway, Mountain View, CA 94043",
         )
 
-    def test_extract_address_from_lines_supports_plus_code_addresses(self) -> None:
-        self.assertEqual(
-            _extract_address_from_lines(
-                [
-                    "Tourist attraction",
-                    "38C5+F57 - Wadi Al Safa 4 - Dubai - United Arab Emirates",
-                ]
-            ),
-            "38C5+F57 - Wadi Al Safa 4 - Dubai - United Arab Emirates",
-        )
-
-    def test_clean_address_text_rejects_page_chrome_and_entity_tokens(self) -> None:
-        self.assertIsNone(
-            _clean_address_text(
-                "Imagery ©2026 , Map data ©2026 United StatesTermsPrivacySend Product Feedback"
-            )
-        )
-        self.assertIsNone(_clean_address_text("/m/0cnyfm6"))
-        self.assertIsNone(
-            _clean_address_text("https://encrypted-tbn3.gstatic.com/faviconV2?foo=bar")
-        )
-        self.assertIsNone(_clean_address_text("Street View & 360°"))
-        self.assertIsNone(_clean_address_text("1,558 reviews"))
-        self.assertIsNone(
-            _clean_address_text(
-                "Unique, 150-m-tall building resembling a picture frame, with historic displays & panoramic views."
-            )
-        )
-
-    def test_clean_address_text_strips_ui_prefixes(self) -> None:
-        self.assertEqual(
-            _clean_address_text("企業のオフィス ·  · Exit 37 - Sheikh Mohammed Bin Zayed Rd"),
-            "Exit 37 - Sheikh Mohammed Bin Zayed Rd",
-        )
-
-    def test_build_place_details_drops_page_chrome_address(self) -> None:
-        details = _build_place_details(
-            "https://www.google.com/maps/place/Dubai+Frame",
-            resolved_url="https://www.google.com/maps/place/Dubai+Frame",
-            snapshot={
-                "name": "Dubai Frame",
-                "category": "Tourist attraction",
-                "address": (
-                    "Imagery ©2026 , Map data ©2026 United StatesTermsPrivacySend Product Feedback"
-                ),
-                "body_text": "Dubai Frame\nTourist attraction",
-            },
-        )
-
-        self.assertIsNone(details.address)
-
     def test_clean_name_text_preserves_names_that_start_with_open_or_closed(self) -> None:
         self.assertEqual(_clean_name_text("Open Kitchen"), "Open Kitchen")
         self.assertEqual(_clean_name_text("Closed Loop Coffee"), "Closed Loop Coffee")
@@ -213,6 +166,15 @@ class PlaceScraperTests(unittest.TestCase):
                 None,
                 None,
                 None,
+                [
+                    [
+                        "0x60188c981788132b:0x6ef132909b155a88",
+                        None,
+                        None,
+                        "/m/0131whcb",
+                        "ChIJ8T36HxCLGGARvpARPDyaKLA",
+                    ]
+                ],
                 None,
                 None,
                 None,
@@ -308,6 +270,19 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertEqual(enrichment["phone"], "+81 3-6455-5433")
         self.assertEqual(enrichment["plus_code"], "MPF7+73 Shibuya, Tokyo, Japan")
         self.assertEqual(
+            enrichment["address_parts"],
+            [
+                "2 Chome Jingumae",
+                "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
+                "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
+                "Shibuya",
+                "150-0001",
+                "Tokyo",
+                "JP",
+                ["Floor 1"],
+            ],
+        )
+        self.assertEqual(
             enrichment["address"],
             "Japan, 〒150-0001 Tokyo, Shibuya, Jingumae, 2 Chome−3−18 Den, 建築家会館ＪＩＡ館",
         )
@@ -315,49 +290,7 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertEqual(enrichment["description"], "Modern setting for fine dining menus")
         self.assertEqual(enrichment["lat"], 35.6731762)
         self.assertEqual(enrichment["lng"], 139.7127216)
-
-    def test_extract_preview_place_enrichment_preserves_google_place_id_and_address_parts(self) -> None:
-        payload_data = [
-            [
-                [
-                    [
-                        [
-                            [
-                                "Trailhead",
-                                "Xinyi District, Taipei City",
-                                "Xinyi District, Taipei City",
-                                "Xinyi District",
-                                "110",
-                                "Taipei City",
-                                "TW",
-                                ["Taiwan"],
-                            ],
-                            [["2HGG+M6 Taipei City, Taiwan"]],
-                        ]
-                    ]
-                ],
-                ["ChIJ8T36HxCLGGARvpARPDyaKLA", "0x3442c8:0xa82c9a3c3c1090be", "/m/0k64r8"],
-                [[None, None, 25.0272, 121.5705]],
-            ]
-        ]
-        payload = ")]}'\n" + json.dumps(payload_data, ensure_ascii=False)
-
-        enrichment = _extract_preview_place_enrichment(payload)
-
         self.assertEqual(enrichment["google_place_id"], "ChIJ8T36HxCLGGARvpARPDyaKLA")
-        self.assertEqual(
-            enrichment["address_parts"],
-            [
-                "Trailhead",
-                "Xinyi District, Taipei City",
-                "Xinyi District, Taipei City",
-                "Xinyi District",
-                "110",
-                "Taipei City",
-                "TW",
-                ["Taiwan"],
-            ],
-        )
 
     def test_extract_preview_description_preserves_text_starting_with_open(self) -> None:
         description = _extract_preview_description(
@@ -382,6 +315,29 @@ class PlaceScraperTests(unittest.TestCase):
         )
 
         self.assertEqual(description, "Open now for lunch and dinner service.")
+
+    def test_extract_preview_place_enrichment_rejects_invalid_address_parts(self) -> None:
+        payload_data = [
+            [
+                [
+                    [
+                        "2 Chome Jingumae",
+                        "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
+                        "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
+                        "Shibuya",
+                        "150-0001",
+                        "Tokyo",
+                        "JP",
+                        ["Floor 1", 3],
+                    ],
+                    ["0ahUKE", "8Q7XMPF7+73", ["MPF7+73 Shibuya, Tokyo, Japan"], 3],
+                ]
+            ]
+        ]
+        payload = ")]}'\n" + json.dumps(payload_data, ensure_ascii=False)
+        enrichment = _extract_preview_place_enrichment(payload)
+
+        self.assertNotIn("address_parts", enrichment)
 
     def test_extract_preview_coordinates_ignores_short_integer_pairs(self) -> None:
         root = [
@@ -519,25 +475,24 @@ class PlaceScraperTests(unittest.TestCase):
             "https://lh3.googleusercontent.com/p/example=s680-w680-h510",
         )
 
-    def test_build_place_details_preserves_google_place_id_and_address_parts(self) -> None:
+    def test_build_place_details_preserves_google_place_id(self) -> None:
         details = _build_place_details(
-            "https://www.google.com/maps/place/Elephant+Mountain",
-            resolved_url="https://www.google.com/maps/place/Elephant+Mountain",
+            "https://www.google.com/maps/place/Den",
+            resolved_url="https://www.google.com/maps/place/Den/@35.6731762,139.7127216,17z",
             snapshot={
-                "name": "象山",
+                "name": "Den",
                 "google_place_id": "ChIJ8T36HxCLGGARvpARPDyaKLA",
-                "address": "2HGG+M6",
                 "address_parts": [
-                    "Trailhead",
-                    "Xinyi District, Taipei City",
-                    "Xinyi District, Taipei City",
-                    "Xinyi District",
-                    "110",
-                    "Taipei City",
-                    "TW",
-                    ["Taiwan"],
+                    "2 Chome Jingumae",
+                    "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
+                    "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
+                    "Shibuya",
+                    "150-0001",
+                    "Tokyo",
+                    "JP",
+                    ["Floor 1"],
                 ],
-                "body_text": "象山",
+                "body_text": "Den\nJapanese restaurant",
             },
         )
 
@@ -545,15 +500,43 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertEqual(
             details.address_parts,
             [
-                "Trailhead",
-                "Xinyi District, Taipei City",
-                "Xinyi District, Taipei City",
-                "Xinyi District",
-                "110",
-                "Taipei City",
-                "TW",
-                ["Taiwan"],
+                "2 Chome Jingumae",
+                "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
+                "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
+                "Shibuya",
+                "150-0001",
+                "Tokyo",
+                "JP",
+                ["Floor 1"],
             ],
+        )
+
+    def test_build_place_details_rejects_invalid_address_parts(self) -> None:
+        details = _build_place_details(
+            "https://www.google.com/maps/place/Den",
+            resolved_url="https://www.google.com/maps/place/Den/@35.6731762,139.7127216,17z",
+            snapshot={
+                "name": "Den",
+                "address_parts": [
+                    "2 Chome Jingumae",
+                    "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
+                    "Jingumae, 2 Chome−3−18 建築家会館ＪＩＡ館",
+                    "Shibuya",
+                    "150-0001",
+                    "Tokyo",
+                    "JP",
+                    ["Floor 1", 3],
+                ],
+                "body_text": "Den\nJapanese restaurant",
+            },
+        )
+
+        self.assertIsNone(details.address_parts)
+
+    def test_normalize_google_place_id_accepts_trailing_hyphen(self) -> None:
+        self.assertEqual(
+            _normalize_google_place_id("ChIJabcdefghij-"),
+            "ChIJabcdefghij-",
         )
 
     def test_build_place_details_rejects_street_view_as_photo(self) -> None:
@@ -575,12 +558,37 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertIsNone(details.main_photo_url)
         self.assertIsNone(details.photo_url)
 
+    def test_build_place_details_rejects_google_avatar_as_photo(self) -> None:
+        details = _build_place_details(
+            "https://www.google.com/maps/place/Fa+Burger",
+            resolved_url="https://www.google.com/maps/place/Fa+Burger",
+            snapshot={
+                "name": "Fa Burger",
+                "main_photo_url": "https://lh3.googleusercontent.com/a-/ALV-UjW_avatar",
+                "photo_url": "https://lh3.googleusercontent.com/a-/ALV-UjW_avatar",
+                "body_text": "Fa Burger",
+            },
+        )
+
+        self.assertIsNone(details.main_photo_url)
+        self.assertIsNone(details.photo_url)
+
     def test_extract_secondary_name_aborts_when_rating_line_follows_name(self) -> None:
         self.assertIsNone(
             _extract_secondary_name(
                 ["Den", "4.4", "傳"],
                 name="Den",
             )
+        )
+
+    def test_normalize_photo_url_rejects_google_avatar_urls(self) -> None:
+        self.assertIsNone(
+            _normalize_photo_url("https://lh3.googleusercontent.com/a-/ALV-UjW_avatar")
+        )
+        self.assertIsNone(_normalize_photo_url("https://lh5.ggpht.com/a/example-avatar"))
+        self.assertEqual(
+            _normalize_photo_url("https://lh3.googleusercontent.com/p/example=s680-w680-h510"),
+            "https://lh3.googleusercontent.com/p/example=s680-w680-h510",
         )
 
     def test_normalize_preview_website_rejects_streetview_thumbnail_urls(self) -> None:

--- a/vendor/gmaps-scraper/tests/test_public_api.py
+++ b/vendor/gmaps-scraper/tests/test_public_api.py
@@ -118,6 +118,7 @@ class PublicApiTests(unittest.TestCase):
         place = PlaceDetails(
             source_url="https://www.google.com/maps/place/Den",
             resolved_url="https://www.google.com/maps/place/Den/@35.6731762,139.7127216,17z",
+            google_place_id="ChIJ8T36HxCLGGARvpARPDyaKLA",
             name="Den",
             secondary_name="傳",
             category="Japanese restaurant",
@@ -152,6 +153,7 @@ class PublicApiTests(unittest.TestCase):
                 "resolved_url": (
                     "https://www.google.com/maps/place/Den/@35.6731762,139.7127216,17z"
                 ),
+                "google_place_id": "ChIJ8T36HxCLGGARvpARPDyaKLA",
                 "name": "Den",
                 "category": "Japanese restaurant",
                 "rating": 4.4,

--- a/vendor/gmaps-scraper/uv.lock
+++ b/vendor/gmaps-scraper/uv.lock
@@ -58,15 +58,15 @@ wheels = [
 
 [[package]]
 name = "cloakbrowser"
-version = "0.3.25"
+version = "0.3.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "playwright" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/e4/d70bbce92f58d2ae4f1895816c1534d35b080877fb21695966f3f693c7b7/cloakbrowser-0.3.25.tar.gz", hash = "sha256:27340edc3498602eb492740d1cff38f04567e28d22728e927809faff4b4f5592", size = 5311369 }
+sdist = { url = "https://files.pythonhosted.org/packages/74/ef/65790b28847a63e5c3708869d423bfc0e2b00f3aee3de525c81ead3d0393/cloakbrowser-0.3.24.tar.gz", hash = "sha256:f0141375cec1eb88ab2c94847894f138fe418aac85e888d3eb96c12d89acb546", size = 5307386 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/bd/703af906951a8c7e4f2e9e6d19dfe46dddb489663e5cda12cc756c0de746/cloakbrowser-0.3.25-py3-none-any.whl", hash = "sha256:58c3dbb5c844b12224c0583c14c8a76b886f46ce6be0e9c3a88083b66b1edf79", size = 61908 },
+    { url = "https://files.pythonhosted.org/packages/7c/85/51c15bb0b63524b559ba9632d99c95989c274c95502fbcc7ca70c67622be/cloakbrowser-0.3.24-py3-none-any.whl", hash = "sha256:d11e76ebc6a1ecc60adc93d973a2ebb78042f93813cc72c536412e50ed4f675c", size = 60582 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Vendor `gmaps-scraper` to upstream commit `191ebc1`, pulling in the fix that skips review-scoped place photos when selecting primary place imagery. This also carries the upstream scraper and test updates for photo URL normalization, preview place IDs and address parts handling, and the vendored `uv.lock` and README snapshot.

## Related Issue
No matching repo issue found.

## How Has This Been Tested?
`uv run --directory vendor/gmaps-scraper python3 -m unittest tests.test_place_scraper tests.test_public_api` and `bun run test:python`
