### PR TITLE
[codex] Filter suspicious place photo URLs

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -3059,6 +3059,13 @@ def canonicalize_enrichment_place(place: EnrichmentPlace | None) -> EnrichmentPl
     return place
 
 
+def canonicalize_enrichment_cache_entry(entry: EnrichmentCacheEntry | None) -> EnrichmentCacheEntry | None:
+    if entry is None:
+        return None
+    canonicalize_enrichment_place(entry.place)
+    return entry
+
+
 def sanitize_place_photo_url(value: str | None) -> str | None:
     normalized = as_string(value)
     if normalized is None:
@@ -4468,6 +4475,9 @@ def preserve_existing_enrichment(
     existing_entry: EnrichmentCacheEntry | None,
     refreshed_entry: EnrichmentCacheEntry,
 ) -> tuple[EnrichmentCacheEntry, str | None]:
+    canonicalize_enrichment_cache_entry(existing_entry)
+    canonicalize_enrichment_cache_entry(refreshed_entry)
+
     if not cache_entry_has_publishable_enrichment(existing_entry):
         return refreshed_entry, None
 
@@ -4481,8 +4491,6 @@ def preserve_existing_enrichment(
 
     previous_place = existing_entry.place
     refreshed_place = refreshed_entry.place
-    canonicalize_enrichment_place(previous_place)
-    canonicalize_enrichment_place(refreshed_place)
     assert previous_place is not None
     assert refreshed_place is not None
 
@@ -4638,7 +4646,8 @@ def load_places_cache_from_sqlite(slug: str) -> dict[str, EnrichmentCacheEntry] 
     for place_id, cache_json in rows:
         if not isinstance(place_id, str) or not isinstance(cache_json, str):
             continue
-        result[place_id] = EnrichmentCacheEntry.model_validate_json(cache_json)
+        entry = EnrichmentCacheEntry.model_validate_json(cache_json)
+        result[place_id] = canonicalize_enrichment_cache_entry(entry) or entry
     return result
 
 
@@ -4674,7 +4683,11 @@ def save_places_cache_to_sqlite(slug: str, payload: dict[str, EnrichmentCacheEnt
                             entry.score,
                             entry.error,
                             entry.error_body,
-                            json.dumps(entry.model_dump(mode="json"), ensure_ascii=False, separators=(",", ":")),
+                            json.dumps(
+                                (canonicalize_enrichment_cache_entry(entry) or entry).model_dump(mode="json"),
+                                ensure_ascii=False,
+                                separators=(",", ":"),
+                            ),
                         )
                         for place_id, entry in sorted(payload.items())
                     ],

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -126,6 +126,8 @@ PHOTO_DOWNLOAD_TIMEOUT_SECONDS = 20
 PHOTO_CARD_WIDTH = 800
 PHOTO_CARD_HEIGHT = 600
 PHOTO_CARD_QUALITY = 78
+MIN_PLACE_PHOTO_SOURCE_DIMENSION = 200
+PLACE_PHOTO_SOURCE_DIMENSION_RE = re.compile(r"w(?P<width>\d+)-h(?P<height>\d+)")
 # Bump this for any SQLite schema or row-derivation semantic change that must force a rebuild.
 PLACES_SQLITE_SIGNATURE_VERSION = 3
 PLACES_SQLITE_BUILD_METADATA_KEY = "build_signature"
@@ -3052,7 +3054,43 @@ def canonicalize_enrichment_place(place: EnrichmentPlace | None) -> EnrichmentPl
 
     place.primary_type_display_name = canonical_display_name
     place.primary_type_display_name_localized = localized_display_name
+    place.main_photo_url = sanitize_place_photo_url(place.main_photo_url)
+    place.photo_url = sanitize_place_photo_url(place.photo_url)
     return place
+
+
+def sanitize_place_photo_url(value: str | None) -> str | None:
+    normalized = as_string(value)
+    if normalized is None:
+        return None
+
+    url_parts = urlsplit(normalized)
+    host = url_parts.netloc.lower()
+    path = url_parts.path.lower()
+    if "staticmap" in path:
+        return None
+    if (
+        ("googleusercontent.com" in host or host.endswith("ggpht.com"))
+        and path.startswith(("/a-", "/a/"))
+    ):
+        return None
+
+    dimensions = extract_place_photo_source_dimensions(normalized)
+    if (
+        dimensions is not None
+        and dimensions[0] < MIN_PLACE_PHOTO_SOURCE_DIMENSION
+        and dimensions[1] < MIN_PLACE_PHOTO_SOURCE_DIMENSION
+    ):
+        return None
+
+    return normalized
+
+
+def extract_place_photo_source_dimensions(value: str) -> tuple[int, int] | None:
+    match = PLACE_PHOTO_SOURCE_DIMENSION_RE.search(value)
+    if match is None:
+        return None
+    return int(match.group("width")), int(match.group("height"))
 
 
 def normalized_enrichment_type_ids(
@@ -6231,8 +6269,8 @@ def normalize_place_page_enrichment(details: Any) -> EnrichmentPlace:
         if description_address is not None:
             formatted_address = description_address
             description = None
-    main_photo_url = as_string(getattr(details, "main_photo_url", None))
-    photo_url = as_string(getattr(details, "photo_url", None))
+    main_photo_url = sanitize_place_photo_url(as_string(getattr(details, "main_photo_url", None)))
+    photo_url = sanitize_place_photo_url(as_string(getattr(details, "photo_url", None)))
     if from_search_url:
         description = None
     limited_view = bool(getattr(details, "limited_view", False))

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -3072,12 +3072,12 @@ def sanitize_place_photo_url(value: str | None) -> str | None:
         return None
 
     url_parts = urlsplit(normalized)
-    host = url_parts.netloc.lower()
+    host = (url_parts.hostname or "").lower()
     path = url_parts.path.lower()
     if "staticmap" in path:
         return None
     if (
-        ("googleusercontent.com" in host or host.endswith("ggpht.com"))
+        (host.endswith("googleusercontent.com") or host.endswith("ggpht.com"))
         and path.startswith(("/a-", "/a/"))
     ):
         return None
@@ -3085,8 +3085,10 @@ def sanitize_place_photo_url(value: str | None) -> str | None:
     dimensions = extract_place_photo_source_dimensions(normalized)
     if (
         dimensions is not None
-        and dimensions[0] < MIN_PLACE_PHOTO_SOURCE_DIMENSION
-        and dimensions[1] < MIN_PLACE_PHOTO_SOURCE_DIMENSION
+        and (
+            dimensions[0] < MIN_PLACE_PHOTO_SOURCE_DIMENSION
+            or dimensions[1] < MIN_PLACE_PHOTO_SOURCE_DIMENSION
+        )
     ):
         return None
 

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -911,6 +911,21 @@ class BuildDataTests(unittest.TestCase):
         self.assertIsNone(enrichment.main_photo_url)
         self.assertIsNone(enrichment.photo_url)
 
+    def test_normalize_place_page_enrichment_drops_tiny_photo_urls(self) -> None:
+        enrichment = build_data.normalize_place_page_enrichment(
+            SimpleNamespace(
+                source_url="https://www.google.com/maps/place/Open+Kitchen",
+                resolved_url="https://www.google.com/maps/place/Open+Kitchen",
+                name="Open Kitchen",
+                category="Restaurant",
+                address="1 Example St, Tokyo",
+                photo_url="https://lh3.googleusercontent.com/gps-cs-s/example=w122-h92-k-no",
+                limited_view=False,
+            )
+        )
+
+        self.assertIsNone(enrichment.photo_url)
+
     def test_normalize_place_page_enrichment_preserves_google_place_id_and_address_parts(self) -> None:
         enrichment = build_data.normalize_place_page_enrichment(
             SimpleNamespace(
@@ -5233,6 +5248,50 @@ class BuildDataTests(unittest.TestCase):
             "WARNING: Preserving previous enrichment for tokyo-japan:cid:111 [First Place] "
             "because refresh returned degraded result (http_403).",
         )
+
+    def test_enrich_place_job_scrubs_suspicious_photo_when_refresh_degrades(self) -> None:
+        previous_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="First Place, Tokyo",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="First Place",
+                rating=4.7,
+                google_maps_uri="https://www.google.com/maps/search/?api=1&query=First+Place&query_place_id=place123",
+                google_place_id="place123",
+                photo_url="https://lh3.googleusercontent.com/a-/ALV-UjW_avatar=w36-h36-p-rp-mo-br100",
+            ),
+        )
+        degraded_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-23T00:00:00+00:00",
+            query="First Place, Tokyo",
+            source="google_places_api",
+            error="http_403",
+        )
+
+        with (
+            patch.object(build_data, "sleep_for_refresh_startup_jitter"),
+            patch.object(build_data, "fetch_places_enrichment", return_value=degraded_entry),
+            patch("builtins.print"),
+        ):
+            result = build_data.enrich_place_job(
+                "tokyo-japan",
+                "cid:111",
+                "First Place",
+                "refresh-window-expired",
+                {
+                    "name": "First Place",
+                    "address": "1 Example St, Tokyo",
+                    "maps_url": "https://maps.google.com/?cid=111",
+                    "cid": "111",
+                },
+                api_key="test-key",
+                refresh_startup_jitter_seconds=0,
+                existing_entry=previous_entry,
+            )
+
+        self.assertIs(result, previous_entry)
+        self.assertIsNone(result.place.photo_url)
 
     def test_enrich_place_job_preserves_previous_fields_when_refresh_loses_metadata(self) -> None:
         previous_entry = EnrichmentCacheEntry(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -891,6 +891,26 @@ class BuildDataTests(unittest.TestCase):
             "https://lh3.googleusercontent.com/p/example=s680-w680-h510",
         )
 
+    def test_normalize_place_page_enrichment_drops_suspicious_photo_urls(self) -> None:
+        enrichment = build_data.normalize_place_page_enrichment(
+            SimpleNamespace(
+                source_url="https://www.google.com/maps/place/Open+Kitchen",
+                resolved_url="https://www.google.com/maps/place/Open+Kitchen",
+                name="Open Kitchen",
+                category="Restaurant",
+                address="1 Example St, Tokyo",
+                main_photo_url=(
+                    "https://maps.google.com/maps/api/staticmap?center=35.0%2C139.0"
+                    "&zoom=17&size=900x900"
+                ),
+                photo_url="https://lh3.googleusercontent.com/a-/ALV-UjW_avatar=w36-h36-p-rp-mo-br100",
+                limited_view=False,
+            )
+        )
+
+        self.assertIsNone(enrichment.main_photo_url)
+        self.assertIsNone(enrichment.photo_url)
+
     def test_normalize_place_page_enrichment_preserves_google_place_id_and_address_parts(self) -> None:
         enrichment = build_data.normalize_place_page_enrichment(
             SimpleNamespace(
@@ -5279,6 +5299,60 @@ class BuildDataTests(unittest.TestCase):
             print_mock.call_args_list[1].args[0],
             "WARNING: Preserving previous enrichment fields for tokyo-japan:cid:111 [First Place]: "
             "rating, user_rating_count, primary_category, status, maps_url, photo_url.",
+        )
+
+    def test_enrich_place_job_does_not_preserve_suspicious_old_photo_urls(self) -> None:
+        previous_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="First Place, Tokyo",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="First Place",
+                rating=4.7,
+                user_rating_count=321,
+                google_maps_uri="https://www.google.com/maps/search/?api=1&query=First+Place&query_place_id=place123",
+                google_place_id="place123",
+                photo_url="https://lh3.googleusercontent.com/a-/ALV-UjW_avatar=w36-h36-p-rp-mo-br100",
+            ),
+        )
+        refreshed_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-23T00:00:00+00:00",
+            query="First Place, Tokyo",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="First Place",
+                google_maps_uri="https://www.google.com/maps/search/?api=1&query=First+Place",
+            ),
+        )
+
+        with (
+            patch.object(build_data, "sleep_for_refresh_startup_jitter"),
+            patch.object(build_data, "fetch_places_enrichment", return_value=refreshed_entry),
+            patch("builtins.print") as print_mock,
+        ):
+            result = build_data.enrich_place_job(
+                "tokyo-japan",
+                "cid:111",
+                "First Place",
+                "refresh-window-expired",
+                {
+                    "name": "First Place",
+                    "address": "1 Example St, Tokyo",
+                    "maps_url": "https://maps.google.com/?cid=111",
+                    "cid": "111",
+                },
+                api_key=None,
+                refresh_startup_jitter_seconds=0,
+                existing_entry=previous_entry,
+            )
+
+        self.assertIs(result, refreshed_entry)
+        self.assertIsNone(result.place.photo_url)
+        self.assertEqual(print_mock.call_count, 2)
+        self.assertEqual(
+            print_mock.call_args_list[1].args[0],
+            "WARNING: Preserving previous enrichment fields for tokyo-japan:cid:111 [First Place]: "
+            "rating, user_rating_count, maps_url.",
         )
 
     def test_refresh_retries_transient_parse_failure(self) -> None:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -926,6 +926,33 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertIsNone(enrichment.photo_url)
 
+    def test_sanitize_place_photo_url_drops_any_tiny_source_dimension(self) -> None:
+        for photo_url in (
+            "https://lh3.googleusercontent.com/p/example=s680-w120-h800",
+            "https://lh3.googleusercontent.com/p/example=s680-w800-h120",
+        ):
+            with self.subTest(photo_url=photo_url):
+                self.assertIsNone(build_data.sanitize_place_photo_url(photo_url))
+
+        self.assertEqual(
+            build_data.sanitize_place_photo_url(
+                "https://lh3.googleusercontent.com/p/example=s680-w800-h600"
+            ),
+            "https://lh3.googleusercontent.com/p/example=s680-w800-h600",
+        )
+
+    def test_sanitize_place_photo_url_uses_hostname_suffix_for_avatar_hosts(self) -> None:
+        self.assertEqual(
+            build_data.sanitize_place_photo_url(
+                "https://evil-googleusercontent.com.example/a-/ALV-UjW_avatar=w680-h680-p-rp-mo-br100"
+            ),
+            "https://evil-googleusercontent.com.example/a-/ALV-UjW_avatar=w680-h680-p-rp-mo-br100",
+        )
+        self.assertIsNone(
+            build_data.sanitize_place_photo_url(
+                "https://lh3.googleusercontent.com:443/a-/ALV-UjW_avatar=w680-h680-p-rp-mo-br100"
+            )
+        )
     def test_normalize_place_page_enrichment_preserves_google_place_id_and_address_parts(self) -> None:
         enrichment = build_data.normalize_place_page_enrichment(
             SimpleNamespace(


### PR DESCRIPTION
## Summary
- sanitize enrichment photo URLs in `scripts/build_data.py` before storing or preserving them
- drop static map images, Google avatar-style image URLs, and tiny source images that are not suitable as place photos
- add regression coverage for both direct place-page normalization and refresh-time preservation of older cache fields

## Why
Some place enrichments were persisting bad image URLs as primary photos. The bad cases were small avatar-style assets or static map images, which then leaked into the generated photo set instead of real place photography.

## Impact
This keeps the enrichment cache from carrying forward invalid place photos and reduces bad photo outputs during future refreshes.

## Validation
- `uv run python -m unittest tests.python.test_build_data`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved photo data quality by filtering suspicious photo URLs, including blocked image sources and placeholder images below minimum size thresholds, to ensure only valid photos display in place information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->