### PR TITLE
[codex] Avoid mutating cache entries during sqlite save

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -3195,6 +3195,16 @@ def canonicalize_enrichment_cache_entry(entry: EnrichmentCacheEntry | None) -> E
     return entry
 
 
+def canonicalized_enrichment_cache_entry_copy(entry: EnrichmentCacheEntry | None) -> EnrichmentCacheEntry | None:
+    if entry is None:
+        return None
+    return entry.model_copy(
+        update={
+            "place": canonicalize_enrichment_place(entry.place.model_copy()) if entry.place is not None else None
+        }
+    )
+
+
 def sanitize_place_photo_url(value: str | None) -> str | None:
     normalized = as_string(value)
     if normalized is None:
@@ -4801,7 +4811,9 @@ def load_places_cache_from_sqlite(slug: str) -> dict[str, EnrichmentCacheEntry] 
         if not isinstance(place_id, str) or not isinstance(cache_json, str):
             continue
         entry = EnrichmentCacheEntry.model_validate_json(cache_json)
-        result[place_id] = canonicalize_enrichment_cache_entry(entry) or entry
+        canonicalized_entry = canonicalized_enrichment_cache_entry_copy(entry)
+        assert canonicalized_entry is not None
+        result[place_id] = canonicalized_entry
     return result
 
 
@@ -4816,14 +4828,11 @@ def save_places_cache_to_sqlite(slug: str, payload: dict[str, EnrichmentCacheEnt
                 (slug,),
             )
             if payload:
-                connection.executemany(
-                    """
-                    INSERT INTO guide_enrichment_cache (
-                        guide_slug, place_id, fetched_at, last_verified_at, refresh_after, source,
-                        query, input_signature, matched, score, error, error_body, cache_json
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    [
+                serialized_rows = []
+                for place_id, entry in sorted(payload.items()):
+                    canonicalized_entry = canonicalized_enrichment_cache_entry_copy(entry)
+                    assert canonicalized_entry is not None
+                    serialized_rows.append(
                         (
                             slug,
                             place_id,
@@ -4838,13 +4847,20 @@ def save_places_cache_to_sqlite(slug: str, payload: dict[str, EnrichmentCacheEnt
                             entry.error,
                             entry.error_body,
                             json.dumps(
-                                (canonicalize_enrichment_cache_entry(entry) or entry).model_dump(mode="json"),
+                                canonicalized_entry.model_dump(mode="json"),
                                 ensure_ascii=False,
                                 separators=(",", ":"),
                             ),
                         )
-                        for place_id, entry in sorted(payload.items())
-                    ],
+                    )
+                connection.executemany(
+                    """
+                    INSERT INTO guide_enrichment_cache (
+                        guide_slug, place_id, fetched_at, last_verified_at, refresh_after, source,
+                        query, input_signature, matched, score, error, error_body, cache_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    serialized_rows,
                 )
     finally:
         connection.close()
@@ -6493,8 +6509,8 @@ def normalize_place_page_enrichment(details: Any) -> EnrichmentPlace:
         if description_address is not None:
             formatted_address = description_address
             description = None
-    main_photo_url = sanitize_place_photo_url(as_string(getattr(details, "main_photo_url", None)))
-    photo_url = sanitize_place_photo_url(as_string(getattr(details, "photo_url", None)))
+    main_photo_url = sanitize_place_photo_url(getattr(details, "main_photo_url", None))
+    photo_url = sanitize_place_photo_url(getattr(details, "photo_url", None))
     if from_search_url:
         description = None
     limited_view = bool(getattr(details, "limited_view", False))

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1109,15 +1109,39 @@ class BuildDataTests(unittest.TestCase):
         for photo_url in (
             "https://lh3.googleusercontent.com/p/example=s680-w120-h800",
             "https://lh3.googleusercontent.com/p/example=s680-w800-h120",
+            "https://lh3.googleusercontent.com/p/example=s680-w199-h400",
         ):
             with self.subTest(photo_url=photo_url):
                 self.assertIsNone(build_data.sanitize_place_photo_url(photo_url))
 
         self.assertEqual(
             build_data.sanitize_place_photo_url(
+                "https://lh3.googleusercontent.com/p/example=s680-w200-h200"
+            ),
+            "https://lh3.googleusercontent.com/p/example=s680-w200-h200",
+        )
+        self.assertEqual(
+            build_data.sanitize_place_photo_url(
                 "https://lh3.googleusercontent.com/p/example=s680-w800-h600"
             ),
             "https://lh3.googleusercontent.com/p/example=s680-w800-h600",
+        )
+
+    def test_sanitize_place_photo_url_rejects_static_map_and_avatar_path_variants(self) -> None:
+        self.assertIsNone(
+            build_data.sanitize_place_photo_url(
+                "https://maps.google.com/maps/api/staticmap?center=35.0%2C139.0&zoom=17&size=900x900"
+            )
+        )
+        self.assertIsNone(
+            build_data.sanitize_place_photo_url(
+                "https://lh3.googleusercontent.com:443/a-/ALV-UjW_avatar=w680-h680-p-rp-mo-br100"
+            )
+        )
+        self.assertIsNone(
+            build_data.sanitize_place_photo_url(
+                "https://lh5.ggpht.com:443/a/example-avatar=w680-h680-p-rp-mo-br100"
+            )
         )
 
     def test_sanitize_place_photo_url_uses_hostname_suffix_for_avatar_hosts(self) -> None:
@@ -1132,6 +1156,7 @@ class BuildDataTests(unittest.TestCase):
                 "https://lh3.googleusercontent.com:443/a-/ALV-UjW_avatar=w680-h680-p-rp-mo-br100"
             )
         )
+
     def test_normalize_place_page_enrichment_preserves_google_place_id_and_address_parts(self) -> None:
         enrichment = build_data.normalize_place_page_enrichment(
             SimpleNamespace(
@@ -5303,6 +5328,45 @@ class BuildDataTests(unittest.TestCase):
 
             self.assertEqual(loaded_payload["cid:111"].query, cache_entry.query)
             self.assertTrue(loaded_payload["cid:111"].matched)
+
+    def test_save_places_cache_to_sqlite_canonicalizes_without_mutating_payload(self) -> None:
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="Open Kitchen",
+            matched=True,
+            place=EnrichmentPlace(
+                primary_type="restaurant",
+                primary_type_display_name="Restaurant",
+                primary_type_display_name_localized="レストラン",
+                photo_url="https://lh3.googleusercontent.com:443/a-/ALV-UjW_avatar=w680-h680-p-rp-mo-br100",
+            ),
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            db_path = tmpdir_path / "places.sqlite"
+
+            with patch.object(build_data, "PLACES_SQLITE_PATH", db_path):
+                build_data.save_places_cache_to_sqlite("tokyo-japan", {"cid:111": cache_entry})
+                loaded_payload = build_data.load_places_cache("tokyo-japan")
+
+        assert cache_entry.place is not None
+        self.assertEqual(
+            cache_entry.place.primary_type_display_name,
+            "Restaurant",
+        )
+        self.assertEqual(
+            cache_entry.place.primary_type_display_name_localized,
+            "レストラン",
+        )
+        self.assertEqual(
+            cache_entry.place.photo_url,
+            "https://lh3.googleusercontent.com:443/a-/ALV-UjW_avatar=w680-h680-p-rp-mo-br100",
+        )
+        assert loaded_payload["cid:111"].place is not None
+        self.assertEqual(loaded_payload["cid:111"].place.primary_type_display_name, "Restaurant")
+        self.assertEqual(loaded_payload["cid:111"].place.primary_type_display_name_localized, "レストラン")
+        self.assertIsNone(loaded_payload["cid:111"].place.photo_url)
 
     def test_export_places_cache_json_writes_debug_output(self) -> None:
         cache_entry = EnrichmentCacheEntry(


### PR DESCRIPTION
## Description
- canonicalize enrichment cache entries on save/load using a copied entry so callers do not see unexpected in-memory mutations after SQLite persistence
- remove redundant `as_string()` wrapping before `sanitize_place_photo_url()` so the sanitizer remains the single normalization point
- add regression coverage for static-map/avatar photo URLs, host-with-port handling, dimension thresholds, and non-mutating cache serialization

## Related Issue
- None

## How Has This Been Tested?
- `../tools/uv-aarch64-apple-darwin/uv run python3 -m unittest tests.python.test_build_data`
