### PR TITLE
[codex] Fix refresh branch merge identity

### DIFF
--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -193,6 +193,9 @@ jobs:
         run: |
           set -euo pipefail
 
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           git fetch origin main
           if git ls-remote --exit-code --heads origin "${REFRESH_BRANCH}" >/dev/null 2>&1; then
             git fetch origin "${REFRESH_BRANCH}:${REFRESH_BRANCH}"

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -188,13 +188,18 @@ jobs:
       - name: Install Python dependencies
         run: uv sync --frozen
 
-      - name: Prepare refresh branch
+      - name: Configure Git identity
         shell: bash
         run: |
           set -euo pipefail
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Prepare refresh branch
+        shell: bash
+        run: |
+          set -euo pipefail
 
           git fetch origin main
           if git ls-remote --exit-code --heads origin "${REFRESH_BRANCH}" >/dev/null 2>&1; then
@@ -256,8 +261,6 @@ jobs:
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "Refresh place data (${PROFILE})"
           git push origin "${REFRESH_BRANCH}"
 


### PR DESCRIPTION
## Description
Configure the data-refresh workflow to set a Git identity before merging `origin/main` into `automation/data-refresh`.
This fixes the self-hosted refresh job failure where `git merge --no-edit` aborts because no committer name/email is configured.

## Related Issue
None found.

## How Has This Been Tested?
Not run locally; validated against the failing downstream GitHub Actions job and the matching workflow logic in this repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated data refresh workflow configuration to ensure Git commit author metadata is initialized earlier in the process, improving workflow reliability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->