### PR TITLE
chore: add GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,37 @@
+name: 🐞 Bug Report
+description: Create a bug report to help us improve
+title: "bug: "
+labels: ["🐞❔ unconfirmed bug"]
+body:
+  - type: textarea
+    attributes:
+      label: Provide environment information
+      description: |
+        Run this command in your project root and paste the results in a code block:
+        ```bash
+        npx envinfo --system --binaries
+        ```
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of the bug, as well as what you expected to happen when encountering it.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Link to reproduction
+      description: Please provide a link to a reproduction of the bug. Issues without a reproduction repo may be ignored.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: To reproduce
+      description: Describe how to reproduce your bug. Steps, code snippets, reproduction repos etc.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Add any other information related to the bug here, screenshots if applicable.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,9 +7,12 @@ body:
     attributes:
       label: Provide environment information
       description: |
-        Run this command in your project root and paste the results in a code block:
+        Run these commands in your project root and paste the results in a code block:
         ```bash
         npx envinfo --system --binaries
+        bun --version
+        python3 --version
+        uv --version
         ```
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,8 @@ body:
       description: |
         Run these commands in your project root and paste the results in a code block:
         ```bash
-        npx envinfo --system --binaries
+        bunx envinfo --system --binaries
+        # If bunx is unavailable, use: npx envinfo --system --binaries
         bun --version
         python3 --version
         uv --version

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: Ask a question
+    url: https://github.com/t3-oss/create-t3-turbo/discussions
+    about: Ask questions and discuss with other community members
+  - name: Feature request
+    url: https://github.com/t3-oss/create-t3-turbo/discussions/new?category=ideas
+    about: Feature requests should be opened as discussions

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,1 @@
-contact_links:
-  - name: Ask a question
-    url: https://github.com/t3-oss/create-t3-turbo/discussions
-    about: Ask questions and discuss with other community members
-  - name: Feature request
-    url: https://github.com/t3-oss/create-t3-turbo/discussions/new?category=ideas
-    about: Feature requests should be opened as discussions
+blank_issues_enabled: true


### PR DESCRIPTION
## Description
Add a GitHub bug report form and a minimal issue template config.
This gives the repo a structured bug intake without carrying over unrelated discussion links from another project.

## Related Issue
None found after checking existing GitHub issues.

## How Has This Been Tested?
Not run. This change only adds GitHub metadata files.
