### PR TITLE
Add route-level SEO metadata

### DIFF
--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -7,10 +7,21 @@ import { siteConfig } from "../data/site";
 interface Props {
   title: string;
   description?: string;
+  canonicalPath?: string;
+  image?: string | null;
+  openGraphType?: "website" | "article";
+  robots?: string;
+  jsonLd?: Record<string, unknown> | Array<Record<string, unknown>>;
 }
 
-const { title, description } = Astro.props;
+const { title, description, canonicalPath, image, openGraphType, robots, jsonLd } = Astro.props;
 const metaDescription = description ?? siteConfig.siteDescription;
+const siteUrl = Astro.site ?? new URL("/", Astro.url);
+const canonicalUrl = new URL(canonicalPath ?? Astro.url.pathname, siteUrl).toString();
+const resolveAbsoluteUrl = (value: string | null | undefined) =>
+  value ? new URL(value, siteUrl).toString() : undefined;
+const metaImage = resolveAbsoluteUrl(image ?? siteConfig.defaultSeoImage);
+const jsonLdEntries = (Array.isArray(jsonLd) ? jsonLd : jsonLd ? [jsonLd] : []).filter(Boolean);
 ---
 
 <!doctype html>
@@ -21,10 +32,21 @@ const metaDescription = description ?? siteConfig.siteDescription;
     <title>{title}</title>
     <meta name="description" content={metaDescription} />
     <meta name="author" content={siteConfig.ownerName} />
+    <meta name="robots" content={robots ?? "index,follow"} />
+    <link rel="canonical" href={canonicalUrl} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={metaDescription} />
     <meta property="og:site_name" content={siteConfig.siteName} />
-    {siteConfig.defaultSeoImage && <meta property="og:image" content={siteConfig.defaultSeoImage} />}
+    <meta property="og:type" content={openGraphType ?? "website"} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta name="twitter:card" content={metaImage ? "summary_large_image" : "summary"} />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={metaDescription} />
+    {metaImage && <meta property="og:image" content={metaImage} />}
+    {metaImage && <meta name="twitter:image" content={metaImage} />}
+    {jsonLdEntries.map((entry) => (
+      <script is:inline type="application/ld+json" set:html={JSON.stringify(entry)} />
+    ))}
     {siteConfig.favicon && (
       <link
         rel="icon"

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -3,6 +3,7 @@
 import "../styles/global.css";
 import "favorite-places:site-theme";
 import { siteConfig } from "../data/site";
+import { serializeJsonLdForHtml } from "../lib/seo";
 
 interface Props {
   title: string;
@@ -45,7 +46,11 @@ const jsonLdEntries = (Array.isArray(jsonLd) ? jsonLd : jsonLd ? [jsonLd] : []).
     {metaImage && <meta property="og:image" content={metaImage} />}
     {metaImage && <meta name="twitter:image" content={metaImage} />}
     {jsonLdEntries.map((entry) => (
-      <script is:inline type="application/ld+json" set:html={JSON.stringify(entry)} />
+      <script
+        is:inline
+        type="application/ld+json"
+        set:html={serializeJsonLdForHtml(entry)}
+      ></script>
     ))}
     {siteConfig.favicon && (
       <link

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -24,7 +24,7 @@ const countryNameBySlug: Record<string, string> = {
   seychelles: "Seychelles",
 };
 
-function getDisplayCountryName(guide: Guide): string {
+export function getDisplayCountryName(guide: Guide): string {
   if (guide.slug in countryNameBySlug) {
     return countryNameBySlug[guide.slug];
   }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -4,6 +4,8 @@ import type { Guide, GuideManifest, Place } from "./types";
 export type SeoJsonLd = Record<string, unknown>;
 
 const DEFAULT_DESCRIPTION_LENGTH = 160;
+const HOME_JSON_LD_GUIDE_LIMIT = 24;
+const GUIDE_JSON_LD_PLACE_LIMIT = 25;
 
 function normalizeWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
@@ -53,6 +55,10 @@ export function toPlainText(value: string | null | undefined): string | null {
 
   const normalized = normalizeWhitespace(stripMarkdownLinks(value));
   return normalized || null;
+}
+
+export function serializeJsonLdForHtml(value: SeoJsonLd): string {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
 }
 
 export function buildHomeMetaDescription({
@@ -137,6 +143,18 @@ export function buildHomeJsonLd({
   description: string;
   guides: GuideManifest[];
 }): SeoJsonLd {
+  const itemListElement = guides.slice(0, HOME_JSON_LD_GUIDE_LIMIT).map((guide, index) => ({
+    "@type": "ListItem",
+    position: index + 1,
+    url: new URL(`/guides/${guide.slug}/`, siteUrl).toString(),
+    name: guide.title,
+    description:
+      toPlainText(guide.description) ??
+      truncateDescription(
+        `${guide.place_count} saved places in ${[guide.city_name, guide.country_name].filter(Boolean).join(", ")}.`,
+      ),
+  }));
+
   return {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
@@ -149,18 +167,8 @@ export function buildHomeJsonLd({
     },
     mainEntity: {
       "@type": "ItemList",
-      numberOfItems: guides.length,
-      itemListElement: guides.slice(0, 24).map((guide, index) => ({
-        "@type": "ListItem",
-        position: index + 1,
-        url: new URL(`/guides/${guide.slug}/`, siteUrl).toString(),
-        name: guide.title,
-        description:
-          toPlainText(guide.description) ??
-          truncateDescription(
-            `${guide.place_count} saved places in ${[guide.city_name, guide.country_name].filter(Boolean).join(", ")}.`,
-          ),
-      })),
+      numberOfItems: itemListElement.length,
+      itemListElement,
     },
   };
 }
@@ -201,6 +209,12 @@ export function buildGuideJsonLd({
   countryName: string;
   visiblePlaces: Place[];
 }): SeoJsonLd[] {
+  const itemListElement = visiblePlaces.slice(0, GUIDE_JSON_LD_PLACE_LIMIT).map((place, index) => ({
+    "@type": "ListItem",
+    position: index + 1,
+    item: buildPlaceEntity(place),
+  }));
+
   return [
     {
       "@context": "https://schema.org",
@@ -245,12 +259,8 @@ export function buildGuideJsonLd({
         : {}),
       mainEntity: {
         "@type": "ItemList",
-        numberOfItems: visiblePlaces.length,
-        itemListElement: visiblePlaces.slice(0, 25).map((place, index) => ({
-          "@type": "ListItem",
-          position: index + 1,
-          item: buildPlaceEntity(place),
-        })),
+        numberOfItems: itemListElement.length,
+        itemListElement,
       },
     },
   ];

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,257 @@
+import { siteConfig } from "../data/site";
+import type { Guide, GuideManifest, Place } from "./types";
+
+export type SeoJsonLd = Record<string, unknown>;
+
+const DEFAULT_DESCRIPTION_LENGTH = 160;
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function stripMarkdownLinks(value: string): string {
+  return value
+    .replace(/\[([^\]\n]+)\]\((https?:\/\/[^\s)]+)\)/g, "$1")
+    .replace(/https?:\/\/\S+/g, "");
+}
+
+function formatList(values: string[]): string {
+  if (values.length === 0) {
+    return "";
+  }
+
+  if (values.length === 1) {
+    return values[0];
+  }
+
+  if (values.length === 2) {
+    return `${values[0]} and ${values[1]}`;
+  }
+
+  return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
+}
+
+function formatCategoryLabel(value: string): string {
+  return normalizeWhitespace(value.replace(/-/g, " "));
+}
+
+function truncateDescription(value: string, maxLength = DEFAULT_DESCRIPTION_LENGTH): string {
+  const normalized = normalizeWhitespace(value);
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  const cutoff = normalized.lastIndexOf(" ", maxLength - 3);
+  const sliceEnd = cutoff >= Math.floor(maxLength * 0.6) ? cutoff : maxLength - 3;
+  return `${normalized.slice(0, sliceEnd).trimEnd()}...`;
+}
+
+export function toPlainText(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = normalizeWhitespace(stripMarkdownLinks(value));
+  return normalized || null;
+}
+
+export function buildHomeMetaDescription({
+  intro,
+  guideCount,
+  countryCount,
+  placeCount,
+}: {
+  intro: string;
+  guideCount: number;
+  countryCount: number;
+  placeCount: number;
+}): string {
+  return truncateDescription(
+    `${toPlainText(intro) ?? siteConfig.siteDescription} Browse ${guideCount} guides across ${countryCount} countries and ${placeCount} saved places.`,
+  );
+}
+
+export function buildGuideMetaDescription({
+  guide,
+  countryName,
+  featuredPlaceNames,
+}: {
+  guide: Guide;
+  countryName: string;
+  featuredPlaceNames: string[];
+}): string {
+  const explicitDescription = toPlainText(guide.description);
+  if (explicitDescription) {
+    return truncateDescription(explicitDescription);
+  }
+
+  const location = [guide.city_name, countryName].filter(Boolean).join(", ");
+  const placeLabel = guide.place_count === 1 ? "place" : "places";
+  const featuredSnippet = featuredPlaceNames.length
+    ? ` Includes ${formatList(featuredPlaceNames.slice(0, 3))}.`
+    : "";
+  const categorySnippet =
+    !featuredSnippet && guide.top_categories.length
+      ? ` Highlights ${formatList(guide.top_categories.slice(0, 3).map(formatCategoryLabel))}.`
+      : "";
+
+  return truncateDescription(
+    `${guide.place_count} saved ${placeLabel} in ${location}.${featuredSnippet}${categorySnippet}`,
+  );
+}
+
+function buildPublisher(): SeoJsonLd | undefined {
+  const publisherName = normalizeWhitespace(siteConfig.ownerName);
+  if (!publisherName) {
+    return undefined;
+  }
+
+  return {
+    "@type": "Person",
+    name: publisherName,
+  };
+}
+
+export function buildWebsiteJsonLd(siteUrl: string): SeoJsonLd {
+  const publisher = buildPublisher();
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": `${siteUrl}#website`,
+    name: siteConfig.siteName,
+    url: siteUrl,
+    description: siteConfig.siteDescription,
+    ...(publisher ? { publisher } : {}),
+  };
+}
+
+export function buildHomeJsonLd({
+  siteUrl,
+  pageUrl,
+  description,
+  guides,
+}: {
+  siteUrl: string;
+  pageUrl: string;
+  description: string;
+  guides: GuideManifest[];
+}): SeoJsonLd {
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": `${pageUrl}#webpage`,
+    url: pageUrl,
+    name: siteConfig.siteName,
+    description,
+    isPartOf: {
+      "@id": `${siteUrl}#website`,
+    },
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: guides.length,
+      itemListElement: guides.slice(0, 24).map((guide, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        url: new URL(`/guides/${guide.slug}/`, siteUrl).toString(),
+        name: guide.title,
+        description:
+          toPlainText(guide.description) ??
+          truncateDescription(
+            `${guide.place_count} saved places in ${[guide.city_name, guide.country_name].filter(Boolean).join(", ")}.`,
+          ),
+      })),
+    },
+  };
+}
+
+function buildPlaceEntity(place: Place): SeoJsonLd {
+  return {
+    "@type": "Place",
+    name: place.name,
+    ...(place.address ? { address: place.address } : {}),
+    ...(place.maps_url ? { sameAs: place.maps_url } : {}),
+    ...(toPlainText(place.note ?? place.why_recommended)
+      ? { description: toPlainText(place.note ?? place.why_recommended) }
+      : {}),
+    ...(typeof place.lat === "number" && typeof place.lng === "number"
+      ? {
+          geo: {
+            "@type": "GeoCoordinates",
+            latitude: place.lat,
+            longitude: place.lng,
+          },
+        }
+      : {}),
+  };
+}
+
+export function buildGuideJsonLd({
+  siteUrl,
+  pageUrl,
+  description,
+  guide,
+  countryName,
+  visiblePlaces,
+}: {
+  siteUrl: string;
+  pageUrl: string;
+  description: string;
+  guide: Guide;
+  countryName: string;
+  visiblePlaces: Place[];
+}): SeoJsonLd[] {
+  return [
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: siteConfig.siteName,
+          item: siteUrl,
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: guide.title,
+          item: pageUrl,
+        },
+      ],
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "CollectionPage",
+      "@id": `${pageUrl}#webpage`,
+      url: pageUrl,
+      name: guide.title,
+      description,
+      isPartOf: {
+        "@id": `${siteUrl}#website`,
+      },
+      about: {
+        "@type": "Place",
+        name: [guide.city_name, countryName].filter(Boolean).join(", "),
+      },
+      ...(guide.list_tags.length || guide.top_categories.length
+        ? {
+            keywords: [...guide.list_tags, ...guide.top_categories]
+              .map((value) => normalizeWhitespace(value))
+              .filter(Boolean)
+              .slice(0, 10)
+              .join(", "),
+          }
+        : {}),
+      mainEntity: {
+        "@type": "ItemList",
+        numberOfItems: visiblePlaces.length,
+        itemListElement: visiblePlaces.slice(0, 25).map((place, index) => ({
+          "@type": "ListItem",
+          position: index + 1,
+          item: buildPlaceEntity(place),
+        })),
+      },
+    },
+  ];
+}

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -5,7 +5,7 @@ import Layout from "../../components/Layout.astro";
 import PlaceCard from "../../components/PlaceCard.astro";
 import SectionHeading from "../../components/ui/SectionHeading.astro";
 import { siteConfig } from "../../data/site";
-import { getGuides } from "../../lib/data";
+import { getDisplayCountryName, getGuides } from "../../lib/data";
 import { getGuideAsideHtml, getTemplateHtml } from "../../lib/heroAsideContent";
 import {
   getDisplayGuideTags,
@@ -14,6 +14,7 @@ import {
   normalizeTagValue,
 } from "../../lib/placeTags";
 import { renderRichText } from "../../lib/renderRichText";
+import { buildGuideJsonLd, buildGuideMetaDescription, buildWebsiteJsonLd } from "../../lib/seo";
 import type { Place } from "../../lib/types";
 
 const DEFAULT_SUGGESTION_PRIORITY = [
@@ -115,6 +116,7 @@ const areaFilterGroups = getGuideAreaFilterGroups(visiblePlaces);
 const areaFilters = areaFilterGroups.primary;
 const broaderAreaFilters = areaFilterGroups.secondary;
 const displayGuideTags = getDisplayGuideTags(guide.list_tags, placeTagGuideContext);
+const displayCountryName = getDisplayCountryName(guide);
 const explicitTypes = [
   ...visiblePlaces.reduce((typeCounts, place) => {
     if (place.primary_category) {
@@ -207,9 +209,37 @@ const guideSidebarFallback = siteConfig.guide.sidebarContent
   .map((content) => renderRichText(content))
   .filter((content): content is string => Boolean(content));
 const hasMappablePlaces = visiblePlaces.some((place) => place.lat !== null && place.lng !== null);
+const featuredPlaceNames = visiblePlaces
+  .filter((place) => featuredPlaceIds.has(place.id))
+  .map((place) => place.name)
+  .slice(0, 3);
+const guideMetaDescription = buildGuideMetaDescription({
+  guide,
+  countryName: displayCountryName,
+  featuredPlaceNames,
+});
+const siteUrl = new URL("/", Astro.site ?? Astro.url).toString();
+const pageUrl = new URL(`/guides/${guide.slug}/`, Astro.site ?? Astro.url).toString();
+const guideJsonLd = [
+  buildWebsiteJsonLd(siteUrl),
+  ...buildGuideJsonLd({
+    siteUrl,
+    pageUrl,
+    description: guideMetaDescription,
+    guide,
+    countryName: displayCountryName,
+    visiblePlaces,
+  }),
+];
 ---
 
-<Layout title={`${guide.title} · ${siteConfig.siteName}`} description={guide.description ?? undefined}>
+<Layout
+  title={`${guide.title} · ${siteConfig.siteName}`}
+  description={guideMetaDescription}
+  canonicalPath={`/guides/${guide.slug}/`}
+  openGraphType="article"
+  jsonLd={guideJsonLd}
+>
   <section class="hero ui-hero">
     <div class="hero-grid ui-hero-grid">
       <div class="section-stack ui-stack">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -137,7 +137,6 @@ const homeHighlights = siteConfig.home.highlights
 const homeBeforeGuidesHtml = getTemplateHtml("home-before-guides.html");
 const homeAfterGuidesHtml = getTemplateHtml("home-after-guides.html");
 const siteUrl = new URL("/", Astro.site ?? Astro.url).toString();
-const pageUrl = new URL("/", Astro.site ?? Astro.url).toString();
 const homeMetaDescription = buildHomeMetaDescription({
   intro: siteConfig.home.intro,
   guideCount: guides.length,
@@ -148,7 +147,7 @@ const homeJsonLd = [
   buildWebsiteJsonLd(siteUrl),
   buildHomeJsonLd({
     siteUrl,
-    pageUrl,
+    pageUrl: siteUrl,
     description: homeMetaDescription,
     guides,
   }),

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import { siteConfig } from "../data/site";
 import { getGuideManifests } from "../lib/data";
 import { getHomeAsideHtml, getTemplateHtml } from "../lib/heroAsideContent";
 import { renderRichText } from "../lib/renderRichText";
+import { buildHomeJsonLd, buildHomeMetaDescription, buildWebsiteJsonLd } from "../lib/seo";
 
 const guides = getGuideManifests();
 const countryEntries = Object.entries(
@@ -135,11 +136,31 @@ const homeHighlights = siteConfig.home.highlights
   .filter((highlight): highlight is string => Boolean(highlight));
 const homeBeforeGuidesHtml = getTemplateHtml("home-before-guides.html");
 const homeAfterGuidesHtml = getTemplateHtml("home-after-guides.html");
+const siteUrl = new URL("/", Astro.site ?? Astro.url).toString();
+const pageUrl = new URL("/", Astro.site ?? Astro.url).toString();
+const homeMetaDescription = buildHomeMetaDescription({
+  intro: siteConfig.home.intro,
+  guideCount: guides.length,
+  countryCount,
+  placeCount,
+});
+const homeJsonLd = [
+  buildWebsiteJsonLd(siteUrl),
+  buildHomeJsonLd({
+    siteUrl,
+    pageUrl,
+    description: homeMetaDescription,
+    guides,
+  }),
+];
 ---
 
 <Layout
   title={siteConfig.siteName}
-  description={siteConfig.siteDescription}
+  description={homeMetaDescription}
+  canonicalPath="/"
+  openGraphType="website"
+  jsonLd={homeJsonLd}
 >
   {siteConfig.home.showHero && (
     <section class="hero ui-hero">

--- a/tests/frontend/seo.test.ts
+++ b/tests/frontend/seo.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGuideJsonLd,
+  buildGuideMetaDescription,
+  buildHomeJsonLd,
+  buildHomeMetaDescription,
+  serializeJsonLdForHtml,
+  toPlainText,
+} from "../../src/lib/seo";
+import type { Guide, GuideManifest, Place } from "../../src/lib/types";
+
+function createGuideManifest(overrides: Partial<GuideManifest> = {}): GuideManifest {
+  return {
+    slug: "tokyo-japan",
+    title: "Tokyo, Japan",
+    description: null,
+    country_name: "Japan",
+    country_code: "JP",
+    center_lat: 35.6764,
+    center_lng: 139.65,
+    city_name: "Tokyo",
+    list_tags: [],
+    place_count: 3,
+    featured_names: [],
+    top_categories: ["restaurant"],
+    ...overrides,
+  };
+}
+
+function createPlace(overrides: Partial<Place> = {}): Place {
+  return {
+    id: "place-1",
+    name: "Coffee Spot",
+    address: "1 Example St",
+    lat: 35.0,
+    lng: 139.0,
+    maps_url: "https://maps.example/place-1",
+    cid: null,
+    google_id: null,
+    google_place_id: null,
+    google_place_resource_name: null,
+    rating: 4.5,
+    user_rating_count: 120,
+    primary_category: "cafe",
+    primary_category_localized: null,
+    marker_icon: "cafe",
+    tags: ["coffee"],
+    vibe_tags: ["quiet"],
+    locality_path: [],
+    neighborhood: "Shibuya",
+    note: "Great espresso",
+    why_recommended: null,
+    main_photo_path: null,
+    top_pick: false,
+    hidden: false,
+    manual_rank: 0,
+    status: "open",
+    provenance: {
+      tags: [],
+    },
+    ...overrides,
+  };
+}
+
+function createGuide(overrides: Partial<Guide> = {}): Guide {
+  return {
+    slug: "tokyo-japan",
+    title: "Tokyo, Japan",
+    description: null,
+    source_url: null,
+    list_id: null,
+    country_name: "Japan",
+    country_code: "JP",
+    city_name: "Tokyo",
+    list_tags: ["coffee", "late-night"],
+    featured_place_ids: [],
+    best_hit_place_ids: [],
+    best_hit_min_rating: null,
+    best_hit_min_reviews: null,
+    top_categories: ["coffee-shop", "restaurant"],
+    generated_at: "2026-04-28T00:00:00.000Z",
+    place_count: 3,
+    center_lat: 35.6764,
+    center_lng: 139.65,
+    places: [],
+    ...overrides,
+  };
+}
+
+describe("seo helpers", () => {
+  it("normalizes markdown links, raw urls, and whitespace to plain text", () => {
+    expect(
+      toPlainText("  Start [Example](https://example.com) and https://foo.test  \n  End  "),
+    ).toBe("Start Example and End");
+  });
+
+  it("builds a home meta description from intro text and counters", () => {
+    expect(
+      buildHomeMetaDescription({
+        intro: " Saved places for trip planning. ",
+        guideCount: 12,
+        countryCount: 5,
+        placeCount: 320,
+      }),
+    ).toBe(
+      "Saved places for trip planning. Browse 12 guides across 5 countries and 320 saved places.",
+    );
+  });
+
+  it("uses explicit guide descriptions after plain-text normalization", () => {
+    const guide = createGuide({
+      description: "A [great](https://example.com) food guide for Tokyo.",
+    });
+
+    expect(
+      buildGuideMetaDescription({
+        guide,
+        countryName: "Japan",
+        featuredPlaceNames: ["Sushi Saito"],
+      }),
+    ).toBe("A great food guide for Tokyo.");
+  });
+
+  it("builds a fallback guide description from location and featured places", () => {
+    const guide = createGuide({
+      description: null,
+      place_count: 4,
+      top_categories: ["coffee-shop", "bakery"],
+    });
+
+    expect(
+      buildGuideMetaDescription({
+        guide,
+        countryName: "Japan",
+        featuredPlaceNames: ["Glitch Coffee", "Fuglen Tokyo"],
+      }),
+    ).toBe("4 saved places in Tokyo, Japan. Includes Glitch Coffee and Fuglen Tokyo.");
+  });
+
+  it("escapes opening angle brackets when serializing JSON-LD for html", () => {
+    expect(
+      serializeJsonLdForHtml({
+        "@context": "https://schema.org",
+        description: "</script><script>alert(1)</script>",
+      }),
+    ).toContain("\\u003c/script>\\u003cscript>alert(1)\\u003c/script>");
+  });
+
+  it("keeps home JSON-LD list counts aligned with the emitted guide list", () => {
+    const guides = Array.from({ length: 30 }, (_, index) =>
+      createGuideManifest({
+        slug: `guide-${index + 1}`,
+        title: `Guide ${index + 1}`,
+      }),
+    );
+
+    const jsonLd = buildHomeJsonLd({
+      siteUrl: "https://favorite-places.pages.dev/",
+      pageUrl: "https://favorite-places.pages.dev/",
+      description: "Home page description",
+      guides,
+    });
+
+    const itemList = jsonLd.mainEntity as {
+      numberOfItems: number;
+      itemListElement: unknown[];
+    };
+
+    expect(itemList.numberOfItems).toBe(24);
+    expect(itemList.itemListElement).toHaveLength(24);
+  });
+
+  it("keeps guide JSON-LD list counts aligned with the emitted place list", () => {
+    const visiblePlaces = Array.from({ length: 28 }, (_, index) =>
+      createPlace({
+        id: `place-${index + 1}`,
+        name: `Place ${index + 1}`,
+      }),
+    );
+    const guide = createGuide({
+      place_count: visiblePlaces.length,
+      places: visiblePlaces,
+    });
+
+    const [, collectionPage] = buildGuideJsonLd({
+      siteUrl: "https://favorite-places.pages.dev/",
+      pageUrl: "https://favorite-places.pages.dev/guides/tokyo-japan/",
+      description: "Guide description",
+      guide,
+      countryName: "Japan",
+      visiblePlaces,
+    });
+
+    const itemList = collectionPage.mainEntity as {
+      numberOfItems: number;
+      itemListElement: unknown[];
+    };
+
+    expect(itemList.numberOfItems).toBe(25);
+    expect(itemList.itemListElement).toHaveLength(25);
+  });
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,6 +1,14 @@
+import { fileURLToPath } from "node:url";
 import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "favorite-places:site-config": fileURLToPath(
+        new URL("./site.example/config.ts", import.meta.url),
+      ),
+    },
+  },
   test: {
     exclude: [...configDefaults.exclude, ".context/**"],
   },


### PR DESCRIPTION
## Description
Adds centralized SEO metadata handling for the shared layout and wires route-specific metadata into the home and guide pages. This includes canonical URLs, robots tags, Open Graph and Twitter metadata, and JSON-LD structured data with generated fallback descriptions.

## Related Issue
No related open issue found after searching `508-dev/favorite-places` for SEO, metadata, canonical, Open Graph, Twitter card, and structured-data issues.

## How Has This Been Tested?
- `bun run check`
- `bun run build:data`
- `bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced SEO capabilities with canonical URL and robots directive support.
  * Dynamic meta descriptions optimized for search engines.
  * Improved Open Graph and social media card metadata with image handling.
  * Added JSON-LD schema markup for better search visibility and rich snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->