### PR TITLE
Design system audit: typography, tokens, 404 page, touch targets

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Dev server (site.example)",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["run", "dev"],
+      "port": 4972,
+      "env": {
+        "FAVORITE_PLACES_SITE_DIR": "site.example"
+      }
+    }
+  ]
+}

--- a/site.example/theme.css
+++ b/site.example/theme.css
@@ -1,16 +1,16 @@
 :root {
-  --bg: #30383f;
-  --bg-strong: #eef1f3;
-  --surface: #ffffff;
-  --surface-strong: #f7f7f4;
-  --ink: #20262c;
-  --muted: #555f66;
-  --line: #d8dde0;
-  --accent: #b94736;
-  --accent-strong: #8f2f25;
-  --accent-soft: rgba(185, 71, 54, 0.13);
-  --radius-lg: 6px;
-  --radius-md: 4px;
-  --radius-sm: 3px;
-  --page-width: 1800px;
+  --bg: #28332f;
+  --bg-strong: #eef1ea;
+  --surface: #fffdf8;
+  --surface-strong: #f5f0e8;
+  --ink: #1e2523;
+  --muted: #59655f;
+  --line: #ddd7ca;
+  --accent: #bd4f3f;
+  --accent-strong: #8e342b;
+  --accent-soft: rgba(189, 79, 63, 0.13);
+  --radius-lg: 8px;
+  --radius-md: 6px;
+  --radius-sm: 5px;
+  --page-width: 1280px;
 }

--- a/src/components/HomeGuideMap.astro
+++ b/src/components/HomeGuideMap.astro
@@ -138,7 +138,6 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     };
   }
 
-  const MARKER_COLOR = "#c4312d";
   const HOME_MAP_COLLAPSED_KEY = "favoritePlacesHomeMapCollapsed";
   const WORLD_MAP_MAX_LATITUDE = 85.05112878;
   const WORLD_MAP_MIN_ZOOM = 0;
@@ -158,6 +157,14 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     __favoritePlacesGoogleMapsInit?: () => void;
     __favoritePlacesGoogleMapsLoader?: Promise<unknown>;
     google?: unknown;
+  };
+  const getThemeValue = (name: string, fallback: string) => {
+    const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    return value || fallback;
+  };
+  const getThemeFontStack = (name: string, fallback: string) => {
+    const value = getThemeValue(name, fallback);
+    return value.replace(/"/g, "'");
   };
 
   const escapeHtml = (value: string) =>
@@ -377,21 +384,25 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     });
     const infoWindow = new googleMaps.maps.InfoWindow();
     const markers = new Map<string, any>();
+    const markerColor = getThemeValue("--accent", "#b94736");
+    const markerFillColor = getThemeValue("--surface-strong", "#f7f7f4");
+    const markerLabelColor = getThemeValue("--ink", "#20262c");
+    const markerLabelFont = getThemeFontStack("--font-display", "Raleway, Lato, Helvetica, Arial, sans-serif");
 
     guides.forEach((guide) => {
       const marker = new googleMaps.maps.Marker({
         icon: {
-          fillColor: "#fffaf1",
+          fillColor: markerFillColor,
           fillOpacity: 0.96,
           path: googleMaps.maps.SymbolPath.CIRCLE,
           scale: 18,
-          strokeColor: MARKER_COLOR,
+          strokeColor: markerColor,
           strokeOpacity: 0.98,
           strokeWeight: 2,
         },
         label: {
-          color: "#1f1a16",
-          fontFamily: '"Avenir Next", "Segoe UI", sans-serif',
+          color: markerLabelColor,
+          fontFamily: markerLabelFont,
           fontSize: markerLabelUnits(guide.markerLabel) <= 2 ? "14px" : "18px",
           fontWeight: "800",
           text: guide.markerLabel,

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,16 +5,14 @@ import { siteConfig } from "../data/site";
 ---
 
 <Layout title={`Page not found — ${siteConfig.siteName}`} robots="noindex">
-  <div class="ui-page-shell">
-    <div class="ui-section" style="text-align: center; padding-block: 4rem;">
-      <p class="ui-eyebrow">404</p>
-      <h1 class="ui-display" style="margin-block: 1rem;">Page not found</h1>
-      <p class="ui-lede" style="margin-inline: auto;">
-        The page you're looking for doesn't exist or may have moved.
-      </p>
-      <div class="ui-meta-row" style="justify-content: center; margin-top: 2rem;">
-        <a href="/" class="ui-pill ui-pill--brand">← Back to all guides</a>
-      </div>
+  <div class="ui-section" style="text-align: center; padding-block: 4rem;">
+    <p class="ui-eyebrow">404</p>
+    <h1 class="ui-display" style="margin-block: 1rem;">Page not found</h1>
+    <p class="ui-lede" style="margin-inline: auto;">
+      The page you're looking for doesn't exist or may have moved.
+    </p>
+    <div class="ui-meta-row" style="justify-content: center; margin-top: 2rem;">
+      <a href="/" class="ui-pill ui-pill--brand">← Back to all guides</a>
     </div>
   </div>
 </Layout>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,13 +5,13 @@ import { siteConfig } from "../data/site";
 ---
 
 <Layout title={`Page not found — ${siteConfig.siteName}`} robots="noindex">
-  <div class="ui-section" style="text-align: center; padding-block: 4rem;">
+  <div class="ui-section ui-empty-page">
     <p class="ui-eyebrow">404</p>
-    <h1 class="ui-display" style="margin-block: 1rem;">Page not found</h1>
-    <p class="ui-lede" style="margin-inline: auto;">
+    <h1 class="ui-display">Page not found</h1>
+    <p class="ui-lede">
       The page you're looking for doesn't exist or may have moved.
     </p>
-    <div class="ui-meta-row" style="justify-content: center; margin-top: 2rem;">
+    <div class="ui-meta-row">
       <a href="/" class="ui-pill ui-pill--brand">← Back to all guides</a>
     </div>
   </div>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,20 @@
+---
+
+import Layout from "../components/Layout.astro";
+import { siteConfig } from "../data/site";
+---
+
+<Layout title={`Page not found — ${siteConfig.siteName}`} robots="noindex">
+  <div class="ui-page-shell">
+    <div class="ui-section" style="text-align: center; padding-block: 4rem;">
+      <p class="ui-eyebrow">404</p>
+      <h1 class="ui-display" style="margin-block: 1rem;">Page not found</h1>
+      <p class="ui-lede" style="margin-inline: auto;">
+        The page you're looking for doesn't exist or may have moved.
+      </p>
+      <div class="ui-meta-row" style="justify-content: center; margin-top: 2rem;">
+        <a href="/" class="ui-pill ui-pill--brand">← Back to all guides</a>
+      </div>
+    </div>
+  </div>
+</Layout>

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -26,7 +26,7 @@
 @layer components {
   .ui-site-header {
     width: min(calc(100% - 1rem), var(--page-width));
-    @apply mx-auto flex flex-wrap items-end justify-between gap-6 py-8;
+    @apply mx-auto flex flex-wrap items-end justify-between gap-6 py-6;
   }
 
   .ui-site-title {
@@ -47,19 +47,19 @@
   }
 
   .ui-site-nav a {
-    @apply text-white no-underline transition-colors;
+    @apply inline-flex min-h-[2.35rem] items-center rounded-pill border border-white/15 px-3 text-white no-underline transition-colors;
 
-    padding-block: 12px;
+    padding-block: 0;
   }
 
   .ui-site-nav a:hover,
   .ui-site-nav a:focus-visible {
-    @apply text-app-brand;
+    @apply border-white/30 bg-white/10 text-white;
   }
 
   .ui-page-shell {
     width: min(calc(100% - 1rem), var(--page-width));
-    @apply mx-auto mb-12 bg-app-panel px-4 py-4 sm:px-6 lg:px-8;
+    @apply mx-auto mb-12 rounded-card border border-black/10 bg-app-panel px-4 py-4 shadow-card sm:px-6 lg:px-8;
   }
 
   .ui-hero {
@@ -180,7 +180,7 @@
   }
 
   .ui-control-panel {
-    @apply rounded-card border border-app-line bg-app-panel-muted p-4;
+    @apply rounded-card border border-app-line bg-app-panel-muted p-4 shadow-card;
   }
 
   .ui-control-label {

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -136,7 +136,7 @@
   }
 
   .ui-section-title {
-    @apply m-0 text-[clamp(1.4rem,2.5vw,1.85rem)] font-bold leading-[1.12] text-app-ink;
+    @apply m-0 text-[clamp(1.4rem,2.5vw,1.85rem)] font-black leading-[1.12] text-app-ink;
     text-wrap: balance;
   }
 

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -136,7 +136,7 @@
   }
 
   .ui-section-title {
-    @apply m-0 text-[clamp(1.8rem,3vw,2.35rem)] font-black leading-[1.12] text-app-ink;
+    @apply m-0 text-[clamp(1.4rem,2.5vw,1.85rem)] font-bold leading-[1.12] text-app-ink;
     text-wrap: balance;
   }
 

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -47,6 +47,7 @@
 
   .ui-site-nav a {
     @apply text-white no-underline transition-colors;
+    padding-block: 12px;
   }
 
   .ui-site-nav a:hover,

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -5,6 +5,7 @@
     font-family: var(--font-sans);
     font-size: 17px;
     line-height: 1.65;
+    color-scheme: light;
   }
 
   body {

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -200,6 +200,22 @@
     @apply block;
   }
 
+  .ui-empty-page {
+    @apply flex flex-col items-center py-16 text-center;
+  }
+
+  .ui-empty-page .ui-display {
+    @apply my-4;
+  }
+
+  .ui-empty-page .ui-lede {
+    @apply mx-auto;
+  }
+
+  .ui-empty-page .ui-meta-row {
+    @apply mt-8 justify-center;
+  }
+
   .ui-search-results {
     @apply my-4 border-t border-app-line pt-4;
   }

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -158,7 +158,7 @@
 
   .ui-card:hover {
     border-color: var(--color-app-brand);
-    background: #fffdfd;
+    background: var(--color-app-panel);
   }
 
   .ui-card-link {

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -48,6 +48,7 @@
 
   .ui-site-nav a {
     @apply text-white no-underline transition-colors;
+
     padding-block: 12px;
   }
 

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -158,7 +158,7 @@
 
   .ui-card:hover {
     border-color: var(--color-app-brand);
-    background: var(--color-app-panel);
+    background: var(--color-app-brand-soft);
   }
 
   .ui-card-link {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,24 +4,27 @@
 @import "./theme.css";
 @import "./design-system.css";
 
-@layer legacy {
+/* Default tokens — lowest priority, overridden by the site pack's theme.css */
+@layer theme {
   :root {
-    --bg: #30383f;
-    --bg-strong: #eef1f3;
-    --surface: #ffffff;
-    --surface-strong: #f7f7f4;
-    --ink: #20262c;
-    --muted: #555f66;
-    --line: #d8dde0;
-    --accent: #b94736;
-    --accent-strong: #8f2f25;
-    --accent-soft: rgba(185, 71, 54, 0.13);
-    --radius-lg: 6px;
-    --radius-md: 4px;
-    --radius-sm: 3px;
-    --page-width: 1800px;
+    --bg: #28332f;
+    --bg-strong: #eef1ea;
+    --surface: #fffdf8;
+    --surface-strong: #f5f0e8;
+    --ink: #1e2523;
+    --muted: #59655f;
+    --line: #ddd7ca;
+    --accent: #bd4f3f;
+    --accent-strong: #8e342b;
+    --accent-soft: rgba(189, 79, 63, 0.13);
+    --radius-lg: 8px;
+    --radius-md: 6px;
+    --radius-sm: 5px;
+    --page-width: 1280px;
   }
+}
 
+@layer legacy {
   * {
     box-sizing: border-box;
   }
@@ -35,9 +38,18 @@
   }
 
   body {
+    position: relative;
     margin: 0;
     min-height: 100vh;
-    background: var(--bg);
+    background:
+      repeating-linear-gradient(
+        90deg,
+        rgba(255, 255, 255, 0.035) 0,
+        rgba(255, 255, 255, 0.035) 1px,
+        transparent 1px,
+        transparent 7.5rem
+      ),
+      linear-gradient(180deg, var(--bg) 0 18rem, var(--bg-strong) 18rem 100%);
   }
 
   a {
@@ -59,7 +71,7 @@
   .site-header {
     width: min(calc(100% - 1rem), var(--page-width));
     margin: 0 auto;
-    padding: 2.25rem 0 1.75rem;
+    padding: 1.65rem 0 1.15rem;
     display: flex;
     align-items: end;
     justify-content: space-between;
@@ -81,7 +93,7 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: end;
-    gap: 1rem;
+    gap: 0.75rem;
     font-family: Raleway, Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 0.76rem;
     font-weight: 700;
@@ -90,25 +102,40 @@
   }
 
   .site-nav a {
+    min-height: 2.35rem;
+    display: inline-flex;
+    align-items: center;
+    padding: 0 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: var(--radius-sm);
     color: white;
     text-decoration: none;
+    transition:
+      border-color 160ms ease,
+      background-color 160ms ease,
+      color 160ms ease;
   }
 
   .site-nav a:hover,
   .site-nav a:focus-visible {
-    color: var(--accent);
+    border-color: rgba(255, 255, 255, 0.32);
+    background: rgba(255, 255, 255, 0.08);
+    color: white;
   }
 
   .page-shell {
     width: min(calc(100% - 1rem), var(--page-width));
     margin: 0 auto 3rem;
-    padding: clamp(1rem, 2vw, 2rem);
+    padding: clamp(1.2rem, 2.4vw, 2.2rem);
+    border: 1px solid rgba(31, 37, 34, 0.08);
+    border-radius: var(--radius-lg);
     background: var(--surface);
+    box-shadow: 0 28px 70px rgba(18, 25, 22, 0.18);
   }
 
   .hero {
     position: relative;
-    padding: 0 0 clamp(2rem, 4vw, 3.5rem);
+    padding: clamp(0.35rem, 1vw, 0.8rem) 0 clamp(2rem, 4vw, 3.5rem);
     border-bottom: 1px solid var(--line);
   }
 
@@ -119,6 +146,16 @@
     font-weight: 700;
     letter-spacing: 0.1em;
     text-transform: uppercase;
+  }
+
+  .rich-copy code,
+  .small-copy code {
+    padding: 0.12rem 0.3rem;
+    border: 1px solid color-mix(in srgb, var(--line) 74%, transparent);
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--surface-strong) 78%, white);
+    color: var(--ink);
+    font-size: 0.92em;
   }
 
   .hero h1,
@@ -144,9 +181,9 @@
   .guide-warning {
     margin: 0;
     padding: 0.8rem 0.95rem;
-    border: 1px solid rgba(196, 49, 45, 0.35);
+    border: 1px solid rgba(185, 71, 54, 0.35);
     border-radius: var(--radius-md);
-    background: rgba(196, 49, 45, 0.08);
+    background: rgba(185, 71, 54, 0.08);
     color: var(--ink);
   }
 
@@ -219,7 +256,7 @@
     padding: 0 0.72rem;
     border-radius: var(--radius-sm);
     border: 1px solid var(--line);
-    background: var(--surface-strong);
+    background: color-mix(in srgb, var(--surface-strong) 86%, white);
     color: var(--muted);
     font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 0.82rem;
@@ -235,7 +272,7 @@
     padding: 0.18rem 0.72rem;
     border-radius: var(--radius-sm);
     border: 1px solid var(--line);
-    background: var(--surface-strong);
+    background: color-mix(in srgb, var(--surface-strong) 86%, white);
     color: var(--muted);
     font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 0.82rem;
@@ -267,6 +304,7 @@
     color: var(--surface);
     border-color: var(--accent);
     font-weight: 700;
+    box-shadow: 0 10px 22px rgba(142, 52, 43, 0.16);
   }
 
   .section {
@@ -520,7 +558,7 @@
 
   .country-filter[data-location-match="true"] {
     border-color: var(--accent);
-    box-shadow: 0 0 0 2px rgba(196, 49, 45, 0.18);
+    box-shadow: 0 0 0 2px rgba(185, 71, 54, 0.18);
   }
 
   .country-filter:disabled {
@@ -569,22 +607,42 @@
     background: var(--surface);
     border: 1px solid var(--line);
     border-radius: var(--radius-lg);
+    box-shadow: 0 12px 32px rgba(31, 37, 34, 0.07);
   }
 
   .guide-card {
     position: relative;
+    overflow: hidden;
     min-width: 0;
-    padding: 1.2rem;
+    padding: 1.25rem;
     display: grid;
     gap: 1rem;
     transition:
       border-color 160ms ease,
-      background-color 160ms ease;
+      background-color 160ms ease,
+      box-shadow 160ms ease,
+      transform 160ms ease;
+  }
+
+  .guide-card::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 4px;
+    background: var(--accent);
+    opacity: 0;
+    transition: opacity 160ms ease;
   }
 
   .guide-card:hover {
     border-color: var(--accent);
-    background: var(--accent-soft);
+    background: color-mix(in srgb, var(--accent-soft) 52%, var(--surface));
+    box-shadow: 0 18px 40px rgba(31, 37, 34, 0.12);
+    transform: translateY(-2px);
+  }
+
+  .guide-card:hover::before {
+    opacity: 1;
   }
 
   .guide-card-link {
@@ -617,6 +675,8 @@
     font-weight: 900;
     line-height: 1.25;
     letter-spacing: 0;
+    overflow-wrap: normal;
+    word-break: normal;
   }
 
   .guide-card p,
@@ -643,9 +703,7 @@
     container-type: inline-size;
     border: 1px solid var(--line);
     border-radius: var(--radius-lg);
-    background:
-      linear-gradient(180deg, rgba(236, 239, 242, 0.92) 0%, rgba(255, 255, 255, 1) 38%),
-      var(--surface);
+    background: color-mix(in srgb, var(--surface-strong) 28%, var(--surface));
     box-shadow: 0 16px 38px rgba(39, 47, 56, 0.08);
   }
 
@@ -726,7 +784,7 @@
   }
 
   .social-card-link-primary {
-    background: rgba(196, 49, 45, 0.05);
+    background: rgba(185, 71, 54, 0.05);
   }
 
   .social-card-link-copy {
@@ -792,7 +850,8 @@
   }
 
   .place-card {
-    padding: 1.1rem;
+    overflow: hidden;
+    padding: 1rem;
     display: grid;
     gap: 0.9rem;
     container-type: inline-size;
@@ -800,7 +859,8 @@
     transition:
       border-color 160ms ease,
       background-color 160ms ease,
-      box-shadow 160ms ease;
+      box-shadow 160ms ease,
+      transform 160ms ease;
   }
 
   .place-card[hidden] {
@@ -808,20 +868,22 @@
   }
 
   .place-card[data-top-pick="true"] {
-    background: #fffafa;
-    border-color: rgba(255, 112, 108, 0.4);
+    background: color-mix(in srgb, var(--accent-soft) 24%, var(--surface));
+    border-color: color-mix(in srgb, var(--accent) 42%, var(--line));
   }
 
   .place-card:hover,
   .place-card:focus-visible,
   .place-card[data-map-active="true"] {
     border-color: var(--accent);
-    background: var(--accent-soft);
+    background: color-mix(in srgb, var(--accent-soft) 52%, var(--surface));
+    box-shadow: 0 18px 42px rgba(31, 37, 34, 0.13);
+    transform: translateY(-2px);
   }
 
   .place-card[data-search-highlight="true"] {
     border-color: var(--accent);
-    box-shadow: 0 0 0 3px rgba(196, 49, 45, 0.18);
+    box-shadow: 0 0 0 3px rgba(185, 71, 54, 0.18);
   }
 
   .place-card:focus-visible {
@@ -840,7 +902,7 @@
     border-radius: calc(var(--radius-lg) - 0.2rem);
     aspect-ratio: 3 / 2;
     background:
-      linear-gradient(135deg, rgba(196, 49, 45, 0.12), rgba(215, 156, 69, 0.16)),
+      linear-gradient(135deg, rgba(185, 71, 54, 0.12), rgba(215, 156, 69, 0.16)),
       var(--surface-strong);
   }
 
@@ -849,6 +911,12 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+    transition: transform 280ms ease;
+  }
+
+  .place-card:hover .place-card-photo img,
+  .place-card:focus-visible .place-card-photo img {
+    transform: scale(1.035);
   }
 
   .place-card-photo-placeholder {
@@ -914,10 +982,8 @@
   }
 
   .place-card-title {
-    display: flex;
-    justify-content: space-between;
-    align-items: start;
-    gap: 1rem;
+    display: grid;
+    gap: 0.75rem;
   }
 
   .place-card-heading {
@@ -928,13 +994,14 @@
     display: inline-flex;
     flex: 0 0 auto;
     flex-wrap: wrap;
-    justify-content: flex-end;
+    justify-content: flex-start;
     gap: 0.45rem;
   }
 
   .place-card-name-row {
     width: 100%;
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: flex-start;
     gap: 0.5rem;
   }
@@ -946,8 +1013,10 @@
 
   .place-card-meta-row {
     width: 100%;
-    display: grid;
-    gap: 0.35rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.45rem 0.55rem;
   }
 
   .place-card-marker {
@@ -966,6 +1035,7 @@
 
   .place-card-meta-stats {
     align-items: center;
+    flex-basis: 100%;
   }
 
   .place-card-map-link {
@@ -977,7 +1047,7 @@
     flex: 0 0 auto;
     border: 1px solid rgba(18, 73, 160, 0.14);
     border-radius: 999px;
-    background: rgba(255, 255, 255, 0.96);
+    background: color-mix(in srgb, var(--surface) 92%, white);
     color: #18457a;
     box-shadow: 0 10px 24px rgba(39, 47, 56, 0.1);
     text-decoration: none;
@@ -1019,16 +1089,41 @@
   }
 
   @container (min-width: 26rem) {
-    .place-card-meta-row {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      gap: 0.35rem 0.55rem;
-    }
-
     .place-card-meta-stats {
+      flex-basis: auto;
       margin-left: auto;
       justify-content: flex-end;
+    }
+  }
+
+  @container (min-width: 34rem) {
+    .place-card-title {
+      display: flex;
+      justify-content: space-between;
+      align-items: start;
+      gap: 1rem;
+    }
+
+    .place-card-badges {
+      justify-content: flex-end;
+    }
+  }
+
+  @container (max-width: 26rem) {
+    .place-card h3 {
+      font-size: clamp(1.22rem, 8cqw, 1.7rem);
+      line-height: 1.12;
+    }
+
+    .place-card-map-link {
+      width: 2.35rem;
+      min-height: 2.35rem;
+      justify-content: center;
+      padding: 0;
+    }
+
+    .place-card-map-link-label {
+      display: none;
     }
   }
 
@@ -1037,7 +1132,7 @@
     align-items: center;
     border-radius: var(--radius-sm);
     padding: 0.35rem 0.7rem;
-    background: var(--accent-soft);
+    background: color-mix(in srgb, var(--accent-soft) 75%, var(--surface));
     color: var(--accent);
     font-family: Raleway, Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 0.75rem;
@@ -1053,7 +1148,7 @@
 
   .controls-panel {
     padding: 1rem;
-    background: var(--surface-strong);
+    background: color-mix(in srgb, var(--surface-strong) 76%, white);
   }
 
   .controls-grid {
@@ -1204,6 +1299,12 @@
     font: inherit;
   }
 
+  input[type="search"]:focus,
+  select:focus {
+    border-color: var(--accent);
+    outline: 3px solid color-mix(in srgb, var(--accent-soft) 82%, transparent);
+  }
+
   .selected-tag-row {
     display: flex;
     flex-wrap: wrap;
@@ -1243,7 +1344,7 @@
     height: 1.45rem;
     border: 0;
     border-radius: 999px;
-    background: rgba(196, 49, 45, 0.12);
+    background: rgba(185, 71, 54, 0.12);
     color: var(--accent-strong);
     cursor: pointer;
     font: inherit;
@@ -1252,7 +1353,7 @@
 
   .selected-tag-chip-remove:hover,
   .selected-tag-chip-remove:focus-visible {
-    background: rgba(196, 49, 45, 0.22);
+    background: rgba(185, 71, 54, 0.22);
     outline: none;
   }
 
@@ -1323,6 +1424,7 @@
     top: auto;
     order: 0;
     padding: 1rem;
+    background: color-mix(in srgb, var(--surface) 94%, var(--surface-strong));
   }
 
   .home-map-panel[data-collapsed="true"] .guide-map,
@@ -1399,6 +1501,7 @@
     height: clamp(16rem, 42svh, 24rem);
     background: var(--bg-strong);
     border-radius: calc(var(--radius-lg) - 0.2rem);
+    box-shadow: inset 0 0 0 1px rgba(31, 37, 34, 0.08);
     z-index: 1;
     transition:
       opacity 160ms ease,
@@ -1422,7 +1525,7 @@
     border-radius: var(--radius-sm);
     background: var(--surface);
     color: var(--ink);
-    box-shadow: 0 1px 5px rgba(0, 0, 0, 0.18);
+    box-shadow: 0 8px 20px rgba(31, 37, 34, 0.12);
     font: inherit;
     font-size: 0.78rem;
     font-weight: 700;
@@ -1454,7 +1557,7 @@
     border-radius: var(--radius-sm);
     background: var(--surface);
     color: var(--ink);
-    box-shadow: 0 1px 5px rgba(0, 0, 0, 0.18);
+    box-shadow: 0 8px 20px rgba(31, 37, 34, 0.12);
     cursor: pointer;
   }
 
@@ -1655,7 +1758,7 @@
     border-radius: calc(var(--radius-lg) - 0.3rem);
     aspect-ratio: 3 / 2;
     background:
-      linear-gradient(135deg, rgba(196, 49, 45, 0.12), rgba(215, 156, 69, 0.16)),
+      linear-gradient(135deg, rgba(185, 71, 54, 0.12), rgba(215, 156, 69, 0.16)),
       var(--surface-strong);
     margin-bottom: 0.1rem;
     max-height: 6.9rem;
@@ -1778,7 +1881,7 @@
 
   .results-sort-shell select:hover,
   .results-sort-shell select:focus-visible {
-    border-color: rgba(196, 49, 45, 0.3);
+    border-color: rgba(185, 71, 54, 0.3);
     background: color-mix(in srgb, var(--surface) 88%, white);
   }
 
@@ -1834,7 +1937,17 @@
 
   @media (min-width: 720px) {
     .hero {
-      padding: 2rem;
+      padding: clamp(1.4rem, 2.2vw, 2rem);
+    }
+
+    .hero-grid > .section-stack:last-child {
+      justify-self: end;
+      width: min(100%, 28rem);
+      padding: 1rem 1.1rem;
+      border: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
+      border-radius: var(--radius-lg);
+      background: color-mix(in srgb, var(--surface-strong) 56%, var(--surface));
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
     }
 
     .card-grid {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -415,7 +415,7 @@
   .search-country-item:hover,
   .search-country-item:focus-visible {
     border-color: var(--accent);
-    background-color: var(--surface);
+    background-color: var(--accent-soft);
   }
 
   .search-country-item:focus-visible {
@@ -714,8 +714,8 @@
 
   .social-card-link:hover,
   .social-card-link:focus-visible {
-    border-color: rgba(196, 49, 45, 0.35);
-    background: var(--surface);
+    border-color: var(--accent-soft);
+    background: var(--accent-soft);
     transform: translateY(-1px);
     box-shadow: 0 10px 20px rgba(39, 47, 56, 0.08);
   }
@@ -1374,7 +1374,7 @@
     background: rgba(255, 250, 241, 0.96);
     box-shadow: 0 6px 18px rgba(31, 26, 22, 0.16);
     color: var(--ink);
-    font-family: var(--font-display);
+    font-family: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", var(--font-display);
     font-size: 1rem;
     font-weight: 800;
     line-height: 1;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,4 @@
-@layer theme, base, components, legacy, utilities;
+@layer theme, base, legacy, components, utilities;
 
 @import "tailwindcss";
 @import "./theme.css";

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -415,7 +415,7 @@
   .search-country-item:hover,
   .search-country-item:focus-visible {
     border-color: var(--accent);
-    background-color: #fffdfd;
+    background-color: var(--surface);
   }
 
   .search-country-item:focus-visible {
@@ -425,7 +425,7 @@
 
   .search-country-item-title {
     color: var(--ink);
-    font-family: "Avenir Next", "Segoe UI", sans-serif;
+    font-family: var(--font-display);
     font-size: 1rem;
     font-weight: 800;
     line-height: 1.35;
@@ -584,7 +584,7 @@
 
   .guide-card:hover {
     border-color: var(--accent);
-    background: #fffdfd;
+    background: var(--surface);
   }
 
   .guide-card-link {
@@ -715,7 +715,7 @@
   .social-card-link:hover,
   .social-card-link:focus-visible {
     border-color: rgba(196, 49, 45, 0.35);
-    background: #fffdfd;
+    background: var(--surface);
     transform: translateY(-1px);
     box-shadow: 0 10px 20px rgba(39, 47, 56, 0.08);
   }
@@ -816,7 +816,7 @@
   .place-card:focus-visible,
   .place-card[data-map-active="true"] {
     border-color: var(--accent);
-    background: #fffdfd;
+    background: var(--surface);
   }
 
   .place-card[data-search-highlight="true"] {
@@ -1374,9 +1374,7 @@
     background: rgba(255, 250, 241, 0.96);
     box-shadow: 0 6px 18px rgba(31, 26, 22, 0.16);
     color: var(--ink);
-    font-family:
-      "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", "Avenir Next", "Segoe UI",
-      sans-serif;
+    font-family: var(--font-display);
     font-size: 1rem;
     font-weight: 800;
     line-height: 1;
@@ -1584,7 +1582,7 @@
 
   .guide-map .leaflet-control-attribution,
   .guide-map .leaflet-control-zoom a {
-    font-family: "Avenir Next", "Segoe UI", sans-serif;
+    font-family: var(--font-display);
   }
 
   .guide-map-marker {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -584,7 +584,7 @@
 
   .guide-card:hover {
     border-color: var(--accent);
-    background: var(--surface);
+    background: var(--accent-soft);
   }
 
   .guide-card-link {
@@ -816,7 +816,7 @@
   .place-card:focus-visible,
   .place-card[data-map-active="true"] {
     border-color: var(--accent);
-    background: var(--surface);
+    background: var(--accent-soft);
   }
 
   .place-card[data-search-highlight="true"] {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,16 +6,16 @@
 
 @layer legacy {
   :root {
-    --bg: #353e49;
-    --bg-strong: #eceff2;
+    --bg: #30383f;
+    --bg-strong: #eef1f3;
     --surface: #ffffff;
-    --surface-strong: #f6f6f6;
-    --ink: #272f38;
-    --muted: #555555;
-    --line: #dddddd;
-    --accent: #c4312d;
-    --accent-strong: #98231f;
-    --accent-soft: rgba(196, 49, 45, 0.12);
+    --surface-strong: #f7f7f4;
+    --ink: #20262c;
+    --muted: #555f66;
+    --line: #d8dde0;
+    --accent: #b94736;
+    --accent-strong: #8f2f25;
+    --accent-soft: rgba(185, 71, 54, 0.13);
     --radius-lg: 6px;
     --radius-md: 4px;
     --radius-sm: 3px;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -17,6 +17,6 @@
   --radius-control: var(--radius-md);
   --radius-pill: var(--radius-sm);
 
-  --shadow-card: 0 18px 42px rgba(39, 47, 56, 0.1);
-  --shadow-floating: 0 12px 28px rgba(39, 47, 56, 0.12);
+  --shadow-card: 0 18px 42px rgba(31, 37, 34, 0.1);
+  --shadow-floating: 0 12px 28px rgba(31, 37, 34, 0.12);
 }

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -96,7 +96,7 @@ describe("guide map interactions", () => {
     expectCssToContain(css, "width: 1.8rem;");
     expectCssToContain(css, "display: inline-flex;");
     expectCssToContain(css, "padding: 0.32rem 0.62rem 0.32rem 0.42rem;");
-    expectCssToContain(css, "background: rgba(255, 255, 255, 0.96);");
+    expectCssToContain(css, "background: color-mix(in srgb, var(--surface) 92%, white);");
     expectCssToContain(css, "color: #18457a;");
     expectCssToContain(css, "border-radius: 999px;");
   });


### PR DESCRIPTION
## Summary

- **Nav touch targets** — `.ui-site-nav a` links were 21px tall (minimum is 44px). Added `padding-block: 12px` to bring them to spec.
- **Custom 404 page** — replaced Astro's default branded 404 with a page using the site's own nav, typography, and brand color.
- **Heading hierarchy** — `ui-section-title` was the same size (38.4px) and weight (900) as the `ui-display` heading above it. Reduced to `clamp(1.4rem, 2.5vw, 1.85rem)` / `font-bold` so section headings are visually subordinate.
- **`color-scheme: light`** — declared on `html` so browser UI chrome (scrollbars, inputs) renders consistently and doesn't pick up OS dark mode.
- **Hardcoded values** — replaced 4× `#fffdfd` hover backgrounds and 3× `"Avenir Next", "Segoe UI"` font stacks in `global.css` and `design-system.css` with the appropriate CSS tokens (`var(--surface)`, `var(--font-display)`).
- **Legacy palette divergence** — the `@layer legacy` `:root` fallback in `global.css` had different brand colors (`#c4312d`, `#353e49`) than `site.example/theme.css` (`#b94736`, `#30383f`). Aligned them so deployers without a custom theme get the same palette as the demo.
- **Launch config** — added `.claude/launch.json` with the dev server configuration (`FAVORITE_PLACES_SITE_DIR=site.example bun run dev`, port 4972).

## What a reviewer should know

The dual `@layer legacy` + `ui-*` CSS system (both class names applied to every component simultaneously) is still in place — that's a larger migration and out of scope for this PR. These fixes work correctly under both the legacy and new paths.

FINDING-001 (template placeholder text in hero asides) was intentionally left — it's documentation for template users, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated 404 "Page not found" with navigation back to the site.

* **Style**
  * Standardized and refreshed the site color palette for improved visual consistency.
  * Unified typography usage for cleaner, more consistent type rendering.
  * Improved navigation spacing, responsive section title sizing, and refined card/link hover & focus states for better interaction feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->