### PR TITLE
fix: set git identity before refresh merge

### DIFF
--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -201,6 +201,9 @@ jobs:
         run: |
           set -euo pipefail
 
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           git fetch origin main
           if git ls-remote --exit-code --heads origin "${REFRESH_BRANCH}" >/dev/null 2>&1; then
             git fetch origin "${REFRESH_BRANCH}:${REFRESH_BRANCH}"


### PR DESCRIPTION
## Description
Configure the GitHub Actions bot identity before the refresh branch merge in the data refresh workflow.
The scheduled job at https://github.com/michaelmwu/demflyers-favorites/actions/runs/25093674833/job/73525327166 shows the workflow can need a merge commit when `automation/data-refresh` is behind `main`, but currently reaches `git merge --no-edit origin/main` before `user.name` and `user.email` are configured.
This moves the git identity setup earlier so the branch sync step can create that merge commit successfully.

## Related Issue
No related issue found.

## How Has This Been Tested?
Reviewed the failing job log at https://github.com/michaelmwu/demflyers-favorites/actions/runs/25093674833/job/73525327166 and confirmed the merge happens before the existing git identity setup.
Ran `git diff --check` after updating the workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to ensure consistent Git identity during data refresh operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->