### PR TITLE
[codex] Harden Google Maps place scraper cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
               - "scripts/**"
               - "pyproject.toml"
               - "uv.lock"
-              - "vendor/google-saved-lists/**"
+              - "vendor/gmaps-scraper/**"
               - "tests/python/**"
             content_or_data:
               - "data/raw/**"
@@ -115,7 +115,9 @@ jobs:
         run: uv sync --frozen
 
       - name: Run Python tests
-        run: uv run python3 -m unittest discover -s tests/python -p 'test_*.py'
+        run: |
+          uv run python3 -m unittest discover -s tests/python -p 'test_*.py'
+          uv run python3 -m unittest discover -s vendor/gmaps-scraper/tests -p 'test_*.py'
 
   verify-site:
     needs: changes

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -78,6 +78,17 @@ _ADDRESS_KEYWORD_PATTERN = re.compile(
     r"court|ct|square|sq|suite|ste|unit|floor|fl|plaza|parkway|pkwy|highway|hwy)\b",
     re.IGNORECASE,
 )
+_ADDRESS_REJECT_SUBSTRINGS = (
+    "about this data",
+    "faviconv2",
+    "imagery ©",
+    "map data ©",
+    "send product feedback",
+    "street view",
+    "termsprivacy",
+)
+_ADDRESS_REJECT_HOST_FRAGMENTS = ("gstatic.com", "googleusercontent.com")
+_ADDRESS_ENTITY_TOKEN_PATTERN = re.compile(r"^/(?:g|m)/[A-Za-z0-9_-]+$")
 _PLACE_JS_EXTRACTOR = r"""
 () => {
   const titleSelectors = ["h1.DUwDvf", "h1.lfPIob", "div[role='main'] h1"];
@@ -500,13 +511,14 @@ def _build_place_details(
         category=category,
         rating=_parse_rating(snapshot.get("rating")),
         review_count=_parse_review_count(snapshot.get("review_count")),
-        address=_clean_text(snapshot.get("address")) or _extract_address_from_lines(combined_lines),
+        address=_clean_address_text(snapshot.get("address"))
+        or _extract_address_from_lines(combined_lines),
         located_in=_clean_text(snapshot.get("located_in")),
         status=_clean_text(snapshot.get("status")) or _extract_status_from_lines(combined_lines),
         website=_normalize_website(snapshot.get("website")),
         phone=_normalize_phone_candidate(snapshot.get("phone"))
         or _extract_phone_from_lines(combined_lines),
-        plus_code=_clean_text(snapshot.get("plus_code"))
+        plus_code=_clean_plus_code_text(snapshot.get("plus_code"))
         or _extract_plus_code_from_lines(combined_lines),
         address_parts=_extract_address_parts(snapshot.get("address_parts")),
         description=_extract_description(snapshot, combined_lines),
@@ -676,6 +688,50 @@ def _clean_text(value: object) -> str | None:
     if not normalized:
         return None
     return normalized
+
+
+def _clean_address_text(value: object) -> str | None:
+    normalized = _clean_text(value)
+    if normalized is None:
+        return None
+
+    lowered = normalized.lower()
+    if lowered.startswith(("http://", "https://", "www.")):
+        return None
+    if any(fragment in lowered for fragment in _ADDRESS_REJECT_SUBSTRINGS):
+        return None
+    if any(fragment in lowered for fragment in _ADDRESS_REJECT_HOST_FRAGMENTS):
+        return None
+    if _ADDRESS_ENTITY_TOKEN_PATTERN.fullmatch(normalized):
+        return None
+    if any(keyword in lowered for keyword in _REVIEW_LABEL_KEYWORDS) and any(
+        character.isdigit() for character in normalized
+    ):
+        return None
+    if normalized.endswith(".") and _PLUS_CODE_PATTERN.search(normalized) is None:
+        return None
+
+    if "·" in normalized:
+        segments = [segment.strip() for segment in normalized.split("·") if segment.strip()]
+        for candidate in reversed(segments):
+            if candidate == normalized:
+                continue
+            if _looks_like_address_line(candidate):
+                return candidate
+
+    if _looks_like_address_line(normalized):
+        return normalized
+    return None
+
+
+def _clean_plus_code_text(value: object) -> str | None:
+    normalized = _clean_text(value)
+    if normalized is None:
+        return None
+    match = _PLUS_CODE_PATTERN.search(normalized)
+    if match is None:
+        return None
+    return match.group(0).strip()
 
 
 def _clean_name_text(value: object) -> str | None:
@@ -885,7 +941,7 @@ def _normalize_photo_url(value: object) -> str | None:
     parsed = urlparse(normalized)
     if parsed.scheme not in {"http", "https"}:
         return None
-    host = parsed.netloc.lower()
+    host = (parsed.hostname or "").lower()
     path = parsed.path.lower()
     if host.endswith("gstatic.com") and (
         "result-no-thumbnail" in path
@@ -1015,13 +1071,12 @@ def _extract_preview_address_parts(root: list[object]) -> AddressParts | None:
 def _extract_preview_address(strings: list[str]) -> str | None:
     candidates: list[str] = []
     for value in strings:
-        normalized = value.strip()
+        normalized = _clean_text(value)
+        if normalized is None:
+            continue
         if "maps/preview/place" in normalized or normalized.startswith("/g/"):
             continue
-        if "〒" in normalized or normalized.startswith("Japan, "):
-            candidates.append(normalized)
-            continue
-        if normalized.count(",") >= 2 and re.search(r"\d", normalized):
+        if _clean_address_text(normalized) is not None:
             candidates.append(normalized)
     if not candidates:
         return None
@@ -1084,6 +1139,8 @@ def _normalize_phone_candidate(value: object) -> str | None:
         return None
     digit_count = sum(character.isdigit() for character in normalized)
     if digit_count < 8 or digit_count > 15:
+        return None
+    if normalized.isdigit() and digit_count == 13 and normalized.startswith("17"):
         return None
     return normalized
 

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -9,6 +9,7 @@ from gmaps_scraper.place_scraper import (
     _clean_category_text,
     _clean_name_text,
     _extract_address_from_lines,
+    _extract_preview_address,
     _extract_preview_coordinates,
     _extract_preview_description,
     _extract_preview_phone,
@@ -356,8 +357,22 @@ class PlaceScraperTests(unittest.TestCase):
             "+33 1 42 00 00 00",
         )
 
+    def test_extract_preview_address_rejects_map_urls_and_prefers_postal_address(self) -> None:
+        self.assertEqual(
+            _extract_preview_address(
+                [
+                    "https://www.google.com/maps/place/Test/@48.8814703,2.340862,17z/data=!3m1!4b1",
+                    "26-28 Cotham Rd, Kew VIC 3101, Australia",
+                ]
+            ),
+            "26-28 Cotham Rd, Kew VIC 3101, Australia",
+        )
+
     def test_normalize_phone_candidate_accepts_long_unformatted_international_numbers(self) -> None:
         self.assertEqual(_normalize_phone_candidate("442071838750"), "442071838750")
+
+    def test_normalize_phone_candidate_rejects_numeric_preview_entity_ids(self) -> None:
+        self.assertIsNone(_normalize_phone_candidate("1777026232472"))
 
     def test_build_place_details_ignores_placeholder_name_invalid_phone_and_status_description(
         self,
@@ -533,6 +548,44 @@ class PlaceScraperTests(unittest.TestCase):
 
         self.assertIsNone(details.address_parts)
 
+    def test_build_place_details_rejects_page_chrome_address_and_falls_back_to_body(self) -> None:
+        details = _build_place_details(
+            "https://www.google.com/maps/place/Bianchetto",
+            resolved_url="https://www.google.com/maps/place/Bianchetto",
+            snapshot={
+                "name": "Bianchetto",
+                "address": "Imagery © 2026 Google TermsPrivacySend Product Feedback",
+                "body_text": "\n".join(
+                    [
+                        "Bianchetto",
+                        "Restaurant",
+                        "26-28 Cotham Rd, Kew VIC 3101, Australia",
+                    ]
+                ),
+            },
+        )
+
+        self.assertEqual(details.address, "26-28 Cotham Rd, Kew VIC 3101, Australia")
+
+    def test_build_place_details_rejects_invalid_snapshot_plus_code_and_falls_back_to_lines(self) -> None:
+        details = _build_place_details(
+            "https://www.google.com/maps/place/Den",
+            resolved_url="https://www.google.com/maps/place/Den",
+            snapshot={
+                "name": "Den",
+                "plus_code": "https://www.google.com/maps/place/Den",
+                "body_text": "\n".join(
+                    [
+                        "Den",
+                        "Japanese restaurant",
+                        "MPF7+73 Shibuya, Tokyo, Japan",
+                    ]
+                ),
+            },
+        )
+
+        self.assertEqual(details.plus_code, "MPF7+73 Shibuya, Tokyo, Japan")
+
     def test_normalize_google_place_id_accepts_trailing_hyphen(self) -> None:
         self.assertEqual(
             _normalize_google_place_id("ChIJabcdefghij-"),
@@ -586,6 +639,9 @@ class PlaceScraperTests(unittest.TestCase):
             _normalize_photo_url("https://lh3.googleusercontent.com/a-/ALV-UjW_avatar")
         )
         self.assertIsNone(_normalize_photo_url("https://lh5.ggpht.com/a/example-avatar"))
+        self.assertIsNone(
+            _normalize_photo_url("https://lh3.googleusercontent.com:443/a-/ALV-UjW_avatar")
+        )
         self.assertEqual(
             _normalize_photo_url("https://lh3.googleusercontent.com/p/example=s680-w680-h510"),
             "https://lh3.googleusercontent.com/p/example=s680-w680-h510",


### PR DESCRIPTION
## Description
Restores downstream scraper hardening in the vendored Google Maps scraper. The place scraper now rejects page chrome and asset URLs when selecting addresses, validates snapshot plus codes before trusting them, avoids treating Maps preview entity IDs as phone numbers, and normalizes photo hosts without port noise. CI now treats `vendor/gmaps-scraper/**` as Python pipeline input and runs the vendored scraper unittest suite.

## Related Issue
No related issue found after searching GitHub issues for `scraper address cleanup`, `Google Maps place scraper invalid address plus code`, and `place scraper photo url phone entity id`.

## How Has This Been Tested?
- `uv run python3 -m unittest vendor.gmaps-scraper.tests.test_place_scraper`
- `uv run python3 -m unittest discover -s tests/python -p 'test_*.py'`\n- `uv run python3 -m unittest discover -s vendor/gmaps-scraper/tests -p 'test_*.py'`