### PR TITLE
[codex] Polish responsive cards and guide descriptions

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -4028,11 +4028,18 @@ def read_json(path: Path) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
-@lru_cache(maxsize=None)
 def load_site_build_hooks_module(path: Path) -> Any | None:
-    if not path.exists():
+    try:
+        resolved_path = path.resolve(strict=True)
+    except FileNotFoundError:
         return None
-    module_name = f"favorite_places_site_build_hooks_{hashlib.sha1(str(path).encode('utf-8')).hexdigest()[:12]}"
+    return _load_site_build_hooks_module(resolved_path, resolved_path.stat().st_mtime_ns)
+
+
+@lru_cache(maxsize=None)
+def _load_site_build_hooks_module(path: Path, mtime_ns: int) -> Any:
+    module_identity = f"{path}:{mtime_ns}"
+    module_name = f"favorite_places_site_build_hooks_{hashlib.sha1(module_identity.encode('utf-8')).hexdigest()[:12]}"
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None or spec.loader is None:
         raise ImportError(f"Could not load site build hooks from {path}")
@@ -4056,7 +4063,7 @@ def transform_guide_description_with_site_hook(
     if hook is None:
         return normalized_description
     if not callable(hook):
-        raise TypeError("site/build_hooks.py transform_guide_description must be callable")
+        raise TypeError(f"{SITE_BUILD_HOOKS_PATH} transform_guide_description must be callable")
     transformed = hook(
         normalized_description,
         slug=slug,
@@ -4066,7 +4073,7 @@ def transform_guide_description_with_site_hook(
     if transformed is None:
         return None
     if not isinstance(transformed, str):
-        raise TypeError("site/build_hooks.py transform_guide_description must return str | None")
+        raise TypeError(f"{SITE_BUILD_HOOKS_PATH} transform_guide_description must return str | None")
     return normalize_text_blocks(transformed)
 
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import csv
 import hashlib
+import importlib.util
 import io
 import json
 import math
@@ -91,6 +92,7 @@ GENERATED_DIR = ROOT / "src" / "data" / "generated"
 GENERATED_LISTS_DIR = GENERATED_DIR / "lists"
 PUBLIC_DATA_DIR = ROOT / "public" / "data"
 PLACE_PHOTOS_DIR = SITE_DIR / "public" / "place-photos"
+SITE_BUILD_HOOKS_PATH = SITE_DIR / "build_hooks.py"
 LIST_OVERRIDES_DIR = SITE_DIR / "overrides" / "lists"
 PLACE_OVERRIDES_DIR = SITE_DIR / "overrides" / "places"
 SCRAPER_STATE_DIR = ROOT / ".context" / "gmaps-scraper"
@@ -2092,6 +2094,12 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
 
     title = as_string(list_override.get("title")) or raw.title or slug.replace("-", " ").title()
     description = as_string(list_override.get("description")) or raw.description
+    description = transform_guide_description_with_site_hook(
+        description,
+        slug=slug,
+        raw=raw,
+        list_override=list_override,
+    )
 
     city_name = as_string(list_override.get("city_name")) or infer_city_name(title)
     country_name = as_string(list_override.get("country_name")) or infer_country_name(title, raw)
@@ -4018,6 +4026,59 @@ def read_json(path: Path) -> dict[str, Any]:
         return {}
     payload = json.loads(path.read_text(encoding="utf-8"))
     return payload if isinstance(payload, dict) else {}
+
+
+@lru_cache(maxsize=None)
+def load_site_build_hooks_module(path: Path) -> Any | None:
+    if not path.exists():
+        return None
+    module_name = f"favorite_places_site_build_hooks_{hashlib.sha1(str(path).encode('utf-8')).hexdigest()[:12]}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load site build hooks from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def transform_guide_description_with_site_hook(
+    description: str | None,
+    *,
+    slug: str,
+    raw: RawSavedList,
+    list_override: dict[str, Any],
+) -> str | None:
+    normalized_description = normalize_text_blocks(description)
+    module = load_site_build_hooks_module(SITE_BUILD_HOOKS_PATH)
+    if module is None:
+        return normalized_description
+    hook = getattr(module, "transform_guide_description", None)
+    if hook is None:
+        return normalized_description
+    if not callable(hook):
+        raise TypeError("site/build_hooks.py transform_guide_description must be callable")
+    transformed = hook(
+        normalized_description,
+        slug=slug,
+        raw=raw,
+        list_override=list_override,
+    )
+    if transformed is None:
+        return None
+    if not isinstance(transformed, str):
+        raise TypeError("site/build_hooks.py transform_guide_description must return str | None")
+    return normalize_text_blocks(transformed)
+
+
+def normalize_text_blocks(value: str | None) -> str | None:
+    normalized = as_string(value)
+    if normalized is None:
+        return None
+    normalized = normalized.replace("\r\n", "\n").replace("\r", "\n")
+    normalized = "\n".join(line.rstrip() for line in normalized.split("\n"))
+    normalized = re.sub(r"\n[ \t]*\n(?:[ \t]*\n)+", "\n\n", normalized)
+    normalized = normalized.strip()
+    return normalized or None
 
 
 def load_raw_saved_list(path: Path) -> RawSavedList | None:

--- a/site.example/build_hooks.py
+++ b/site.example/build_hooks.py
@@ -1,0 +1,6 @@
+"""Optional site-specific build hooks.
+
+Copy this file into your site pack and define functions here to customize
+generated data without changing the shared pipeline code.
+"""
+

--- a/src/components/PlaceCard.astro
+++ b/src/components/PlaceCard.astro
@@ -123,7 +123,7 @@ const badges = [
   <div class="place-card-title">
     <div class="section-stack ui-stack place-card-heading">
       <div class="place-card-name-row">
-        <h3 class="ui-card-title">{place.name}</h3>
+        <h3 class="ui-card-title" title={place.name}>{place.name}</h3>
         {siteConfig.placeCard.showMapLink && (
           <a
             class="place-card-map-link"
@@ -171,11 +171,28 @@ const badges = [
 
   {siteConfig.placeCard.showWhyRecommended && whyRecommendedHtml && <p class="rich-copy ui-copy" set:html={whyRecommendedHtml} />}
   {siteConfig.placeCard.showNote && noteHtml && <p class="small-copy ui-copy ui-copy--sm rich-copy" set:html={noteHtml} />}
-  {siteConfig.placeCard.showAddress && place.address && <p class="small-copy ui-copy ui-copy--sm">{place.address}</p>}
+  {siteConfig.placeCard.showAddress && place.address && (
+    <div class="place-card-address" title={place.address}>
+      <span class="place-card-address-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false">
+          <path
+            fill="currentColor"
+            d="M12 2.8A6.2 6.2 0 0 0 5.8 9c0 4.3 4.9 9.8 5.1 10a1.5 1.5 0 0 0 2.2 0c.2-.2 5.1-5.7 5.1-10A6.2 6.2 0 0 0 12 2.8Zm0 8.5A2.3 2.3 0 1 1 12 6.7a2.3 2.3 0 0 1 0 4.6Z"
+          />
+        </svg>
+      </span>
+      <p class="small-copy ui-copy ui-copy--sm place-card-address-copy">
+        <span class="place-card-address-label">Address</span>
+        <span class="place-card-address-text">{place.address}</span>
+      </p>
+    </div>
+  )}
   {siteConfig.placeCard.showTags && displayTags.length > 0 && (
-    <div class="tag-row ui-tag-row">
+    <div class="tag-row ui-tag-row place-card-tags">
       {displayTags.map((tag) => (
-        <span class="tag-pill ui-tag-pill">#{tag}</span>
+        <span class="tag-pill ui-tag-pill">
+          <span class="tag-pill-label">#{tag}</span>
+        </span>
       ))}
     </div>
   )}

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -146,7 +146,7 @@ const tagFallbacks = [...tagCounts.entries()]
   .filter(({ tag }) => isSuggestibleTag(tag, citySlug, countrySlug))
   .sort((left, right) => right.count - left.count || left.tag.localeCompare(right.tag))
   .map(({ tag }) => tag);
-const defaultSuggestions = buildSuggestionList(DEFAULT_SUGGESTION_PRIORITY, tagFallbacks, 6);
+const defaultSuggestions = buildSuggestionList(DEFAULT_SUGGESTION_PRIORITY, tagFallbacks, 4);
 const typeSeedTags = Object.fromEntries(
   browseTypes.map((type) => {
     const typeKey = normalizeTagValue(type);
@@ -333,7 +333,7 @@ const guideJsonLd = [
             {areaFilters.length > 0 && (
               <div class="control-group" style="grid-column: 1 / -1;">
                 <span class="control-label ui-control-label">{siteConfig.guide.areaLabel}</span>
-                <div class="tag-row ui-tag-row tag-row-mobile-scroll">
+                <div class="tag-row ui-tag-row tag-row-mobile-scroll tag-row-mobile-grid-scroll">
                   <button class="tag-pill ui-tag-pill" type="button" data-area-filter data-area="" data-area-label="All areas">
                     <span>{siteConfig.guide.allFilterLabel}</span>
                     <span class="tag-pill-count" data-filter-count>{visiblePlaces.length}</span>
@@ -357,7 +357,7 @@ const guideJsonLd = [
             {broaderAreaFilters.length > 0 && (
               <div class="control-group" style="grid-column: 1 / -1;">
                 <span class="control-label ui-control-label">{siteConfig.guide.broaderAreaLabel}</span>
-                <div class="tag-row ui-tag-row tag-row-mobile-scroll">
+                <div class="tag-row ui-tag-row tag-row-mobile-scroll tag-row-mobile-grid-scroll">
                   {broaderAreaFilters.map((area) => (
                     <button
                       class="tag-pill ui-tag-pill"
@@ -377,7 +377,7 @@ const guideJsonLd = [
             {browseTypes.length > 0 && (
               <div class="control-group" style="grid-column: 1 / -1;">
                 <span class="control-label ui-control-label">{siteConfig.guide.typeLabel}</span>
-                <div class="tag-row ui-tag-row tag-row-mobile-scroll">
+                <div class="tag-row ui-tag-row tag-row-mobile-scroll tag-row-mobile-grid-scroll">
                   <button class="tag-pill ui-tag-pill" type="button" data-type-filter data-type="">
                     <span>{siteConfig.guide.allFilterLabel}</span>
                     <span class="tag-pill-count" data-filter-count>{visiblePlaces.length}</span>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -247,6 +247,11 @@
     align-items: center;
   }
 
+  .tag-row {
+    align-content: flex-start;
+    align-items: flex-start;
+  }
+
   .stat-pill,
   .action-pill {
     display: inline-flex;
@@ -853,6 +858,8 @@
     overflow: hidden;
     padding: 1rem;
     display: grid;
+    align-content: start;
+    align-items: start;
     gap: 0.9rem;
     container-type: inline-size;
     cursor: pointer;
@@ -1007,8 +1014,12 @@
   }
 
   .place-card-name-row h3 {
+    display: -webkit-box;
     flex: 1 1 auto;
     min-width: 0;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
   }
 
   .place-card-meta-row {
@@ -1038,12 +1049,85 @@
     flex-basis: 100%;
   }
 
+  .place-card-address {
+    width: 100%;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+    gap: 0.58rem;
+    padding: 0.68rem 0.72rem;
+    border: 1px solid color-mix(in srgb, var(--line) 78%, transparent);
+    border-radius: var(--radius-md);
+    background:
+      linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0.3)),
+      color-mix(in srgb, var(--surface-strong) 42%, var(--surface));
+  }
+
+  .place-card-address-icon {
+    width: 1.55rem;
+    height: 1.55rem;
+    display: grid;
+    place-items: center;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--accent-soft) 76%, var(--surface));
+    color: var(--accent-strong);
+  }
+
+  .place-card-address-icon svg {
+    width: 0.9rem;
+    height: 0.9rem;
+    display: block;
+  }
+
+  .place-card-address-copy {
+    display: grid;
+    gap: 0.12rem;
+  }
+
+  .place-card-address-label {
+    color: var(--accent-strong);
+    font-family: Raleway, Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 0.62rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    line-height: 1.1;
+    text-transform: uppercase;
+  }
+
+  .place-card-address-text {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+  }
+
+  .place-card-tags {
+    width: 100%;
+  }
+
+  .place-card-tags .tag-pill {
+    min-width: 0;
+    max-width: 100%;
+    white-space: nowrap;
+  }
+
+  .place-card-tags .tag-pill-label {
+    display: block;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .place-card-map-link {
+    width: 2.45rem;
     min-height: 2.3rem;
     display: inline-flex;
+    justify-content: center;
     align-items: center;
     gap: 0.45rem;
-    padding: 0.32rem 0.62rem 0.32rem 0.42rem;
+    padding: 0;
     flex: 0 0 auto;
     border: 1px solid rgba(18, 73, 160, 0.14);
     border-radius: 999px;
@@ -1067,6 +1151,7 @@
   }
 
   .place-card-map-link-label {
+    display: none;
     font-size: 0.72rem;
     font-weight: 700;
     letter-spacing: 0.04em;
@@ -1090,22 +1175,20 @@
 
   @container (min-width: 26rem) {
     .place-card-meta-stats {
-      flex-basis: auto;
-      margin-left: auto;
-      justify-content: flex-end;
+      flex-basis: 100%;
+      margin-left: 0;
+      justify-content: flex-start;
     }
   }
 
   @container (min-width: 34rem) {
     .place-card-title {
-      display: flex;
-      justify-content: space-between;
-      align-items: start;
+      display: grid;
       gap: 1rem;
     }
 
     .place-card-badges {
-      justify-content: flex-end;
+      justify-content: flex-start;
     }
   }
 
@@ -1118,12 +1201,6 @@
     .place-card-map-link {
       width: 2.35rem;
       min-height: 2.35rem;
-      justify-content: center;
-      padding: 0;
-    }
-
-    .place-card-map-link-label {
-      display: none;
     }
   }
 
@@ -1145,7 +1222,6 @@
     background: rgba(39, 47, 56, 0.08);
     color: var(--ink);
   }
-
   .controls-panel {
     padding: 1rem;
     background: color-mix(in srgb, var(--surface-strong) 76%, white);
@@ -1299,6 +1375,16 @@
     font: inherit;
   }
 
+  #guide-search {
+    font-size: 0.96rem;
+    line-height: 1.25;
+  }
+
+  #guide-search::placeholder {
+    font-size: 0.93em;
+    letter-spacing: -0.01em;
+  }
+
   input[type="search"]:focus,
   select:focus {
     border-color: var(--accent);
@@ -1312,7 +1398,15 @@
   }
 
   .tag-row-mobile-scroll {
-    max-height: min(14rem, 28svh);
+    --filter-scroll-pill-height: 2.3rem;
+    --filter-scroll-row-gap: 0.75rem;
+    --filter-scroll-buffer: 8px;
+
+    max-height: calc(
+      (4 * var(--filter-scroll-pill-height)) +
+      (3 * var(--filter-scroll-row-gap)) +
+      var(--filter-scroll-buffer)
+    );
     overflow-y: auto;
     align-content: flex-start;
     padding-right: 0.2rem;
@@ -1320,6 +1414,9 @@
     scrollbar-gutter: stable;
   }
 
+  .tag-row-mobile-grid-scroll {
+    width: 100%;
+  }
   .selected-tag-chip {
     display: inline-flex;
     align-items: center;
@@ -1379,8 +1476,11 @@
     background: transparent;
     color: var(--ink);
     cursor: pointer;
-    font: inherit;
-    padding: 0.65rem 0.7rem;
+    min-height: 2.3rem;
+    padding: 0.3rem 0.7rem;
+    font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 0.82rem;
+    line-height: 1.15;
     text-align: left;
   }
 
@@ -1613,7 +1713,6 @@
     color: var(--muted);
     opacity: 0.58;
   }
-
   .map-icon-button[data-busy="true"] svg {
     animation: location-target-spin 900ms linear infinite;
   }
@@ -1951,7 +2050,7 @@
     }
 
     .card-grid {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 15.5rem), 1fr));
     }
 
     .search-result-grid {
@@ -1962,13 +2061,14 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
-    .top-picks-grid {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-    }
-
     .controls-grid {
       grid-template-columns: minmax(0, 1.55fr) minmax(190px, 0.75fr) minmax(230px, 0.8fr);
       align-items: end;
+    }
+
+    .card-grid[data-kind="places"],
+    .top-picks-grid {
+      grid-template-columns: minmax(0, 1fr);
     }
   }
 
@@ -2006,6 +2106,10 @@
     select {
       min-height: 2.55rem;
       padding: 0.68rem 0.8rem;
+    }
+
+    #guide-search {
+      font-size: 0.92rem;
     }
 
     .results-row {
@@ -2105,7 +2209,10 @@
       overflow-x: auto;
       overflow-y: hidden;
       max-height: none;
-      padding-right: 0;
+      /* Leave a free gutter beside the scroller so vertical scroll is easier to grab. */
+      width: min(calc(100% - 2.75rem), 24rem);
+      margin-right: auto;
+      padding-right: 0.45rem;
       padding-bottom: 0.2rem;
       align-content: normal;
       -webkit-overflow-scrolling: touch;
@@ -2113,6 +2220,52 @@
     }
 
     .tag-row-mobile-scroll > * {
+      flex: 0 0 auto;
+    }
+
+    .ui-tag-row.tag-row-mobile-grid-scroll {
+      --mobile-filter-pill-height: 2.25rem;
+      --mobile-filter-grid-gap: 0.5rem;
+      --mobile-filter-grid-buffer: 6px;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: var(--mobile-filter-grid-gap);
+      width: 100%;
+
+      max-height: calc(
+        (3 * var(--mobile-filter-pill-height)) +
+        (2 * var(--mobile-filter-grid-gap)) +
+        var(--mobile-filter-grid-buffer)
+      );
+      overflow-x: hidden;
+      overflow-y: auto;
+      padding-right: 0.35rem;
+      padding-bottom: 0;
+      overscroll-behavior: contain;
+      scrollbar-gutter: stable;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    .ui-tag-row.tag-row-mobile-grid-scroll > * {
+      min-width: 0;
+      width: 100%;
+    }
+
+    .ui-tag-row.tag-row-mobile-grid-scroll .tag-pill {
+      width: 100%;
+      justify-content: space-between;
+      gap: 0.45rem;
+      white-space: nowrap;
+    }
+
+    .ui-tag-row.tag-row-mobile-grid-scroll .tag-pill > :first-child {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .ui-tag-row.tag-row-mobile-grid-scroll .tag-pill-count {
       flex: 0 0 auto;
     }
 
@@ -2144,13 +2297,22 @@
     }
 
     .social-card-grid {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 0.4rem;
     }
 
     .social-card-link {
       padding: 0.42rem 0.45rem;
       gap: 0.35rem;
+    }
+
+    .social-card-grid .social-card-link {
+      justify-content: center;
+      padding-inline: 0.4rem;
+    }
+
+    .social-card-grid .social-card-link-copy {
+      display: none;
     }
 
     .social-card-link-title {
@@ -2163,18 +2325,13 @@
     }
   }
 
-  @media (max-width: 359px) {
-    .social-card-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-
   @media (min-width: 980px) and (max-width: 1279px) {
     .browse-layout > .map-panel {
       order: -1;
     }
 
-    .card-grid[data-kind="places"] {
+    .card-grid[data-kind="places"],
+    .top-picks-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
@@ -2276,30 +2433,101 @@
       max-height: none;
     }
 
-    .card-grid[data-kind="places"] {
+    .card-grid[data-kind="places"],
+    .top-picks-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
     .browse-layout[data-map-collapsed="true"] .card-grid[data-kind="places"] {
-      grid-template-columns: repeat(auto-fit, minmax(23rem, 28rem));
-      justify-content: start;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 
   @media (min-width: 1480px) {
     .card-grid[data-kind="places"] {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 }
 
 @media (max-width: 979px) {
+  .map-panel {
+    gap: 0;
+    padding: 0.45rem;
+  }
+
+  .map-toolbar {
+    display: contents;
+  }
+
+  .map-toggle {
+    position: absolute;
+    top: 0.85rem;
+    left: 0.85rem;
+    z-index: 500;
+    height: 2.15rem;
+    padding-inline: 0.72rem;
+    background: color-mix(in srgb, var(--surface) 88%, transparent);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+  }
+
   .map-actions {
-    justify-content: flex-start;
+    position: absolute;
+    top: 0.85rem;
+    right: 0.85rem;
+    z-index: 500;
+    flex: 0 1 auto;
+    justify-content: flex-end;
+    max-width: calc(100% - 9.25rem);
+    margin-left: 0;
   }
 
   .map-control-button {
     flex: 0 1 auto;
+    min-height: 2.15rem;
+    padding-inline: 0.55rem;
+    background: color-mix(in srgb, var(--surface) 90%, transparent);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+    font-size: 0.72rem;
+  }
+
+  .map-icon-button {
+    width: 2.15rem;
+    height: 2.15rem;
+    background: color-mix(in srgb, var(--surface) 90%, transparent);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+  }
+
+  .map-feedback-slot {
+    position: absolute;
+    top: 3.35rem;
+    left: 0.85rem;
+    right: 0.85rem;
+    z-index: 500;
+    min-height: 0;
+    margin: 0;
+    pointer-events: none;
+  }
+
+  .map-location-status {
+    padding: 0.35rem 0.55rem;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--surface) 92%, transparent);
+    box-shadow: 0 8px 20px rgba(31, 37, 34, 0.12);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+  }
+
+  .map-panel[data-collapsed="true"] {
+    padding: 0.55rem 0;
+  }
+
+  .map-panel[data-collapsed="true"] .map-toggle {
+    position: static;
   }
 }
 

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -29,7 +29,7 @@ describe("guide map interactions", () => {
     expectCssToContain(css, ".browse-layout > .map-panel {\n    order: 0;\n    position: sticky;");
   });
 
-  it("uses an in-flow mobile map toolbar instead of overlaying the controls", () => {
+  it("overlays compact mobile map controls without reserving toolbar height", () => {
     const guideMap = readSource("src/components/GuideMap.astro");
     const css = readSource("src/styles/global.css");
 
@@ -39,7 +39,14 @@ describe("guide map interactions", () => {
     expect(cssBlocks(css, ".map-panel").join("\n")).toContain("position: relative");
     expect(cssBlocks(css, ".map-actions").join("\n")).toContain("margin-left: auto");
     expectCssToContain(css, "@media (max-width: 979px)");
-    expectCssToContain(css, ".map-actions {\n    justify-content: flex-start;");
+    expectCssToContain(css, ".map-panel {\n    gap: 0;\n    padding: 0.45rem;");
+    expectCssToContain(css, ".map-toolbar {\n    display: contents;");
+    expectCssToContain(css, ".map-toggle {\n    position: absolute;\n    top: 0.85rem;");
+    expectCssToContain(
+      css,
+      ".map-actions {\n    position: absolute;\n    top: 0.85rem;\n    right: 0.85rem;",
+    );
+    expectCssToContain(css, ".map-feedback-slot {\n    position: absolute;\n    top: 3.35rem;");
     expectCssToContain(css, ".guide-map {\n  width: 100%;\n  min-height: 16rem;");
     expectCssToContain(css, ".map-panel {\n    order: 0;\n    position: sticky;\n    top: 0.5rem;");
   });
@@ -68,7 +75,7 @@ describe("guide map interactions", () => {
     expectCssToContain(css, ".social-card-icon {\n    width: 1.5rem;");
   });
 
-  it("renders the Google Maps action as a labeled pill beside the place name", () => {
+  it("renders the Google Maps action as a compact icon button beside the place name", () => {
     const placeCard = readSource("src/components/PlaceCard.astro");
     const css = readSource("src/styles/global.css");
 
@@ -95,7 +102,10 @@ describe("guide map interactions", () => {
     expectCssToContain(css, ".place-card-name-row");
     expectCssToContain(css, "width: 1.8rem;");
     expectCssToContain(css, "display: inline-flex;");
-    expectCssToContain(css, "padding: 0.32rem 0.62rem 0.32rem 0.42rem;");
+    expectCssToContain(css, "width: 2.45rem;");
+    expectCssToContain(css, "justify-content: center;");
+    expectCssToContain(css, "padding: 0;");
+    expectCssToContain(css, ".place-card-map-link-label {\n    display: none;");
     expectCssToContain(css, "background: color-mix(in srgb, var(--surface) 92%, white);");
     expectCssToContain(css, "color: #18457a;");
     expectCssToContain(css, "border-radius: 999px;");
@@ -148,8 +158,8 @@ describe("guide map interactions", () => {
       css,
       '.browse-layout[data-map-collapsed="true"] .card-grid[data-kind="places"]',
     );
-    expectCssToContain(css, "grid-template-columns: repeat(auto-fit, minmax(23rem, 28rem))");
-    expectCssToContain(css, "justify-content: start;");
+    expectCssToContain(css, "grid-template-columns: repeat(2, minmax(0, 1fr));");
+    expectCssNotToContain(css, "grid-template-columns: repeat(auto-fit, minmax(23rem, 28rem))");
     expect(cssBlocks(css, ".map-panel").join("\n")).toContain("order: 0;");
     expectCssToContain(css, '.map-panel[data-collapsed="true"] .map-toggle');
     expectCssToContain(css, "border-color: transparent");

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1831,7 +1831,7 @@ class BuildDataTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            build_data.load_site_build_hooks_module.cache_clear()
+            build_data._load_site_build_hooks_module.cache_clear()
             try:
                 with (
                     patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
@@ -1840,7 +1840,7 @@ class BuildDataTests(unittest.TestCase):
                 ):
                     guide = build_data.normalize_guide("tokyo-japan", raw, enrichment_cache={})
             finally:
-                build_data.load_site_build_hooks_module.cache_clear()
+                build_data._load_site_build_hooks_module.cache_clear()
 
         self.assertEqual(guide.description, "tokyo-japan: Original description")
 
@@ -1876,7 +1876,7 @@ class BuildDataTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            build_data.load_site_build_hooks_module.cache_clear()
+            build_data._load_site_build_hooks_module.cache_clear()
             try:
                 with (
                     patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
@@ -1885,9 +1885,24 @@ class BuildDataTests(unittest.TestCase):
                 ):
                     guide = build_data.normalize_guide("tokyo-japan", raw, enrichment_cache={})
             finally:
-                build_data.load_site_build_hooks_module.cache_clear()
+                build_data._load_site_build_hooks_module.cache_clear()
 
         self.assertEqual(guide.description, "Original description\n\nExtra note")
+
+    def test_load_site_build_hooks_module_does_not_cache_missing_file(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            hooks_path = Path(tmpdir) / "build_hooks.py"
+
+            self.assertIsNone(build_data.load_site_build_hooks_module(hooks_path))
+            hooks_path.write_text("hook_loaded = True\n", encoding="utf-8")
+
+            try:
+                module = build_data.load_site_build_hooks_module(hooks_path)
+            finally:
+                build_data._load_site_build_hooks_module.cache_clear()
+
+        self.assertIsNotNone(module)
+        self.assertTrue(module.hook_loaded)
 
     def test_normalize_text_blocks_strips_outer_blank_lines_and_collapses_internal_runs(self) -> None:
         self.assertEqual(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1799,6 +1799,102 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertEqual(guide.list_tags, ["geneva", "geneve", "park"])
 
+    def test_normalize_guide_applies_site_build_hook_to_description(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo, Japan",
+            description="Original description",
+            places=[
+                RawPlace(
+                    name="Koffee Mameya",
+                    address="4-15-3 Jingumae, Shibuya City, Tokyo, Japan",
+                    maps_url="https://maps.google.com/?cid=1",
+                    cid="1",
+                )
+            ],
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            hooks_path = tmpdir_path / "build_hooks.py"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+            hooks_path.write_text(
+                "\n".join(
+                    [
+                        "def transform_guide_description(description, *, slug, raw, list_override):",
+                        "    return f\"{slug}: {description}\"",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            build_data.load_site_build_hooks_module.cache_clear()
+            try:
+                with (
+                    patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                    patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+                    patch.object(build_data, "SITE_BUILD_HOOKS_PATH", hooks_path),
+                ):
+                    guide = build_data.normalize_guide("tokyo-japan", raw, enrichment_cache={})
+            finally:
+                build_data.load_site_build_hooks_module.cache_clear()
+
+        self.assertEqual(guide.description, "tokyo-japan: Original description")
+
+    def test_normalize_guide_collapses_blank_lines_after_site_hook_changes(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo, Japan",
+            description="\n\nOriginal description\n\n",
+            places=[
+                RawPlace(
+                    name="Coffee Supreme",
+                    address="Tokyo, Japan",
+                    maps_url="https://maps.google.com/?cid=1",
+                    cid="1",
+                )
+            ],
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            hooks_path = tmpdir_path / "build_hooks.py"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+            hooks_path.write_text(
+                "\n".join(
+                    [
+                        "def transform_guide_description(description, *, slug, raw, list_override):",
+                        "    return f'\\n\\n{description}\\n\\n\\nExtra note\\n\\n'",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            build_data.load_site_build_hooks_module.cache_clear()
+            try:
+                with (
+                    patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                    patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+                    patch.object(build_data, "SITE_BUILD_HOOKS_PATH", hooks_path),
+                ):
+                    guide = build_data.normalize_guide("tokyo-japan", raw, enrichment_cache={})
+            finally:
+                build_data.load_site_build_hooks_module.cache_clear()
+
+        self.assertEqual(guide.description, "Original description\n\nExtra note")
+
+    def test_normalize_text_blocks_strips_outer_blank_lines_and_collapses_internal_runs(self) -> None:
+        self.assertEqual(
+            build_data.normalize_text_blocks("\n\nAlpha  \n\n\nBeta\n \n\nGamma\n\n"),
+            "Alpha\n\nBeta\n\nGamma",
+        )
+
     def test_normalize_guide_normalizes_accented_override_list_tags(self) -> None:
         raw = RawSavedList(
             title="Genève, Switzerland",


### PR DESCRIPTION
## Summary
- restores the responsive place-card/mobile guide UI polish from the closed fork-backed PR #67
- keeps card grids from shrinking into too many columns by using the corrected guide-card min width
- adds generic `site/build_hooks.py` guide-description hooks with shared, site-agnostic tests

## Notes
PR #67 could not be reopened because its head repository was deleted, so this replacement branch lives directly on `508-dev/favorite-places`.
Downstream-specific DEM Flyers text stripping stays in the downstream `site/build_hooks.py` and is not included here.

## Verification
- `uv run python3 -m unittest tests.python.test_build_data`
- `bun run test:frontend`
- `bun run check`
- `bun run build`
