### PR TITLE
[codex] Remove header stripe background

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -42,13 +42,8 @@
     margin: 0;
     min-height: 100vh;
     background:
-      repeating-linear-gradient(
-        90deg,
-        rgba(255, 255, 255, 0.035) 0,
-        rgba(255, 255, 255, 0.035) 1px,
-        transparent 1px,
-        transparent 7.5rem
-      ),
+      radial-gradient(circle at 12% 0, rgba(255, 255, 255, 0.06), transparent 16rem),
+      radial-gradient(circle at 82% 4rem, rgba(255, 255, 255, 0.045), transparent 18rem),
       linear-gradient(180deg, var(--bg) 0 18rem, var(--bg-strong) 18rem 100%);
   }
 


### PR DESCRIPTION
## Summary
- removes the repeating vertical stripe layer from the global page background
- keeps the dark header/banner atmosphere with soft radial highlights instead of layout-like guide lines

## Verification
- `bun run test:frontend`
- `bun run check`
- `bun run build`
