### PR TITLE
Improve responsive map popups and guide hero

### DIFF
--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -26,6 +26,8 @@ const mapPlaces = places
     lng: place.lng,
     mapsUrl: place.maps_url,
     mainPhotoPath: place.main_photo_path,
+    rating: place.rating,
+    userRatingCount: place.user_rating_count,
     topPick: place.top_pick,
   }));
 ---
@@ -41,7 +43,7 @@ const mapPlaces = places
 
         <div class="map-actions" data-map-actions>
           <button class="map-control-button" type="button" data-map-frame-filter>Search this area</button>
-          <button class="map-control-button" type="button" data-map-full-area>Reset Map</button>
+          <button class="map-control-button" type="button" data-map-full-area hidden>Reset Map</button>
           <button
             class="map-icon-button"
             type="button"
@@ -114,6 +116,8 @@ const mapPlaces = places
     lng: number;
     mapsUrl: string;
     mainPhotoPath: string | null;
+    rating: number | null;
+    userRatingCount: number | null;
     topPick: boolean;
   }
 
@@ -128,6 +132,13 @@ const mapPlaces = places
   interface Coordinates {
     lat: number;
     lng: number;
+  }
+
+  interface LatLngBoundsLiteral {
+    east: number;
+    north: number;
+    south: number;
+    west: number;
   }
 
   interface GuideLocationBounds {
@@ -152,6 +163,7 @@ const mapPlaces = places
     hasVisiblePlace: (placeId: string) => boolean;
     highlightPlace: (place: MapPlace, active: boolean) => void;
     invalidateSize?: () => void;
+    isOutsideFocusView: () => boolean;
     onViewportChange?: (handler: () => void) => () => void;
     openPlace: (place: MapPlace) => void;
     setUserLocation: (coordinates: Coordinates | null) => void;
@@ -161,7 +173,7 @@ const mapPlaces = places
 
   interface GoogleMapsApi {
     maps: {
-      InfoWindow: new (options?: { content?: string }) => {
+      InfoWindow: new (options?: { content?: string; headerDisabled?: boolean }) => {
         close: () => void;
         open: (options: { anchor: unknown; map: unknown; shouldFocus?: boolean }) => void;
         setContent: (content: string) => void;
@@ -169,6 +181,7 @@ const mapPlaces = places
       LatLngBounds: new () => {
         contains: (coordinates: Coordinates) => boolean;
         extend: (coordinates: Coordinates) => void;
+        intersects: (bounds: unknown) => boolean;
       };
       Map: new (
         element: HTMLElement,
@@ -176,7 +189,12 @@ const mapPlaces = places
       ) => {
         addListener: (eventName: string, handler: () => void) => { remove: () => void };
         fitBounds: (bounds: unknown, padding?: number | { top: number; right: number; bottom: number; left: number }) => void;
-        getBounds: () => { contains: (coordinates: Coordinates) => boolean } | undefined;
+        getBounds: () =>
+          | {
+              contains: (coordinates: Coordinates) => boolean;
+              intersects: (bounds: unknown) => boolean;
+            }
+          | undefined;
         getCenter: () =>
           | {
               lat: () => number;
@@ -187,6 +205,7 @@ const mapPlaces = places
         getZoom: () => number | undefined;
         panTo: (coordinates: Coordinates) => void;
         setCenter: (coordinates: Coordinates) => void;
+        setOptions: (options: Record<string, unknown>) => void;
         setZoom: (zoom: number) => void;
       };
       Marker: new (options: Record<string, unknown>) => {
@@ -210,7 +229,8 @@ const mapPlaces = places
     }
   }
 
-  const MAP_COLLAPSED_KEY = "favoritePlacesMapCollapsed";
+  const MAP_COLLAPSED_DESKTOP_KEY = "favoritePlacesMapCollapsedDesktop";
+  const MAP_COLLAPSED_MOBILE_KEY = "favoritePlacesMapCollapsedMobile";
   const DESKTOP_MAP_MEDIA_QUERY = "(min-width: 980px)";
   const SIDE_BY_SIDE_MAP_MEDIA_QUERY = "(min-width: 1280px)";
   const LOCATION_PROXIMITY_BUFFER_KM = 25;
@@ -218,6 +238,12 @@ const mapPlaces = places
   const LOCATION_OUTLIER_MIN_DISTANCE_KM = 50;
   const LOCATION_RECENTER_MIN_ZOOM = 14;
   const LOCATION_RECENTER_TOLERANCE_KM = 0.75;
+  const GUIDE_WORLD_MAX_LATITUDE = 85.05112878;
+  const GUIDE_WORLD_MIN_LONGITUDE = -180;
+  const GUIDE_WORLD_MAX_LONGITUDE = 180;
+  const GUIDE_FOCUS_BOUNDS_MIN_SPAN = 0.08;
+  const GUIDE_FOCUS_BOUNDS_PADDING_RATIO = 1.5;
+  const GUIDE_RESET_ZOOM_BUFFER = 5;
 
   const escapeHtml = (value: string) =>
     value
@@ -247,16 +273,64 @@ const mapPlaces = places
     }
   };
 
+  const popupRatingFormatter = new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+  const popupCompactReviewFormatter = new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  });
+  const popupFullReviewFormatter = new Intl.NumberFormat("en-US");
+
+  const popupRatingMeta = (place: MapPlace) => {
+    const rating =
+      typeof place.rating === "number" && Number.isFinite(place.rating) ? popupRatingFormatter.format(place.rating) : null;
+    const reviewCount =
+      typeof place.userRatingCount === "number" && Number.isFinite(place.userRatingCount) && place.userRatingCount >= 0
+        ? place.userRatingCount
+        : null;
+
+    if (!rating && reviewCount === null) return null;
+
+    const compactReviews = reviewCount !== null ? popupCompactReviewFormatter.format(reviewCount) : null;
+    const reviewWord = reviewCount === 1 ? "review" : "reviews";
+    const label = [rating ? `${rating} ★` : null, compactReviews ? `${compactReviews} ${reviewWord}` : null]
+      .filter(Boolean)
+      .join(" · ");
+    const title = [
+      rating ? `${rating} Google Maps rating` : null,
+      reviewCount !== null ? `${popupFullReviewFormatter.format(reviewCount)} Google Maps ${reviewWord}` : null,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+
+    return { label, title };
+  };
+
   const popupHtml = (place: MapPlace, placePhotosEnabled: boolean) => {
     const meta = [place.category, place.neighborhood].filter(Boolean).join(" · ");
     const mapsUrl = safeMapsUrl(place.mapsUrl);
     const photoUrl = placePhotosEnabled ? safePhotoUrl(place.mainPhotoPath) : null;
+    const ratingMeta = popupRatingMeta(place);
+    const mapsActionHtml = mapsUrl
+      ? `<a class="guide-map-popup-map-action" href="${escapeHtml(mapsUrl)}" target="_blank" rel="noreferrer" aria-label="Open ${escapeHtml(place.name)} in Google Maps" title="Open in Google Maps"><img src="/icons/google-maps.svg" alt="" width="18" height="26" loading="lazy" decoding="async" /></a>`
+      : "";
+    const detailsActionHtml = `<button class="guide-map-popup-details-action" type="button" data-guide-map-popup-details data-place-id="${escapeHtml(place.id)}" aria-label="Show details for ${escapeHtml(place.name)}">Details</button>`;
+    const footerHtml = `<span class="guide-map-popup-footer">${ratingMeta ? `<span class="guide-map-popup-rating" title="${escapeHtml(ratingMeta.title)}">${escapeHtml(ratingMeta.label)}</span>` : ""}<span class="guide-map-popup-actions">${detailsActionHtml}${mapsActionHtml}</span></span>`;
+    const popupBody = `
+      ${photoUrl ? `<div class="guide-map-popup-photo"><img src="${escapeHtml(photoUrl)}" alt="Photo of ${escapeHtml(place.name)}" loading="lazy" /></div>` : ""}
+      <span class="guide-map-popup-copy">
+        <strong>${escapeHtml(place.name)}</strong>
+        <span class="guide-map-popup-meta">${escapeHtml(meta)}</span>
+        ${footerHtml}
+      </span>
+    `;
+    const escapedName = escapeHtml(place.name);
     return `
       <div class="guide-map-popup-content">
-        ${photoUrl ? `<div class="guide-map-popup-photo"><img src="${escapeHtml(photoUrl)}" alt="Photo of ${escapeHtml(place.name)}" loading="lazy" /></div>` : ""}
-        <strong>${escapeHtml(place.name)}</strong>
-        <span>${escapeHtml(meta)}</span>
-        ${mapsUrl ? `<a href="${escapeHtml(mapsUrl)}" target="_blank" rel="noreferrer">Open in Google Maps</a>` : ""}
+        <button class="guide-map-popup-close" type="button" data-guide-map-popup-close aria-label="Close place details"></button>
+        <div class="guide-map-popup-place-card" aria-label="${escapedName}">${popupBody}</div>
       </div>
     `;
   };
@@ -318,6 +392,88 @@ const mapPlaces = places
       className: "guide-map-popup-shell",
       closeButton: false,
     });
+
+  const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+  const placesBoundsLiteral = (places: MapPlace[]): LatLngBoundsLiteral | null => {
+    if (places.length === 0) return null;
+
+    return places.reduce<LatLngBoundsLiteral>(
+      (bounds, place) => ({
+        east: Math.max(bounds.east, place.lng),
+        north: Math.max(bounds.north, place.lat),
+        south: Math.min(bounds.south, place.lat),
+        west: Math.min(bounds.west, place.lng),
+      }),
+      {
+        east: places[0].lng,
+        north: places[0].lat,
+        south: places[0].lat,
+        west: places[0].lng,
+      },
+    );
+  };
+
+  const expandBoundsLiteral = (
+    bounds: LatLngBoundsLiteral,
+    minSpan: number,
+    paddingRatio: number,
+  ): LatLngBoundsLiteral => {
+    const centerLat = (bounds.north + bounds.south) / 2;
+    const centerLng = (bounds.east + bounds.west) / 2;
+    const latSpan = Math.max(bounds.north - bounds.south, minSpan);
+    const lngSpan = Math.max(bounds.east - bounds.west, minSpan);
+    const paddedLatHalfSpan = (latSpan * (1 + paddingRatio * 2)) / 2;
+    const paddedLngHalfSpan = (lngSpan * (1 + paddingRatio * 2)) / 2;
+
+    return {
+      east: clamp(centerLng + paddedLngHalfSpan, GUIDE_WORLD_MIN_LONGITUDE, GUIDE_WORLD_MAX_LONGITUDE),
+      north: clamp(centerLat + paddedLatHalfSpan, -GUIDE_WORLD_MAX_LATITUDE, GUIDE_WORLD_MAX_LATITUDE),
+      south: clamp(centerLat - paddedLatHalfSpan, -GUIDE_WORLD_MAX_LATITUDE, GUIDE_WORLD_MAX_LATITUDE),
+      west: clamp(centerLng - paddedLngHalfSpan, GUIDE_WORLD_MIN_LONGITUDE, GUIDE_WORLD_MAX_LONGITUDE),
+    };
+  };
+
+  const guideFocusBounds = (places: MapPlace[]) => {
+    const bounds = placesBoundsLiteral(places);
+    if (!bounds) return null;
+
+    return expandBoundsLiteral(bounds, GUIDE_FOCUS_BOUNDS_MIN_SPAN, GUIDE_FOCUS_BOUNDS_PADDING_RATIO);
+  };
+
+  const leafletBoundsFromLiteral = (bounds: LatLngBoundsLiteral) =>
+    L.latLngBounds([bounds.south, bounds.west], [bounds.north, bounds.east]);
+
+  const leafletPlacesBounds = (places: MapPlace[]) => {
+    const bounds = placesBoundsLiteral(places);
+    return bounds ? leafletBoundsFromLiteral(bounds) : null;
+  };
+
+  const guideFocusMinZoom = (bounds: LatLngBoundsLiteral) => {
+    const span = Math.max(bounds.north - bounds.south, bounds.east - bounds.west);
+    if (span >= 40) return 2;
+    if (span >= 20) return 4;
+    if (span >= 8) return 6;
+    if (span >= 3) return 8;
+    if (span >= 1) return 10;
+    if (span >= 0.35) return 11;
+    return 12;
+  };
+
+  const guideFocusMaxResetZoom = (minZoom: number) => Math.min(19, Math.max(17, minZoom + GUIDE_RESET_ZOOM_BUFFER));
+
+  const focusViewToleranceKm = (bounds: LatLngBoundsLiteral | null) => {
+    if (!bounds) return 5;
+
+    const center = {
+      lat: (bounds.north + bounds.south) / 2,
+      lng: (bounds.east + bounds.west) / 2,
+    };
+    const latDistanceKm = distanceInKm(bounds.south, center.lng, bounds.north, center.lng);
+    const lngDistanceKm = distanceInKm(center.lat, bounds.west, center.lat, bounds.east);
+
+    return Math.max(3, Math.min(50, Math.max(latDistanceKm, lngDistanceKm) * 0.18));
+  };
 
   const fitPlaces = (map: L.Map, places: MapPlace[]) => {
     if (places.length === 0) return;
@@ -489,7 +645,10 @@ const mapPlaces = places
     }
 
     if (persist) {
-      window.localStorage.setItem(MAP_COLLAPSED_KEY, collapsed ? "true" : "false");
+      window.localStorage.setItem(
+        window.matchMedia(DESKTOP_MAP_MEDIA_QUERY).matches ? MAP_COLLAPSED_DESKTOP_KEY : MAP_COLLAPSED_MOBILE_KEY,
+        collapsed ? "true" : "false",
+      );
     }
 
     if (!collapsed && mapElement?.guideMapFit) {
@@ -515,19 +674,26 @@ const mapPlaces = places
   };
 
   const initPanels = () => {
-    const storedCollapsed = window.localStorage.getItem(MAP_COLLAPSED_KEY);
     const desktopMediaQuery = window.matchMedia(DESKTOP_MAP_MEDIA_QUERY);
     const sideBySideMediaQuery = window.matchMedia(SIDE_BY_SIDE_MAP_MEDIA_QUERY);
-    const defaultCollapsed = storedCollapsed === null ? !desktopMediaQuery.matches : storedCollapsed === "true";
+    const defaultCollapsed = () => {
+      const storageKey = desktopMediaQuery.matches ? MAP_COLLAPSED_DESKTOP_KEY : MAP_COLLAPSED_MOBILE_KEY;
+      const storedCollapsed = window.localStorage.getItem(storageKey);
+
+      return storedCollapsed === null ? !desktopMediaQuery.matches : storedCollapsed === "true";
+    };
 
     document.querySelectorAll<HTMLElement>("[data-map-panel]").forEach((panel) => {
       if (panel.dataset.panelInitialized === "true") return;
       panel.dataset.panelInitialized = "true";
 
       syncPanelOrder(panel);
-      setPanelCollapsed(panel, defaultCollapsed, false);
+      setPanelCollapsed(panel, defaultCollapsed(), false);
       panel.querySelector("[data-map-toggle]")?.addEventListener("click", () => {
         setPanelCollapsed(panel, panel.dataset.collapsed !== "true");
+      });
+      desktopMediaQuery.addEventListener("change", () => {
+        setPanelCollapsed(panel, defaultCollapsed(), false);
       });
       sideBySideMediaQuery.addEventListener("change", () => syncPanelOrder(panel));
     });
@@ -630,6 +796,12 @@ const mapPlaces = places
       zoomControl: true,
       zoomSnap: 0.1,
     });
+    mapElement.addEventListener("click", (event) => {
+      const target = event.target instanceof Element ? event.target : null;
+      if (target?.closest("[data-guide-map-popup-close]")) {
+        map.closePopup();
+      }
+    });
     enableTrackpadPinchZoom(map, mapElement);
 
     L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
@@ -640,6 +812,30 @@ const mapPlaces = places
     const markers = new Map<string, L.Marker>();
     let userLocationHalo: L.CircleMarker | null = null;
     let userLocationDot: L.CircleMarker | null = null;
+    let focusBounds = leafletPlacesBounds(places);
+    let focusMinZoom = 0;
+    let focusMaxResetZoom = 19;
+    let focusCenter: Coordinates | null = null;
+    let focusZoom: number | null = null;
+    let focusDistanceToleranceKm = focusViewToleranceKm(placesBoundsLiteral(places));
+    const applyFocusBounds = (visiblePlaces: MapPlace[]) => {
+      const placeBounds = placesBoundsLiteral(visiblePlaces);
+      const nextFocusBounds = leafletPlacesBounds(visiblePlaces);
+      const restrictionBounds = guideFocusBounds(visiblePlaces);
+      focusBounds = nextFocusBounds;
+      focusDistanceToleranceKm = focusViewToleranceKm(placeBounds);
+      focusMinZoom = restrictionBounds ? guideFocusMinZoom(restrictionBounds) : 0;
+      focusMaxResetZoom = guideFocusMaxResetZoom(focusMinZoom);
+      map.setMinZoom(focusMinZoom);
+      if (restrictionBounds) {
+        map.setMaxBounds(leafletBoundsFromLiteral(restrictionBounds));
+      }
+    };
+    const captureFocusView = () => {
+      const center = map.getCenter();
+      focusCenter = { lat: center.lat, lng: center.lng };
+      focusZoom = map.getZoom();
+    };
     places.forEach((place) => {
       const marker = placeMarker(place, placePhotosEnabled).addTo(map);
       marker.on("click", () => onSelectPlace(place.id));
@@ -649,7 +845,11 @@ const mapPlaces = places
     return {
       rawMap: map,
       closePopup: () => map.closePopup(),
-      fitPlaces: (visiblePlaces) => fitPlaces(map, visiblePlaces),
+      fitPlaces: (visiblePlaces) => {
+        applyFocusBounds(visiblePlaces);
+        fitPlaces(map, visiblePlaces);
+        captureFocusView();
+      },
       getBoundsContains: (place) => map.getBounds().contains(L.latLng(place.lat, place.lng)),
       getCenter: () => {
         const center = map.getCenter();
@@ -667,6 +867,22 @@ const mapPlaces = places
         marker.setZIndexOffset(active ? 1000 : place.topPick ? 10 : 0);
       },
       invalidateSize: () => map.invalidateSize(),
+      isOutsideFocusView: () => {
+        const zoom = map.getZoom();
+        const center = map.getCenter();
+        const offFocusCenter = focusCenter
+          ? distanceInKm(center.lat, center.lng, focusCenter.lat, focusCenter.lng) > focusDistanceToleranceKm
+          : false;
+        const offFocusZoom = focusZoom !== null ? Math.abs(zoom - focusZoom) > 0.75 : false;
+        return Boolean(
+          focusBounds &&
+            (!map.getBounds().intersects(focusBounds) ||
+              zoom < focusMinZoom ||
+              zoom > focusMaxResetZoom ||
+              offFocusCenter ||
+              offFocusZoom),
+        );
+      },
       onViewportChange: (handler) => {
         map.on("moveend zoomend", handler);
         return () => {
@@ -756,10 +972,22 @@ const mapPlaces = places
       zoom: 13,
       zoomControl: true,
     });
-    const infoWindow = new google.maps.InfoWindow();
+    const infoWindow = new google.maps.InfoWindow({ headerDisabled: true });
+    mapElement.addEventListener("click", (event) => {
+      const target = event.target instanceof Element ? event.target : null;
+      if (target?.closest("[data-guide-map-popup-close]")) {
+        infoWindow.close();
+      }
+    });
     const markers = new Map<string, any>();
     let userLocationHalo: any | null = null;
     let userLocationDot: any | null = null;
+    let focusBounds: InstanceType<GoogleMapsApi["maps"]["LatLngBounds"]> | null = null;
+    let focusMinZoom = 0;
+    let focusMaxResetZoom = 19;
+    let focusCenter: Coordinates | null = null;
+    let focusZoom: number | null = null;
+    let focusDistanceToleranceKm = focusViewToleranceKm(placesBoundsLiteral(places));
 
     const markerIcon = (place: MapPlace, active = false) => {
       const size = getMapMarkerSize(place.markerIcon, place.topPick, active);
@@ -817,21 +1045,57 @@ const mapPlaces = places
       marker.addListener("click", () => onSelectPlace(place.id));
       markers.set(place.id, marker);
     });
+    const applyFocusBounds = (visiblePlaces: MapPlace[]) => {
+      const placeBounds = placesBoundsLiteral(visiblePlaces);
+      const restrictionBounds = guideFocusBounds(visiblePlaces);
+      focusBounds = visiblePlaces.length > 0 ? new google.maps.LatLngBounds() : null;
+      visiblePlaces.forEach((place) => focusBounds?.extend({ lat: place.lat, lng: place.lng }));
+      focusDistanceToleranceKm = focusViewToleranceKm(placeBounds);
+      focusMinZoom = restrictionBounds ? guideFocusMinZoom(restrictionBounds) : 0;
+      focusMaxResetZoom = guideFocusMaxResetZoom(focusMinZoom);
+      if (restrictionBounds) {
+        map.setOptions({
+          minZoom: focusMinZoom,
+          restriction: {
+            latLngBounds: restrictionBounds,
+            strictBounds: true,
+          },
+        });
+      }
+    };
+    const captureFocusView = () => {
+      const center = map.getCenter();
+      if (!center) return;
+
+      focusCenter = {
+        lat: typeof center.lat === "function" ? center.lat() : center.lat,
+        lng: typeof center.lng === "function" ? center.lng() : center.lng,
+      };
+      focusZoom = map.getZoom() ?? null;
+    };
+    const scheduleFocusViewCapture = () => {
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(captureFocusView);
+      });
+    };
 
     return {
       rawMap: map,
       closePopup: () => infoWindow.close(),
       fitPlaces: (visiblePlaces) => {
         if (visiblePlaces.length === 0) return;
+        applyFocusBounds(visiblePlaces);
         if (visiblePlaces.length === 1) {
           map.setCenter({ lat: visiblePlaces[0].lat, lng: visiblePlaces[0].lng });
           map.setZoom(14);
+          scheduleFocusViewCapture();
           return;
         }
 
         const bounds = new google.maps.LatLngBounds();
         visiblePlaces.forEach((place) => bounds.extend({ lat: place.lat, lng: place.lng }));
         map.fitBounds(bounds, 28);
+        scheduleFocusViewCapture();
       },
       getBoundsContains: (place) => map.getBounds()?.contains({ lat: place.lat, lng: place.lng }) ?? true,
       getCenter: () => {
@@ -852,6 +1116,32 @@ const mapPlaces = places
         if (!marker) return;
         marker.setIcon(markerIcon(place, active));
         marker.setZIndex(active ? 1000 : place.topPick ? 10 : 1);
+      },
+      isOutsideFocusView: () => {
+        const currentBounds = map.getBounds();
+        const zoom = map.getZoom() ?? focusMinZoom;
+        const center = map.getCenter();
+        const currentCenter = center
+          ? {
+              lat: typeof center.lat === "function" ? center.lat() : center.lat,
+              lng: typeof center.lng === "function" ? center.lng() : center.lng,
+            }
+          : null;
+        const offFocusCenter =
+          focusCenter && currentCenter
+            ? distanceInKm(currentCenter.lat, currentCenter.lng, focusCenter.lat, focusCenter.lng) >
+              focusDistanceToleranceKm
+            : false;
+        const offFocusZoom = focusZoom !== null ? Math.abs(zoom - focusZoom) > 0.75 : false;
+        return Boolean(
+          focusBounds &&
+            currentBounds &&
+            (!currentBounds.intersects(focusBounds) ||
+              zoom < focusMinZoom ||
+              zoom > focusMaxResetZoom ||
+              offFocusCenter ||
+              offFocusZoom),
+        );
       },
       onViewportChange: (handler) => {
         const idleListener = map.addListener("idle", handler);
@@ -949,6 +1239,7 @@ const mapPlaces = places
     let currentVisiblePlaceIds = visiblePlaceIdsFromCards();
     let currentPlaces = places.filter((place) => currentVisiblePlaceIds.has(place.id));
     const mapFrameActive = () => mapResetButtons.some((button) => !button.hidden);
+    let currentMapFrameActive = mapFrameActive();
     const mapElement = element as GuideMapElement;
     mapElement.guideLocationBounds = locationBoundsForPlaces(places) ?? undefined;
     const placeById = new Map(places.map((place) => [place.id, place]));
@@ -962,13 +1253,24 @@ const mapPlaces = places
     let locationWatchId: number | null = null;
     const requestedProvider = element.dataset.mapProvider === "google" ? "google" : "leaflet";
     const apiKey = element.dataset.googleMapsApiKey || "";
-    const handleMarkerSelect = (placeId: string) => selectPlace(placeId);
+    const shouldAutoFocusCardFromMarker = () => window.matchMedia(SIDE_BY_SIDE_MAP_MEDIA_QUERY).matches;
+    const handleMarkerSelect = (placeId: string) =>
+      selectPlace(placeId, { focusCard: shouldAutoFocusCardFromMarker() });
     let runtime: MapRuntime | null = null;
 
+    const syncFullAreaButton = () => {
+      if (!mapFullAreaButton) return;
+
+      mapFullAreaButton.hidden = !currentMapFrameActive && !runtime?.isOutsideFocusView();
+    };
+    const scheduleFullAreaButtonSync = () => window.requestAnimationFrame(syncFullAreaButton);
+
     const updateMapFrameControls = (active: boolean) => {
+      currentMapFrameActive = active;
       mapResetButtons.forEach((button) => {
         button.hidden = !active;
       });
+      syncFullAreaButton();
     };
 
     const dispatchUserLocation = (
@@ -1012,6 +1314,7 @@ const mapPlaces = places
       if (!detail.mapFrameActive) {
         runtime.fitPlaces(currentPlaces);
       }
+      scheduleFullAreaButtonSync();
 
       if (shouldRecenterAfterUpdate) {
         scheduleLocationCenter();
@@ -1053,6 +1356,18 @@ const mapPlaces = places
       cards.forEach((card) => {
         card.dataset.mapActive = card.dataset.placeId === placeId ? "true" : "false";
       });
+    };
+    const cardByPlaceId = new Map(
+      cards
+        .map((card) => [card.dataset.placeId, card] as const)
+        .filter((entry): entry is readonly [string, HTMLElement] => Boolean(entry[0])),
+    );
+    const focusPlaceCard = (placeId: string) => {
+      const card = cardByPlaceId.get(placeId);
+      if (!card || card.hidden) return;
+
+      card.focus({ preventScroll: true });
+      card.scrollIntoView({ behavior: "smooth", block: "center", inline: "nearest" });
     };
 
     const updateActiveMarker = (openPopup = false) => {
@@ -1110,11 +1425,26 @@ const mapPlaces = places
       }
     };
 
-    const selectPlace = (placeId: string, expandCollapsed = false) => {
+    const selectPlace = (
+      placeId: string,
+      { expandCollapsed = false, focusCard = false }: { expandCollapsed?: boolean; focusCard?: boolean } = {},
+    ) => {
       hoveredPlaceId = "";
       selectedPlaceId = placeId;
       showPlace(placeId, { ensureVisible: true, expandCollapsed });
+      if (focusCard) focusPlaceCard(placeId);
     };
+
+    mapElement.addEventListener("click", (event) => {
+      const target = event.target instanceof Element ? event.target : null;
+      const detailsButton = target?.closest<HTMLElement>("[data-guide-map-popup-details]");
+      const placeId = detailsButton?.dataset.placeId;
+      if (!placeId) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      selectPlace(placeId, { focusCard: true });
+    });
 
     const hoverPlace = (placeId: string) => {
       hoveredPlaceId = placeId;
@@ -1365,6 +1695,7 @@ const mapPlaces = places
         currentPlaces = places;
         runtime.setVisiblePlaces(new Set(places.map((place) => place.id)));
         runtime.fitPlaces(places);
+        scheduleFullAreaButtonSync();
       }
     };
 
@@ -1380,14 +1711,14 @@ const mapPlaces = places
       card.addEventListener("click", (event) => {
         const target = event.target instanceof Element ? event.target : null;
         if (target?.closest("a, button, input, select, textarea, [role='button']")) return;
-        selectPlace(placeId, true);
+        selectPlace(placeId, { expandCollapsed: true });
       });
       card.addEventListener("keydown", (event) => {
         if (event.key !== "Enter" && event.key !== " ") return;
         const target = event.target instanceof Element ? event.target : null;
         if (target?.closest("a, button, input, select, textarea, [role='button']")) return;
         event.preventDefault();
-        selectPlace(placeId, true);
+        selectPlace(placeId, { expandCollapsed: true });
       });
     });
 
@@ -1399,12 +1730,15 @@ const mapPlaces = places
       locationButton.addEventListener("click", centerOnCurrentLocation);
     }
     runtime.onViewportChange?.(syncLocationButtonToViewport);
+    runtime.onViewportChange?.(syncFullAreaButton);
     mapElement.guideMapFit = () => {
       runtime?.invalidateSize?.();
       runtime?.fitPlaces(currentPlaces);
+      scheduleFullAreaButtonSync();
     };
 
     runtime.fitPlaces(currentPlaces);
+    scheduleFullAreaButtonSync();
     window.setTimeout(() => mapElement.guideMapFit?.(), 0);
   };
 

--- a/src/components/HomeGuideMap.astro
+++ b/src/components/HomeGuideMap.astro
@@ -41,9 +41,14 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
           <p class="small-copy" data-home-map-summary>
             Showing {mapGuides.length} guide{mapGuides.length === 1 ? "" : "s"} on the map.
           </p>
-          <button class="map-inline-toggle" type="button" data-home-map-toggle aria-expanded="true">
-            Hide map
-          </button>
+          <div class="home-map-actions">
+            <button class="map-inline-toggle" type="button" data-home-map-reset hidden>
+              Reset map
+            </button>
+            <button class="map-inline-toggle" type="button" data-home-map-toggle aria-expanded="true">
+              Hide map
+            </button>
+          </div>
         </div>
       </div>
 
@@ -89,6 +94,13 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     lng: number;
   }
 
+  interface LatLngBoundsLiteral {
+    east: number;
+    north: number;
+    south: number;
+    west: number;
+  }
+
   interface HomeGuideMapElement extends HTMLElement {
     homeGuideMapInitialized?: boolean;
   }
@@ -96,6 +108,9 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
   interface HomeMapRuntime {
     fitGuides: (guides: HomeMapGuide[]) => void;
     invalidateSize?: () => void;
+    isOutsideFocusBounds: () => boolean;
+    onViewChanged: (handler: () => void) => void;
+    resetView: () => void;
     setVisibleGuides: (visibleGuideSlugs: Set<string>) => void;
   }
 
@@ -118,13 +133,18 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
       };
       LatLngBounds: new () => {
         extend: (coordinates: Coordinates) => void;
+        intersects: (bounds: unknown) => boolean;
       };
       Map: new (
         element: HTMLElement,
         options: Record<string, unknown>,
       ) => {
+        addListener: (eventName: string, handler: () => void) => void;
         fitBounds: (bounds: unknown, padding?: number | { top: number; right: number; bottom: number; left: number }) => void;
+        getBounds: () => { intersects: (bounds: unknown) => boolean } | undefined;
+        getZoom: () => number | undefined;
         setCenter: (coordinates: Coordinates) => void;
+        setOptions: (options: Record<string, unknown>) => void;
         setZoom: (zoom: number) => void;
       };
       Marker: new (options: Record<string, unknown>) => {
@@ -149,6 +169,9 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     south: -WORLD_MAP_MAX_LATITUDE,
     west: WORLD_MAP_MIN_LONGITUDE,
   };
+  const HOME_FOCUS_BOUNDS_MIN_SPAN = 8;
+  const HOME_FOCUS_BOUNDS_PADDING_RATIO = 0.75;
+  const HOME_RESET_ZOOM_BUFFER = 4;
   const LEAFLET_WORLD_BOUNDS = L.latLngBounds(
     [-WORLD_MAP_MAX_LATITUDE, WORLD_MAP_MIN_LONGITUDE],
     [WORLD_MAP_MAX_LATITUDE, WORLD_MAP_MAX_LONGITUDE],
@@ -206,6 +229,73 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
   `;
 
   const markerLabelUnits = (label: string) => Array.from(label).length;
+
+  const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+  const guideBoundsLiteral = (guides: HomeMapGuide[]): LatLngBoundsLiteral | null => {
+    if (guides.length === 0) return null;
+
+    return guides.reduce<LatLngBoundsLiteral>(
+      (bounds, guide) => ({
+        east: Math.max(bounds.east, guide.lng),
+        north: Math.max(bounds.north, guide.lat),
+        south: Math.min(bounds.south, guide.lat),
+        west: Math.min(bounds.west, guide.lng),
+      }),
+      {
+        east: guides[0].lng,
+        north: guides[0].lat,
+        south: guides[0].lat,
+        west: guides[0].lng,
+      },
+    );
+  };
+
+  const expandBoundsLiteral = (
+    bounds: LatLngBoundsLiteral,
+    minSpan: number,
+    paddingRatio: number,
+  ): LatLngBoundsLiteral => {
+    const centerLat = (bounds.north + bounds.south) / 2;
+    const centerLng = (bounds.east + bounds.west) / 2;
+    const latSpan = Math.max(bounds.north - bounds.south, minSpan);
+    const lngSpan = Math.max(bounds.east - bounds.west, minSpan);
+    const paddedLatHalfSpan = (latSpan * (1 + paddingRatio * 2)) / 2;
+    const paddedLngHalfSpan = (lngSpan * (1 + paddingRatio * 2)) / 2;
+
+    return {
+      east: clamp(centerLng + paddedLngHalfSpan, WORLD_MAP_MIN_LONGITUDE, WORLD_MAP_MAX_LONGITUDE),
+      north: clamp(centerLat + paddedLatHalfSpan, -WORLD_MAP_MAX_LATITUDE, WORLD_MAP_MAX_LATITUDE),
+      south: clamp(centerLat - paddedLatHalfSpan, -WORLD_MAP_MAX_LATITUDE, WORLD_MAP_MAX_LATITUDE),
+      west: clamp(centerLng - paddedLngHalfSpan, WORLD_MAP_MIN_LONGITUDE, WORLD_MAP_MAX_LONGITUDE),
+    };
+  };
+
+  const guideFocusBounds = (guides: HomeMapGuide[]) => {
+    const bounds = guideBoundsLiteral(guides);
+    if (!bounds) return null;
+
+    return expandBoundsLiteral(bounds, HOME_FOCUS_BOUNDS_MIN_SPAN, HOME_FOCUS_BOUNDS_PADDING_RATIO);
+  };
+
+  const leafletBoundsFromLiteral = (bounds: LatLngBoundsLiteral) =>
+    L.latLngBounds([bounds.south, bounds.west], [bounds.north, bounds.east]);
+
+  const leafletGuideBounds = (guides: HomeMapGuide[]) => {
+    const bounds = guideBoundsLiteral(guides);
+    return bounds ? leafletBoundsFromLiteral(bounds) : null;
+  };
+
+  const homeFocusMinZoom = (bounds: LatLngBoundsLiteral) => {
+    const span = Math.max(bounds.north - bounds.south, bounds.east - bounds.west);
+    if (span >= 150) return WORLD_MAP_MIN_ZOOM;
+    if (span >= 70) return 1;
+    if (span >= 35) return 2;
+    if (span >= 16) return 3;
+    return 4;
+  };
+
+  const homeFocusMaxResetZoom = (minZoom: number) => Math.min(12, Math.max(7, minZoom + HOME_RESET_ZOOM_BUFFER));
 
   const fitGuides = (map: L.Map, guides: HomeMapGuide[]) => {
     if (guides.length === 0) return;
@@ -329,6 +419,19 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     }).addTo(map);
 
     const markers = new Map<string, L.Marker>();
+    let focusGuides = guides;
+    let focusBounds = leafletGuideBounds(guides);
+    let focusMinZoom = WORLD_MAP_MIN_ZOOM;
+    let focusMaxResetZoom = 12;
+    const applyFocusBounds = (visibleGuides: HomeMapGuide[]) => {
+      const nextFocusBounds = leafletGuideBounds(visibleGuides);
+      const restrictionBoundsLiteral = guideFocusBounds(visibleGuides);
+      focusBounds = nextFocusBounds;
+      focusMinZoom = restrictionBoundsLiteral ? homeFocusMinZoom(restrictionBoundsLiteral) : WORLD_MAP_MIN_ZOOM;
+      focusMaxResetZoom = homeFocusMaxResetZoom(focusMinZoom);
+      map.setMinZoom(WORLD_MAP_MIN_ZOOM);
+      map.setMaxBounds(LEAFLET_WORLD_BOUNDS);
+    };
     guides.forEach((guide) => {
       const marker = L.marker([guide.lat, guide.lng], {
         icon: L.divIcon({
@@ -348,8 +451,26 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     });
 
     return {
-      fitGuides: (visibleGuides) => fitGuides(map, visibleGuides),
+      fitGuides: (visibleGuides) => {
+        focusGuides = visibleGuides;
+        applyFocusBounds(visibleGuides);
+        fitGuides(map, visibleGuides);
+      },
       invalidateSize: () => map.invalidateSize(),
+      isOutsideFocusBounds: () => {
+        const zoom = map.getZoom();
+        return Boolean(
+          focusBounds &&
+            (!map.getBounds().intersects(focusBounds) || zoom < focusMinZoom || zoom > focusMaxResetZoom),
+        );
+      },
+      onViewChanged: (handler) => {
+        map.on("moveend zoomend", handler);
+      },
+      resetView: () => {
+        applyFocusBounds(focusGuides);
+        fitGuides(map, focusGuides);
+      },
       setVisibleGuides: (visibleGuideSlugs) => {
         markers.forEach((marker, guideSlug) => {
           if (visibleGuideSlugs.has(guideSlug)) {
@@ -384,6 +505,10 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     });
     const infoWindow = new googleMaps.maps.InfoWindow();
     const markers = new Map<string, any>();
+    let focusGuides = guides;
+    let focusBounds: InstanceType<GoogleMapsApi["maps"]["LatLngBounds"]> | null = null;
+    let focusMinZoom = WORLD_MAP_MIN_ZOOM;
+    let focusMaxResetZoom = 12;
     const markerColor = getThemeValue("--accent", "#b94736");
     const markerFillColor = getThemeValue("--surface-strong", "#f7f7f4");
     const markerLabelColor = getThemeValue("--ink", "#20262c");
@@ -418,22 +543,58 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
       markers.set(guide.slug, marker);
     });
 
+    const fitGoogleGuides = (visibleGuides: HomeMapGuide[]) => {
+      if (visibleGuides.length === 0) return;
+
+      if (visibleGuides.length === 1) {
+        map.setCenter({ lat: visibleGuides[0].lat, lng: visibleGuides[0].lng });
+        map.setZoom(5);
+        return;
+      }
+
+      const bounds = new googleMaps.maps.LatLngBounds();
+      visibleGuides.forEach((guide) => bounds.extend({ lat: guide.lat, lng: guide.lng }));
+      map.fitBounds(bounds, 28);
+    };
+    const applyFocusBounds = (visibleGuides: HomeMapGuide[]) => {
+      const restrictionBounds = guideFocusBounds(visibleGuides) || WORLD_MAP_BOUNDS;
+      focusBounds = visibleGuides.length > 0 ? new googleMaps.maps.LatLngBounds() : null;
+      visibleGuides.forEach((guide) => focusBounds?.extend({ lat: guide.lat, lng: guide.lng }));
+      focusMinZoom = homeFocusMinZoom(restrictionBounds);
+      focusMaxResetZoom = homeFocusMaxResetZoom(focusMinZoom);
+      map.setOptions({
+        minZoom: WORLD_MAP_MIN_ZOOM,
+        restriction: {
+          latLngBounds: WORLD_MAP_BOUNDS,
+          strictBounds: true,
+        },
+      });
+    };
+
     return {
       fitGuides: (visibleGuides) => {
-        if (visibleGuides.length === 0) return;
-
-        if (visibleGuides.length === 1) {
-          map.setCenter({ lat: visibleGuides[0].lat, lng: visibleGuides[0].lng });
-          map.setZoom(5);
-          return;
-        }
-
-        const bounds = new googleMaps.maps.LatLngBounds();
-        visibleGuides.forEach((guide) => bounds.extend({ lat: guide.lat, lng: guide.lng }));
-        map.fitBounds(bounds, 28);
+        focusGuides = visibleGuides;
+        applyFocusBounds(visibleGuides);
+        fitGoogleGuides(visibleGuides);
       },
       invalidateSize: () => {
         window.dispatchEvent(new Event("resize"));
+      },
+      isOutsideFocusBounds: () => {
+        const currentBounds = map.getBounds();
+        const zoom = map.getZoom() ?? focusMinZoom;
+        return Boolean(
+          focusBounds &&
+            currentBounds &&
+            (!currentBounds.intersects(focusBounds) || zoom < focusMinZoom || zoom > focusMaxResetZoom),
+        );
+      },
+      onViewChanged: (handler) => {
+        map.addListener("bounds_changed", handler);
+      },
+      resetView: () => {
+        applyFocusBounds(focusGuides);
+        fitGoogleGuides(focusGuides);
       },
       setVisibleGuides: (visibleGuideSlugs) => {
         markers.forEach((marker, guideSlug) => marker.setMap(visibleGuideSlugs.has(guideSlug) ? map : null));
@@ -496,6 +657,7 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
 
     const panel = element.closest<HTMLElement>("[data-home-map-panel]");
     const summary = panel?.querySelector<HTMLElement>("[data-home-map-summary]") || null;
+    const resetButton = panel?.querySelector<HTMLButtonElement>("[data-home-map-reset]") || null;
     const requestedProvider = element.dataset.mapProvider === "google" ? "google" : "leaflet";
     const apiKey = element.dataset.googleMapsApiKey || "";
     let runtime: HomeMapRuntime | null = null;
@@ -508,6 +670,11 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
       visibleGuideCount: guides.length,
       visibleGuideSlugs: guides.map((guide) => guide.slug),
     };
+    const syncResetButton = () => {
+      if (!resetButton) return;
+      resetButton.hidden = !runtime?.isOutsideFocusBounds();
+    };
+    const scheduleResetButtonSync = () => window.requestAnimationFrame(syncResetButton);
 
     const applyVisibility = (
       visibleGuideSlugs: string[],
@@ -523,6 +690,7 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
       currentVisibleGuides = guides.filter((guide) => currentVisibleGuideSlugs.has(guide.slug));
       runtime?.setVisibleGuides(currentVisibleGuideSlugs);
       runtime?.fitGuides(currentVisibleGuides);
+      scheduleResetButtonSync();
       updateSummary(summary, currentVisibleGuides.length, activeScopeLabel, activeScopeMode, query);
     };
 
@@ -556,10 +724,16 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     } catch {
       runtime = initLeafletRuntime(element, guides);
     }
+    runtime.onViewChanged(syncResetButton);
+    resetButton?.addEventListener("click", () => {
+      runtime?.resetView();
+      scheduleResetButtonSync();
+    });
 
     element.addEventListener("favorite-places:home-map-panel-opened", () => {
       runtime?.invalidateSize?.();
       runtime?.fitGuides(currentVisibleGuides);
+      scheduleResetButtonSync();
     });
 
     applyVisibility(
@@ -572,6 +746,7 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     if (panel?.dataset.collapsed !== "true") {
       runtime?.invalidateSize?.();
       runtime?.fitGuides(currentVisibleGuides);
+      scheduleResetButtonSync();
     }
     element.homeGuideMapInitialized = true;
   };

--- a/src/components/HomeGuideMap.astro
+++ b/src/components/HomeGuideMap.astro
@@ -142,6 +142,13 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
         addListener: (eventName: string, handler: () => void) => void;
         fitBounds: (bounds: unknown, padding?: number | { top: number; right: number; bottom: number; left: number }) => void;
         getBounds: () => { intersects: (bounds: unknown) => boolean } | undefined;
+        getCenter: () =>
+          | {
+              lat: () => number;
+              lng: () => number;
+            }
+          | Coordinates
+          | undefined;
         getZoom: () => number | undefined;
         setCenter: (coordinates: Coordinates) => void;
         setOptions: (options: Record<string, unknown>) => void;
@@ -297,6 +304,35 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
 
   const homeFocusMaxResetZoom = (minZoom: number) => Math.min(12, Math.max(7, minZoom + HOME_RESET_ZOOM_BUFFER));
 
+  const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
+
+  const distanceInKm = (fromLat: number, fromLng: number, toLat: number, toLng: number) => {
+    const earthRadiusKm = 6371;
+    const latDelta = toRadians(toLat - fromLat);
+    const lngDelta = toRadians(toLng - fromLng);
+    const fromLatRadians = toRadians(fromLat);
+    const toLatRadians = toRadians(toLat);
+    const a =
+      Math.sin(latDelta / 2) ** 2 +
+      Math.cos(fromLatRadians) * Math.cos(toLatRadians) * Math.sin(lngDelta / 2) ** 2;
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+    return earthRadiusKm * c;
+  };
+
+  const homeFocusViewToleranceKm = (bounds: LatLngBoundsLiteral | null) => {
+    if (!bounds) return 250;
+
+    const center = {
+      lat: (bounds.north + bounds.south) / 2,
+      lng: (bounds.east + bounds.west) / 2,
+    };
+    const latDistanceKm = distanceInKm(bounds.south, center.lng, bounds.north, center.lng);
+    const lngDistanceKm = distanceInKm(center.lat, bounds.west, center.lat, bounds.east);
+
+    return Math.max(150, Math.min(1500, Math.max(latDistanceKm, lngDistanceKm) * 0.18));
+  };
+
   const fitGuides = (map: L.Map, guides: HomeMapGuide[]) => {
     if (guides.length === 0) return;
 
@@ -423,14 +459,24 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     let focusBounds = leafletGuideBounds(guides);
     let focusMinZoom = WORLD_MAP_MIN_ZOOM;
     let focusMaxResetZoom = 12;
+    let focusCenter: Coordinates | null = null;
+    let focusZoom: number | null = null;
+    let focusDistanceToleranceKm = homeFocusViewToleranceKm(guideBoundsLiteral(guides));
     const applyFocusBounds = (visibleGuides: HomeMapGuide[]) => {
+      const guideBounds = guideBoundsLiteral(visibleGuides);
       const nextFocusBounds = leafletGuideBounds(visibleGuides);
       const restrictionBoundsLiteral = guideFocusBounds(visibleGuides);
       focusBounds = nextFocusBounds;
+      focusDistanceToleranceKm = homeFocusViewToleranceKm(guideBounds);
       focusMinZoom = restrictionBoundsLiteral ? homeFocusMinZoom(restrictionBoundsLiteral) : WORLD_MAP_MIN_ZOOM;
       focusMaxResetZoom = homeFocusMaxResetZoom(focusMinZoom);
       map.setMinZoom(WORLD_MAP_MIN_ZOOM);
       map.setMaxBounds(LEAFLET_WORLD_BOUNDS);
+    };
+    const captureFocusView = () => {
+      const center = map.getCenter();
+      focusCenter = { lat: center.lat, lng: center.lng };
+      focusZoom = map.getZoom();
     };
     guides.forEach((guide) => {
       const marker = L.marker([guide.lat, guide.lng], {
@@ -455,13 +501,23 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
         focusGuides = visibleGuides;
         applyFocusBounds(visibleGuides);
         fitGuides(map, visibleGuides);
+        captureFocusView();
       },
       invalidateSize: () => map.invalidateSize(),
       isOutsideFocusBounds: () => {
         const zoom = map.getZoom();
+        const center = map.getCenter();
+        const offFocusCenter = focusCenter
+          ? distanceInKm(center.lat, center.lng, focusCenter.lat, focusCenter.lng) > focusDistanceToleranceKm
+          : false;
+        const offFocusZoom = focusZoom !== null ? Math.abs(zoom - focusZoom) > 0.75 : false;
         return Boolean(
           focusBounds &&
-            (!map.getBounds().intersects(focusBounds) || zoom < focusMinZoom || zoom > focusMaxResetZoom),
+            (!map.getBounds().intersects(focusBounds) ||
+              zoom < focusMinZoom ||
+              zoom > focusMaxResetZoom ||
+              offFocusCenter ||
+              offFocusZoom),
         );
       },
       onViewChanged: (handler) => {
@@ -470,6 +526,7 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
       resetView: () => {
         applyFocusBounds(focusGuides);
         fitGuides(map, focusGuides);
+        captureFocusView();
       },
       setVisibleGuides: (visibleGuideSlugs) => {
         markers.forEach((marker, guideSlug) => {
@@ -509,6 +566,9 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     let focusBounds: InstanceType<GoogleMapsApi["maps"]["LatLngBounds"]> | null = null;
     let focusMinZoom = WORLD_MAP_MIN_ZOOM;
     let focusMaxResetZoom = 12;
+    let focusCenter: Coordinates | null = null;
+    let focusZoom: number | null = null;
+    let focusDistanceToleranceKm = homeFocusViewToleranceKm(guideBoundsLiteral(guides));
     const markerColor = getThemeValue("--accent", "#b94736");
     const markerFillColor = getThemeValue("--surface-strong", "#f7f7f4");
     const markerLabelColor = getThemeValue("--ink", "#20262c");
@@ -557,9 +617,11 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
       map.fitBounds(bounds, 28);
     };
     const applyFocusBounds = (visibleGuides: HomeMapGuide[]) => {
+      const guideBounds = guideBoundsLiteral(visibleGuides);
       const restrictionBounds = guideFocusBounds(visibleGuides) || WORLD_MAP_BOUNDS;
       focusBounds = visibleGuides.length > 0 ? new googleMaps.maps.LatLngBounds() : null;
       visibleGuides.forEach((guide) => focusBounds?.extend({ lat: guide.lat, lng: guide.lng }));
+      focusDistanceToleranceKm = homeFocusViewToleranceKm(guideBounds);
       focusMinZoom = homeFocusMinZoom(restrictionBounds);
       focusMaxResetZoom = homeFocusMaxResetZoom(focusMinZoom);
       map.setOptions({
@@ -570,12 +632,28 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
         },
       });
     };
+    const captureFocusView = () => {
+      const center = map.getCenter();
+      if (!center) return;
+
+      focusCenter = {
+        lat: typeof center.lat === "function" ? center.lat() : center.lat,
+        lng: typeof center.lng === "function" ? center.lng() : center.lng,
+      };
+      focusZoom = map.getZoom() ?? null;
+    };
+    const scheduleFocusViewCapture = () => {
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(captureFocusView);
+      });
+    };
 
     return {
       fitGuides: (visibleGuides) => {
         focusGuides = visibleGuides;
         applyFocusBounds(visibleGuides);
         fitGoogleGuides(visibleGuides);
+        scheduleFocusViewCapture();
       },
       invalidateSize: () => {
         window.dispatchEvent(new Event("resize"));
@@ -583,18 +661,36 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
       isOutsideFocusBounds: () => {
         const currentBounds = map.getBounds();
         const zoom = map.getZoom() ?? focusMinZoom;
+        const center = map.getCenter();
+        const currentCenter = center
+          ? {
+              lat: typeof center.lat === "function" ? center.lat() : center.lat,
+              lng: typeof center.lng === "function" ? center.lng() : center.lng,
+            }
+          : null;
+        const offFocusCenter =
+          focusCenter && currentCenter
+            ? distanceInKm(currentCenter.lat, currentCenter.lng, focusCenter.lat, focusCenter.lng) >
+              focusDistanceToleranceKm
+            : false;
+        const offFocusZoom = focusZoom !== null ? Math.abs(zoom - focusZoom) > 0.75 : false;
         return Boolean(
           focusBounds &&
             currentBounds &&
-            (!currentBounds.intersects(focusBounds) || zoom < focusMinZoom || zoom > focusMaxResetZoom),
+            (!currentBounds.intersects(focusBounds) ||
+              zoom < focusMinZoom ||
+              zoom > focusMaxResetZoom ||
+              offFocusCenter ||
+              offFocusZoom),
         );
       },
       onViewChanged: (handler) => {
-        map.addListener("bounds_changed", handler);
+        map.addListener("idle", handler);
       },
       resetView: () => {
         applyFocusBounds(focusGuides);
         fitGoogleGuides(focusGuides);
+        scheduleFocusViewCapture();
       },
       setVisibleGuides: (visibleGuideSlugs) => {
         markers.forEach((marker, guideSlug) => marker.setMap(visibleGuideSlugs.has(guideSlug) ? map : null));

--- a/src/components/PlaceCard.astro
+++ b/src/components/PlaceCard.astro
@@ -41,14 +41,30 @@ const compactReviewCountFormatter = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 1,
 });
 const reviewCountFormatter = new Intl.NumberFormat("en-US");
+const compactReviewLabel =
+  reviewCount !== null
+    ? `${compactReviewCountFormatter.format(reviewCount)} ${reviewCount === 1 ? "review" : "reviews"}`
+    : null;
+const placeRatingMetaLabel = [
+  siteConfig.placeCard.showRating && ratingValue !== null ? `${ratingFormatter.format(ratingValue)} ★` : null,
+  siteConfig.placeCard.showReviewCount ? compactReviewLabel : null,
+]
+  .filter(Boolean)
+  .join(" · ");
+const placeRatingMetaTitle = [
+  siteConfig.placeCard.showRating && ratingValue !== null ? `${ratingFormatter.format(ratingValue)} Google Maps rating` : null,
+  siteConfig.placeCard.showReviewCount && reviewCount !== null
+    ? `${reviewCountFormatter.format(reviewCount)} Google Maps ${reviewCount === 1 ? "review" : "reviews"}`
+    : null,
+]
+  .filter(Boolean)
+  .join(" · ");
 const placeholderMeta =
   place.neighborhood ??
   guideContext.cityName ??
   guideContext.countryName ??
   siteConfig.placeCard.photoPlaceholderFallback;
-const hasStats =
-  (siteConfig.placeCard.showRating && ratingValue !== null) ||
-  (siteConfig.placeCard.showReviewCount && reviewCount !== null);
+const hasStats = placeRatingMetaLabel.length > 0;
 const metaParts = [
   siteConfig.placeCard.showCategory ? (place.primary_category ?? siteConfig.placeCard.savedPlaceLabel) : null,
   siteConfig.placeCard.showNeighborhood ? place.neighborhood : null,
@@ -148,14 +164,9 @@ const badges = [
         {metaParts.length > 0 && <p class="meta-copy">{metaParts.join(" · ")}</p>}
         {hasStats && (
           <div class="stats-row ui-meta-row place-card-stats place-card-meta-stats">
-            {siteConfig.placeCard.showRating && ratingValue !== null && (
-              <span class="stat-pill ui-pill">{ratingFormatter.format(ratingValue)} ★</span>
-            )}
-            {siteConfig.placeCard.showReviewCount && reviewCount !== null && (
-              <span class="stat-pill ui-pill" title={`${reviewCountFormatter.format(reviewCount)} Google Maps reviews`}>
-                {compactReviewCountFormatter.format(reviewCount)} reviews
-              </span>
-            )}
+            <span class="stat-pill ui-pill place-card-rating-pill" title={placeRatingMetaTitle}>
+              {placeRatingMetaLabel}
+            </span>
           </div>
         )}
       </div>

--- a/src/components/PlaceCard.astro
+++ b/src/components/PlaceCard.astro
@@ -78,6 +78,7 @@ const badges = [
   ...(showTopPickBadge ? [{ className: "badge", label: siteConfig.placeCard.topPickLabel }] : []),
   ...(bestHit ? [{ className: "badge badge--best-hit", label: siteConfig.placeCard.bestHitLabel }] : []),
 ];
+const isTemporarilyClosed = siteConfig.placeCard.showStatus && place.status === "temporarily-closed";
 ---
 
 <article
@@ -96,6 +97,7 @@ const badges = [
   data-neighborhood={place.neighborhood ?? ""}
   data-neighborhood-token={neighborhoodToken}
   data-top-pick={place.top_pick ? "true" : "false"}
+  data-place-status={place.status}
   data-rating={ratingValue !== null ? String(ratingValue) : ""}
   data-rating-count={reviewCount !== null ? String(reviewCount) : ""}
   data-rank={String(place.manual_rank)}
@@ -140,19 +142,38 @@ const badges = [
     <div class="section-stack ui-stack place-card-heading">
       <div class="place-card-name-row">
         <h3 class="ui-card-title" title={place.name}>{place.name}</h3>
-        {siteConfig.placeCard.showMapLink && (
-          <a
-            class="place-card-map-link"
-            href={place.maps_url}
-            target="_blank"
-            rel="noreferrer"
-            aria-label={`Open ${place.name} in Google Maps`}
-            title={`Open ${place.name} in Google Maps`}
-          >
-            <img src="/icons/google-maps.svg" alt="" width="18" height="26" loading="lazy" decoding="async" />
-            <span class="place-card-map-link-label" aria-hidden="true">{siteConfig.placeCard.mapsLabel}</span>
-          </a>
-        )}
+        <div class="place-card-title-actions">
+          {isTemporarilyClosed && (
+            <span
+              class="place-card-status-indicator"
+              tabindex="0"
+              role="img"
+              aria-label="Temporarily closed. Check Google Maps before visiting."
+              title="Temporarily closed · check before visiting"
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M12 3.2a8.8 8.8 0 1 1 0 17.6 8.8 8.8 0 0 1 0-17.6Zm0 2a6.8 6.8 0 1 0 0 13.6 6.8 6.8 0 0 0 0-13.6Zm.9 2.6v4l2.9 1.7-1 1.7-3.9-2.3V7.8h2Z"
+                />
+              </svg>
+              <span class="place-card-status-tooltip" aria-hidden="true">Temporarily closed · check before visiting</span>
+            </span>
+          )}
+          {siteConfig.placeCard.showMapLink && (
+            <a
+              class="place-card-map-link"
+              href={place.maps_url}
+              target="_blank"
+              rel="noreferrer"
+              aria-label={`Open ${place.name} in Google Maps`}
+              title={`Open ${place.name} in Google Maps`}
+            >
+              <img src="/icons/google-maps.svg" alt="" width="18" height="26" loading="lazy" decoding="async" />
+              <span class="place-card-map-link-label" aria-hidden="true">{siteConfig.placeCard.mapsLabel}</span>
+            </a>
+          )}
+        </div>
       </div>
       <div class="place-card-meta-row">
         <span
@@ -208,7 +229,7 @@ const badges = [
     </div>
   )}
 
-  {siteConfig.placeCard.showStatus && place.status !== "active" && (
+  {siteConfig.placeCard.showStatus && place.status !== "active" && !isTemporarilyClosed && (
     <div class="place-card-footer ui-card-footer">
       <span class="stat-pill ui-pill">{place.status}</span>
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -364,6 +364,13 @@
     gap: 0.65rem;
   }
 
+  .home-map-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
   .search-view-toggle-group {
     display: inline-flex;
     align-items: center;
@@ -970,6 +977,21 @@
     gap: 0.55rem;
   }
 
+  .place-card-rating-pill {
+    width: max-content;
+    max-width: 100%;
+    min-height: 1.35rem;
+    padding: 0 0.5rem;
+    border-color: rgba(185, 71, 54, 0.18);
+    background: color-mix(in srgb, var(--surface) 90%, var(--accent) 10%);
+    color: var(--ink);
+    font-size: 0.72rem;
+    font-weight: 900;
+    letter-spacing: 0.01em;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
   .place-card[data-has-photo="false"] .place-card-stats,
   .place-card[data-has-photo="false"] .tag-row {
     gap: 0.45rem;
@@ -1292,12 +1314,17 @@
   }
 
   .map-feedback-slot {
-    min-height: 2rem;
+    position: absolute;
+    top: 3.35rem;
+    left: 0.85rem;
+    right: 0.85rem;
+    z-index: 500;
+    min-height: 0;
     display: flex;
     justify-content: flex-end;
     align-items: flex-start;
-    margin-top: 0.45rem;
-    margin-bottom: 0.45rem;
+    margin: 0;
+    pointer-events: none;
   }
 
   .map-location-status {
@@ -1578,11 +1605,7 @@
   }
 
   .map-toolbar {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 0.75rem;
+    display: contents;
   }
 
   .map-stage {
@@ -1604,13 +1627,17 @@
   }
 
   .map-actions {
+    position: absolute;
+    top: 0.85rem;
+    right: 0.85rem;
+    z-index: 500;
     display: flex;
     flex-wrap: wrap;
-    flex: 1 1 14rem;
+    flex: 0 1 auto;
     justify-content: flex-end;
     gap: 0.45rem;
-    max-width: none;
-    margin-left: auto;
+    max-width: calc(100% - 9.25rem);
+    margin-left: 0;
   }
 
   .map-control-button {
@@ -1713,8 +1740,10 @@
   }
 
   .map-toggle {
-    position: static;
-    z-index: 1;
+    position: absolute;
+    top: 0.85rem;
+    left: 0.85rem;
+    z-index: 500;
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
@@ -1745,19 +1774,24 @@
   }
 
   .map-toggle-icon {
+    position: relative;
+    left: 0;
     width: 0.72rem;
     height: 0.72rem;
     border-top: 2.5px solid currentcolor;
     border-right: 2.5px solid currentcolor;
+    transform-origin: center;
     transform: translateY(0.12rem) rotate(-45deg);
     transition: transform 160ms ease;
   }
 
   .map-panel[data-collapsed="true"] {
-    border-color: transparent;
+    overflow: visible;
+    border: 0;
     border-radius: 0;
     background: transparent;
-    padding-block: 0.55rem;
+    box-shadow: none;
+    padding: 0;
     min-height: 0;
   }
 
@@ -1770,6 +1804,7 @@
   }
 
   .map-panel[data-collapsed="true"] .map-toggle {
+    position: static;
     justify-self: start;
   }
 
@@ -1801,26 +1836,190 @@
   }
 
   .guide-map .leaflet-popup-content-wrapper {
+    overflow: hidden;
     border-radius: var(--radius-lg);
     background: var(--surface-strong);
     color: var(--ink);
+    box-shadow: 0 1.1rem 2.2rem rgba(31, 22, 15, 0.24);
   }
 
   .guide-map .leaflet-popup-content {
     display: grid;
-    gap: 0.25rem;
-    min-width: 11rem;
-    max-width: 13.25rem;
-    margin: 0.85rem 1rem;
+    gap: 0;
+    width: min(72vw, 18.75rem);
+    min-width: min(72vw, 13rem);
+    max-width: min(72vw, 18.75rem);
+    margin: 0.72rem;
     font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
   }
 
-  .guide-map-popup-content {
+  .guide-map .leaflet-popup-close-button {
+    position: absolute;
+    top: 0.55rem;
+    right: 0.55rem;
+    z-index: 4;
     display: grid;
-    gap: 0.45rem;
-    min-width: 11rem;
-    max-width: 13.25rem;
+    width: 1.6rem;
+    height: 1.6rem;
+    place-items: center;
+    border: 1px solid rgba(72, 55, 42, 0.16);
+    border-radius: 999px;
+    background: rgba(255, 253, 248, 0.92);
+    box-shadow: 0 0.45rem 1rem rgba(31, 22, 15, 0.16);
+    color: var(--ink);
+    overflow: hidden;
+    font-size: 0;
+    line-height: 0;
+  }
+
+  .guide-map .leaflet-popup-close-button:hover,
+  .guide-map .leaflet-popup-close-button:focus-visible {
+    background: var(--surface-strong);
+    color: var(--accent-strong);
+  }
+
+  .guide-map .leaflet-popup-close-button::before,
+  .guide-map .leaflet-popup-close-button::after,
+  .guide-map .gm-style-iw button[aria-label="Close"]::before,
+  .guide-map .gm-style-iw button[aria-label="Close"]::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 0.72rem;
+    height: 2px;
+    border-radius: 999px;
+    background: currentcolor;
+  }
+
+  .guide-map .leaflet-popup-close-button::before,
+  .guide-map .gm-style-iw button[aria-label="Close"]::before {
+    transform: translate(-50%, -50%) rotate(45deg);
+  }
+
+  .guide-map .leaflet-popup-close-button::after,
+  .guide-map .gm-style-iw button[aria-label="Close"]::after {
+    transform: translate(-50%, -50%) rotate(-45deg);
+  }
+
+  .guide-map .gm-style-iw-c {
+    padding: 0.72rem !important;
+    border-radius: var(--radius-lg) !important;
+    background: var(--surface-strong) !important;
+    color: var(--ink);
+    box-shadow: 0 1.1rem 2.2rem rgba(31, 22, 15, 0.24) !important;
+  }
+
+  .guide-map .gm-style-iw-c:has(.guide-map-popup-close) .gm-style-iw-chr,
+  .guide-map .gm-style-iw-c:has(.guide-map-popup-close) button[aria-label="Close"] {
+    display: none !important;
+  }
+
+  .guide-map .gm-style-iw-d {
+    overflow: visible !important;
+  }
+
+  .guide-map .gm-style-iw-chr {
+    position: absolute;
+    top: 0.55rem;
+    right: 0.55rem;
+    z-index: 4;
+    min-height: 0;
+    padding: 0;
+  }
+
+  .guide-map .gm-style-iw-ch {
+    display: none;
+  }
+
+  .guide-map .gm-style-iw button[aria-label="Close"] {
+    position: relative !important;
+    display: grid !important;
+    width: 1.6rem !important;
+    height: 1.6rem !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    place-items: center !important;
+    border: 1px solid rgba(72, 55, 42, 0.16) !important;
+    border-radius: 999px !important;
+    background: rgba(255, 253, 248, 0.92) !important;
+    box-shadow: 0 0.45rem 1rem rgba(31, 22, 15, 0.16) !important;
+    color: var(--ink) !important;
+    font-size: 0 !important;
+    line-height: 0 !important;
+    opacity: 1 !important;
+    overflow: hidden !important;
+  }
+
+  .guide-map .gm-style-iw button[aria-label="Close"] span {
+    display: none !important;
+  }
+
+  .guide-map .gm-style-iw button[aria-label="Close"]:hover,
+  .guide-map .gm-style-iw button[aria-label="Close"]:focus-visible {
+    background: var(--surface-strong) !important;
+  }
+
+  .guide-map-popup-content {
+    position: relative;
+    display: grid;
+    gap: 0;
+    width: min(72vw, 18.75rem);
+    min-width: min(72vw, 13rem);
+    max-width: min(72vw, 18.75rem);
     font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  }
+
+  .guide-map-popup-close {
+    position: absolute;
+    top: 0.28rem;
+    right: 0.28rem;
+    z-index: 5;
+    display: grid;
+    width: 1.6rem;
+    height: 1.6rem;
+    place-items: center;
+    border: 1px solid rgba(72, 55, 42, 0.16);
+    border-radius: 999px;
+    background: rgba(255, 253, 248, 0.94);
+    box-shadow: 0 0.45rem 1rem rgba(31, 22, 15, 0.16);
+    color: var(--ink);
+    cursor: pointer;
+  }
+
+  .guide-map-popup-close::before,
+  .guide-map-popup-close::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 0.76rem;
+    height: 2px;
+    border-radius: 999px;
+    background: currentcolor;
+  }
+
+  .guide-map-popup-close::before {
+    transform: translate(-50%, -50%) rotate(45deg);
+  }
+
+  .guide-map-popup-close::after {
+    transform: translate(-50%, -50%) rotate(-45deg);
+  }
+
+  .guide-map-popup-close:hover,
+  .guide-map-popup-close:focus-visible {
+    background: var(--surface-strong);
+    color: var(--accent-strong);
+  }
+
+  .guide-map-popup-place-card {
+    position: relative;
+    display: grid;
+    width: 100%;
+    min-width: 0;
+    gap: 0.58rem;
+    color: var(--ink);
   }
 
   .guide-map-popup-card-link {
@@ -1830,6 +2029,13 @@
   }
 
   .guide-map .leaflet-popup-content a.guide-map-popup-card-link {
+    margin-top: 0;
+    color: inherit;
+    font-weight: inherit;
+    text-decoration: none;
+  }
+
+  .guide-map-popup-content a.guide-map-popup-card-link {
     margin-top: 0;
     color: inherit;
     font-weight: inherit;
@@ -1848,14 +2054,14 @@
   }
 
   .guide-map-popup-photo {
+    width: 100%;
+    min-width: 0;
     overflow: hidden;
-    border-radius: calc(var(--radius-lg) - 0.3rem);
+    border-radius: calc(var(--radius-lg) - 0.35rem);
     aspect-ratio: 3 / 2;
     background:
       linear-gradient(135deg, rgba(185, 71, 54, 0.12), rgba(215, 156, 69, 0.16)),
       var(--surface-strong);
-    margin-bottom: 0.1rem;
-    max-height: 6.9rem;
   }
 
   .guide-map-popup-photo img {
@@ -1863,35 +2069,214 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+    object-position: center top;
+  }
+
+  .guide-map-popup-copy {
+    display: grid;
+    gap: 0.36rem;
+    min-width: 0;
+  }
+
+  .guide-map-popup-content:not(:has(.guide-map-popup-photo)) .guide-map-popup-copy {
+    padding-right: 1.85rem;
   }
 
   .guide-map .leaflet-popup-content strong {
-    font-size: 1.1rem;
+    font-size: clamp(1rem, 2.7vw, 1.12rem);
     font-weight: 900;
+    line-height: 1.12;
   }
 
   .guide-map-popup-content strong {
-    font-size: 1.1rem;
+    font-size: clamp(1rem, 2.7vw, 1.12rem);
     font-weight: 900;
+    line-height: 1.12;
   }
 
   .guide-map .leaflet-popup-content span {
     color: var(--muted);
+    font-size: 0.78rem;
+    line-height: 1.32;
   }
 
   .guide-map-popup-content span {
     color: var(--muted);
+    font-size: 0.78rem;
+    line-height: 1.32;
   }
 
-  .guide-map .leaflet-popup-content a {
-    margin-top: 0.35rem;
+  .guide-map-popup-content .guide-map-popup-rating {
+    display: inline-flex;
+    width: max-content;
+    max-width: 100%;
+    min-height: 1.32rem;
+    align-items: center;
+    padding: 0 0.46rem;
+    border: 1px solid rgba(185, 71, 54, 0.16);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--surface) 90%, var(--accent) 10%);
+    color: var(--ink);
+    font-size: 0.68rem;
+    font-weight: 900;
+    letter-spacing: 0.01em;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  .guide-map-popup-footer {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.45rem 0.55rem;
+    margin-top: 0.04rem;
+  }
+
+  .guide-map-popup-actions {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.35rem;
+    margin-left: auto;
+  }
+
+  .guide-map-popup-details-action,
+  .guide-map-popup-map-action {
+    min-height: 1.65rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(72, 55, 42, 0.16);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--surface) 92%, white);
+    box-shadow: 0 0.35rem 0.8rem rgba(31, 22, 15, 0.08);
+    color: var(--ink);
+    font: inherit;
+    font-size: 0.68rem;
+    font-weight: 900;
+    line-height: 1;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .guide-map-popup-details-action {
+    padding: 0 0.58rem;
+  }
+
+  .guide-map-popup-map-action {
+    width: 1.65rem;
+    padding: 0;
+    color: #18457a;
+  }
+
+  .guide-map-popup-details-action:hover,
+  .guide-map-popup-details-action:focus-visible,
+  .guide-map-popup-map-action:hover,
+  .guide-map-popup-map-action:focus-visible {
+    border-color: var(--accent);
+    background: var(--surface-strong);
+    color: var(--accent-strong);
+  }
+
+  .guide-map-popup-map-action img {
+    width: 0.72rem;
+    height: auto;
+  }
+
+  @media (min-width: 1280px) {
+    .guide-map-popup-details-action {
+      display: none;
+    }
+  }
+
+  @media (max-width: 979px) {
+    .guide-map .gm-style-iw-c {
+      padding: 0.56rem !important;
+    }
+
+    .guide-map .leaflet-popup-content,
+    .guide-map-popup-content {
+      width: min(78vw, 16rem);
+      min-width: min(78vw, 12rem);
+      max-width: min(78vw, 16rem);
+      margin: 0.56rem;
+    }
+
+    .guide-map-popup-close {
+      top: 0.2rem;
+      right: 0.2rem;
+      width: 1.48rem;
+      height: 1.48rem;
+    }
+
+    .guide-map-popup-place-card {
+      gap: 0.44rem;
+    }
+
+    .guide-map-popup-photo {
+      aspect-ratio: 16 / 9;
+    }
+
+    .guide-map-popup-copy {
+      gap: 0.26rem;
+    }
+
+    .guide-map .leaflet-popup-content strong,
+    .guide-map-popup-content strong {
+      font-size: 0.98rem;
+      line-height: 1.12;
+    }
+
+    .guide-map .leaflet-popup-content span,
+    .guide-map-popup-content span {
+      font-size: 0.74rem;
+      line-height: 1.26;
+    }
+
+    .guide-map-popup-content .guide-map-popup-rating {
+      min-height: 1.22rem;
+      padding: 0 0.42rem;
+      font-size: 0.64rem;
+    }
+
+    .guide-map-popup-footer {
+      gap: 0.34rem;
+      margin-top: 0.02rem;
+    }
+
+    .guide-map-popup-actions {
+      gap: 0.28rem;
+    }
+
+    .guide-map-popup-details-action,
+    .guide-map-popup-map-action {
+      min-height: 1.48rem;
+      font-size: 0.64rem;
+    }
+
+    .guide-map-popup-map-action {
+      width: 1.48rem;
+    }
+
+    .guide-map-popup-map-action img {
+      width: 0.66rem;
+    }
+  }
+
+  .guide-map
+    .leaflet-popup-content
+    a:not(.guide-map-popup-map-action):not(.guide-map-popup-card-link) {
+    margin-top: 0.12rem;
     color: var(--accent);
+    font-size: 0.83rem;
     font-weight: 700;
   }
 
-  .guide-map-popup-content a {
-    margin-top: 0.35rem;
+  .guide-map-popup-content a:not(.guide-map-popup-map-action):not(.guide-map-popup-card-link) {
+    margin-top: 0.12rem;
     color: var(--accent);
+    font-size: 0.83rem;
     font-weight: 700;
   }
 
@@ -2325,6 +2710,15 @@
       order: -1;
     }
 
+    .browse-layout > .map-panel:not([data-collapsed="true"]) {
+      gap: 0;
+      padding: 0;
+    }
+
+    .browse-layout > .map-panel:not([data-collapsed="true"]) .guide-map {
+      border-radius: calc(var(--radius-lg) - 1px);
+    }
+
     .card-grid[data-kind="places"],
     .top-picks-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2376,7 +2770,7 @@
     }
 
     .browse-layout[data-map-collapsed="true"] {
-      grid-template-columns: minmax(0, 1fr) 2.75rem;
+      grid-template-columns: minmax(0, 1fr);
     }
 
     .browse-layout > .map-panel {
@@ -2391,22 +2785,36 @@
     }
 
     .browse-layout > .map-panel[data-collapsed="true"] {
-      width: 2.75rem;
-      height: calc(100vh - 1rem);
-      min-height: 28rem;
+      position: fixed;
+      top: 50%;
+      right: 0;
+      z-index: 900;
+      width: auto;
+      height: auto;
+      min-height: 0;
       max-height: none;
+      pointer-events: none;
+      transform: translateY(-50%);
     }
 
     .browse-layout > .map-panel[data-collapsed="true"] .map-toggle {
-      top: 50%;
-      left: -1px;
+      position: static;
+      display: inline-flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 0;
       width: 2.25rem;
       height: 4.25rem;
       min-width: 0;
       padding: 0;
-      border-left: 0;
-      border-radius: 0 1rem 1rem 0;
-      transform: translateY(-50%);
+      border: 1px solid var(--line);
+      border-right: 0;
+      border-radius: 1rem 0 0 1rem;
+      background: var(--surface);
+      box-shadow: none;
+      pointer-events: auto;
+      transform: none;
     }
 
     .map-toggle-label {
@@ -2414,11 +2822,23 @@
     }
 
     .map-toggle-icon {
+      left: -0.11rem;
       transform: rotate(45deg);
     }
 
     .browse-layout > .map-panel[data-collapsed="true"] .map-toggle-icon {
+      left: 0.17rem;
+      width: 0.72rem;
+      height: 0.72rem;
       transform: rotate(225deg);
+    }
+
+    .browse-layout > .map-panel[data-collapsed="true"] .map-toggle-label {
+      display: none;
+    }
+
+    .browse-layout > .map-panel[data-collapsed="true"] .map-toggle-label::after {
+      content: none;
     }
 
     .guide-map {
@@ -2434,21 +2854,33 @@
     }
 
     .browse-layout[data-map-collapsed="true"] .card-grid[data-kind="places"] {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
 
   @media (min-width: 1480px) {
-    .card-grid[data-kind="places"] {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+    .browse-layout[data-map-collapsed="true"] .card-grid[data-kind="places"] {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
     }
   }
 }
 
 @media (max-width: 979px) {
   .map-panel {
+    --mobile-guide-map-height: clamp(22rem, 64svh, 34rem);
+
     gap: 0;
-    padding: 0.45rem;
+    padding: 0;
+  }
+
+  .map-panel:not([data-collapsed="true"]) .map-stage,
+  .map-panel:not([data-collapsed="true"]) .guide-map {
+    min-height: var(--mobile-guide-map-height);
+  }
+
+  .map-panel:not([data-collapsed="true"]) .guide-map {
+    height: var(--mobile-guide-map-height);
+    border-radius: calc(var(--radius-lg) - 1px);
   }
 
   .map-toolbar {
@@ -2518,7 +2950,7 @@
   }
 
   .map-panel[data-collapsed="true"] {
-    padding: 0.55rem 0;
+    padding: 0;
   }
 
   .map-panel[data-collapsed="true"] .map-toggle {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -857,6 +857,7 @@
   }
 
   .place-card {
+    position: relative;
     overflow: hidden;
     padding: 1rem;
     display: grid;
@@ -881,6 +882,28 @@
     border-color: color-mix(in srgb, var(--accent) 42%, var(--line));
   }
 
+  .place-card[data-place-status="temporarily-closed"] {
+    border-color: color-mix(in srgb, var(--accent) 46%, var(--line));
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--accent-soft) 38%, var(--surface)),
+      var(--surface)
+    );
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 12%, transparent);
+  }
+
+  .place-card[data-place-status="temporarily-closed"]::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 0.42rem;
+    background: color-mix(in srgb, var(--accent) 58%, var(--accent-soft));
+    pointer-events: none;
+    transition:
+      background-color 160ms ease,
+      width 160ms ease;
+  }
+
   .place-card:hover,
   .place-card:focus-visible,
   .place-card[data-map-active="true"] {
@@ -902,6 +925,36 @@
 
   .place-card[data-map-active="true"] {
     box-shadow: inset 0 0 0 1px var(--accent);
+  }
+
+  .place-card[data-place-status="temporarily-closed"]:hover,
+  .place-card[data-place-status="temporarily-closed"]:focus-visible,
+  .place-card[data-place-status="temporarily-closed"][data-map-active="true"] {
+    border-color: color-mix(in srgb, var(--accent) 72%, var(--line));
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--accent-soft) 58%, var(--surface)),
+      color-mix(in srgb, var(--surface) 88%, var(--accent-soft))
+    );
+    box-shadow:
+      inset 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent),
+      0 18px 42px rgba(31, 37, 34, 0.13);
+  }
+
+  .place-card[data-place-status="temporarily-closed"]:hover::before,
+  .place-card[data-place-status="temporarily-closed"]:focus-visible::before,
+  .place-card[data-place-status="temporarily-closed"][data-map-active="true"]::before {
+    width: 0.48rem;
+    background: color-mix(in srgb, var(--accent) 72%, var(--accent-soft));
+  }
+
+  .place-card[data-place-status="temporarily-closed"]:hover .place-card-status-indicator,
+  .place-card[data-place-status="temporarily-closed"]:focus-visible .place-card-status-indicator,
+  .place-card[data-place-status="temporarily-closed"][data-map-active="true"]
+    .place-card-status-indicator {
+    border-color: color-mix(in srgb, var(--accent) 58%, var(--line));
+    background: color-mix(in srgb, var(--accent-soft) 86%, var(--surface));
+    box-shadow: 0 12px 28px rgba(185, 71, 54, 0.18);
   }
 
   .place-card-photo {
@@ -1028,6 +1081,82 @@
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: flex-start;
     gap: 0.5rem;
+  }
+
+  .place-card-title-actions {
+    display: inline-flex;
+    align-items: flex-start;
+    gap: 0.42rem;
+  }
+
+  .place-card-status-indicator {
+    position: relative;
+    width: 2.3rem;
+    min-height: 2.3rem;
+    display: inline-grid;
+    place-items: center;
+    flex: 0 0 auto;
+    border: 1px solid color-mix(in srgb, var(--accent) 34%, var(--line));
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--accent-soft) 72%, var(--surface));
+    color: var(--accent-strong);
+    box-shadow: 0 10px 24px rgba(39, 47, 56, 0.1);
+    cursor: help;
+  }
+
+  .place-card-status-indicator::after {
+    content: "";
+    position: absolute;
+    right: 0.34rem;
+    top: 0.34rem;
+    width: 0.45rem;
+    height: 0.45rem;
+    border: 2px solid var(--surface);
+    border-radius: 999px;
+    background: var(--accent);
+  }
+
+  .place-card-status-indicator svg {
+    width: 0.95rem;
+    height: 0.95rem;
+    display: block;
+  }
+
+  .place-card-status-tooltip {
+    position: absolute;
+    z-index: 3;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    width: max-content;
+    max-width: min(15rem, 72vw);
+    padding: 0.48rem 0.62rem;
+    border: 1px solid color-mix(in srgb, var(--accent) 32%, var(--line));
+    border-radius: 0.7rem;
+    background: color-mix(in srgb, var(--surface) 92%, white);
+    color: var(--ink);
+    box-shadow: 0 16px 34px rgba(31, 37, 34, 0.16);
+    font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 0.76rem;
+    font-weight: 800;
+    letter-spacing: 0.01em;
+    line-height: 1.2;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-0.2rem);
+    transition:
+      opacity 160ms ease,
+      transform 160ms ease;
+  }
+
+  .place-card-status-indicator:hover .place-card-status-tooltip,
+  .place-card-status-indicator:focus-visible .place-card-status-tooltip {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .place-card-status-indicator:focus-visible {
+    outline: 3px solid var(--accent);
+    outline-offset: 3px;
   }
 
   .place-card-name-row h3 {
@@ -2884,7 +3013,7 @@
     }
   }
 
-  @media (min-width: 980px) and (max-width: 1279px) {
+  @media (min-width: 720px) and (max-width: 1279px) {
     .hero-grid {
       grid-template-columns: minmax(0, 1fr);
       gap: 0.85rem;
@@ -2893,23 +3022,22 @@
     .hero-grid > .section-stack:last-child {
       align-self: start;
       justify-self: start;
-      width: min(100%, 48rem);
+      width: min(100%, 34rem);
       margin-top: 0;
     }
 
     .hero-grid > .section-stack:last-child .social-card {
       width: 100%;
-      grid-template-columns: minmax(11rem, 1fr) auto;
-      align-items: center;
-      padding: 0.62rem;
-      gap: 0.55rem;
-      border-radius: var(--radius-md);
+      grid-template-columns: minmax(0, 1fr);
+      align-items: stretch;
+      padding: 0.82rem;
+      gap: 0.62rem;
     }
 
     .hero-grid > .section-stack:last-child .social-card-copy {
-      max-width: 24rem;
-      font-size: 0.78rem;
-      line-height: 1.28;
+      max-width: none;
+      font-size: 0.95rem;
+      line-height: 1.4;
     }
 
     .hero-grid > .section-stack:last-child .social-card-link {
@@ -2919,8 +3047,8 @@
     }
 
     .hero-grid > .section-stack:last-child .social-card-grid {
-      grid-template-columns: repeat(3, minmax(2.35rem, 1fr));
-      gap: 0.38rem;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 0.45rem;
     }
 
     .hero-grid > .section-stack:last-child .social-card-grid .social-card-link {
@@ -2929,65 +3057,16 @@
     }
 
     .hero-grid > .section-stack:last-child .social-card-grid .social-card-link-copy {
-      display: none;
+      display: grid;
     }
 
     .hero-grid > .section-stack:last-child .social-card-icon {
-      width: 1.55rem;
-      height: 1.55rem;
+      width: 1.65rem;
+      height: 1.65rem;
     }
 
     .hero-grid > .section-stack:last-child .social-card-link-primary {
-      min-width: 8.75rem;
-    }
-  }
-
-  @media (min-width: 1280px) and (max-width: 1439px) {
-    .hero-grid {
-      grid-template-columns: minmax(0, 1.45fr) minmax(18rem, 0.55fr);
-      align-items: start;
-    }
-
-    .hero-grid > .section-stack:last-child {
-      align-self: start;
-      justify-self: end;
-      width: min(100%, 22rem);
-      margin-top: clamp(3.75rem, 5vw, 5.25rem);
-    }
-
-    .hero-grid > .section-stack:last-child .social-card {
-      width: 100%;
-      padding: 0.75rem;
-      gap: 0.55rem;
-    }
-
-    .hero-grid > .section-stack:last-child .social-card-copy {
-      font-size: 0.84rem;
-      line-height: 1.34;
-    }
-
-    .hero-grid > .section-stack:last-child .social-card-link {
-      min-height: 2.35rem;
-      padding: 0.46rem 0.55rem;
-      gap: 0.4rem;
-    }
-
-    .hero-grid > .section-stack:last-child .social-card-grid {
-      gap: 0.4rem;
-    }
-
-    .hero-grid > .section-stack:last-child .social-card-grid .social-card-link {
-      justify-content: center;
-      padding-inline: 0.45rem;
-    }
-
-    .hero-grid > .section-stack:last-child .social-card-grid .social-card-link-copy {
-      display: none;
-    }
-
-    .hero-grid > .section-stack:last-child .social-card-icon {
-      width: 1.5rem;
-      height: 1.5rem;
+      min-width: 0;
     }
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2754,7 +2754,6 @@
   @media (min-width: 1280px) {
     .hero-grid {
       grid-template-columns: minmax(0, 1.7fr) minmax(280px, 0.8fr);
-      align-items: start;
     }
 
     .map-toolbar {
@@ -2885,7 +2884,7 @@
     }
   }
 
-  @media (min-width: 1280px) and (max-width: 1599px) {
+  @media (min-width: 980px) and (max-width: 1279px) {
     .hero-grid {
       grid-template-columns: minmax(0, 1fr);
       gap: 0.85rem;
@@ -2940,6 +2939,55 @@
 
     .hero-grid > .section-stack:last-child .social-card-link-primary {
       min-width: 8.75rem;
+    }
+  }
+
+  @media (min-width: 1280px) and (max-width: 1439px) {
+    .hero-grid {
+      grid-template-columns: minmax(0, 1.45fr) minmax(18rem, 0.55fr);
+      align-items: start;
+    }
+
+    .hero-grid > .section-stack:last-child {
+      align-self: start;
+      justify-self: end;
+      width: min(100%, 22rem);
+      margin-top: clamp(3.75rem, 5vw, 5.25rem);
+    }
+
+    .hero-grid > .section-stack:last-child .social-card {
+      width: 100%;
+      padding: 0.75rem;
+      gap: 0.55rem;
+    }
+
+    .hero-grid > .section-stack:last-child .social-card-copy {
+      font-size: 0.84rem;
+      line-height: 1.34;
+    }
+
+    .hero-grid > .section-stack:last-child .social-card-link {
+      min-height: 2.35rem;
+      padding: 0.46rem 0.55rem;
+      gap: 0.4rem;
+    }
+
+    .hero-grid > .section-stack:last-child .social-card-grid {
+      gap: 0.4rem;
+    }
+
+    .hero-grid > .section-stack:last-child .social-card-grid .social-card-link {
+      justify-content: center;
+      padding-inline: 0.45rem;
+    }
+
+    .hero-grid > .section-stack:last-child .social-card-grid .social-card-link-copy {
+      display: none;
+    }
+
+    .hero-grid > .section-stack:last-child .social-card-icon {
+      width: 1.5rem;
+      height: 1.5rem;
     }
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1967,6 +1967,7 @@
     width: min(72vw, 18.75rem);
     min-width: min(72vw, 13rem);
     max-width: min(72vw, 18.75rem);
+    max-height: min(68svh, 24rem);
     font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
   }
 
@@ -2056,6 +2057,7 @@
   .guide-map-popup-photo {
     width: 100%;
     min-width: 0;
+    max-height: 9.25rem;
     overflow: hidden;
     border-radius: calc(var(--radius-lg) - 0.35rem);
     aspect-ratio: 3 / 2;
@@ -2190,17 +2192,32 @@
     }
   }
 
-  @media (max-width: 979px) {
+  @media (max-width: 1279px) {
     .guide-map .gm-style-iw-c {
-      padding: 0.56rem !important;
+      padding: 0.52rem !important;
+    }
+
+    .guide-map .gm-style-iw-d {
+      max-height: min(54svh, 16rem) !important;
+      overflow-y: auto !important;
     }
 
     .guide-map .leaflet-popup-content,
     .guide-map-popup-content {
-      width: min(78vw, 16rem);
-      min-width: min(78vw, 12rem);
-      max-width: min(78vw, 16rem);
-      margin: 0.56rem;
+      width: min(74vw, 15.5rem);
+      min-width: min(74vw, 11.5rem);
+      max-width: min(74vw, 15.5rem);
+      margin: 0.52rem;
+    }
+
+    .guide-map .leaflet-popup-content {
+      max-height: min(56svh, 17rem);
+    }
+
+    .guide-map-popup-content {
+      max-height: min(54svh, 16rem);
+      overflow-y: auto;
+      scrollbar-width: thin;
     }
 
     .guide-map-popup-close {
@@ -2211,37 +2228,39 @@
     }
 
     .guide-map-popup-place-card {
-      gap: 0.44rem;
+      gap: 0.36rem;
     }
 
     .guide-map-popup-photo {
-      aspect-ratio: 16 / 9;
+      height: clamp(4.75rem, 16svh, 6rem);
+      max-height: 6rem;
+      aspect-ratio: auto;
     }
 
     .guide-map-popup-copy {
-      gap: 0.26rem;
+      gap: 0.22rem;
     }
 
     .guide-map .leaflet-popup-content strong,
     .guide-map-popup-content strong {
-      font-size: 0.98rem;
+      font-size: 0.9rem;
       line-height: 1.12;
     }
 
     .guide-map .leaflet-popup-content span,
     .guide-map-popup-content span {
-      font-size: 0.74rem;
+      font-size: 0.69rem;
       line-height: 1.26;
     }
 
     .guide-map-popup-content .guide-map-popup-rating {
-      min-height: 1.22rem;
-      padding: 0 0.42rem;
-      font-size: 0.64rem;
+      min-height: 1.16rem;
+      padding: 0 0.38rem;
+      font-size: 0.6rem;
     }
 
     .guide-map-popup-footer {
-      gap: 0.34rem;
+      gap: 0.28rem;
       margin-top: 0.02rem;
     }
 
@@ -2251,12 +2270,12 @@
 
     .guide-map-popup-details-action,
     .guide-map-popup-map-action {
-      min-height: 1.48rem;
-      font-size: 0.64rem;
+      min-height: 1.38rem;
+      font-size: 0.6rem;
     }
 
     .guide-map-popup-map-action {
-      width: 1.48rem;
+      width: 1.38rem;
     }
 
     .guide-map-popup-map-action img {
@@ -2427,6 +2446,13 @@
       border-radius: var(--radius-lg);
       background: color-mix(in srgb, var(--surface-strong) 56%, var(--surface));
       box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+    }
+
+    .hero-grid > .section-stack:last-child:has(.social-card) {
+      padding: 0;
+      border: 0;
+      background: transparent;
+      box-shadow: none;
     }
 
     .card-grid {
@@ -2728,6 +2754,7 @@
   @media (min-width: 1280px) {
     .hero-grid {
       grid-template-columns: minmax(0, 1.7fr) minmax(280px, 0.8fr);
+      align-items: start;
     }
 
     .map-toolbar {
@@ -2855,6 +2882,64 @@
 
     .browse-layout[data-map-collapsed="true"] .card-grid[data-kind="places"] {
       grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  @media (min-width: 1280px) and (max-width: 1599px) {
+    .hero-grid {
+      grid-template-columns: minmax(0, 1fr);
+      gap: 0.85rem;
+    }
+
+    .hero-grid > .section-stack:last-child {
+      align-self: start;
+      justify-self: start;
+      width: min(100%, 48rem);
+      margin-top: 0;
+    }
+
+    .hero-grid > .section-stack:last-child .social-card {
+      width: 100%;
+      grid-template-columns: minmax(11rem, 1fr) auto;
+      align-items: center;
+      padding: 0.62rem;
+      gap: 0.55rem;
+      border-radius: var(--radius-md);
+    }
+
+    .hero-grid > .section-stack:last-child .social-card-copy {
+      max-width: 24rem;
+      font-size: 0.78rem;
+      line-height: 1.28;
+    }
+
+    .hero-grid > .section-stack:last-child .social-card-link {
+      min-height: 2.35rem;
+      padding: 0.45rem 0.55rem;
+      gap: 0.38rem;
+    }
+
+    .hero-grid > .section-stack:last-child .social-card-grid {
+      grid-template-columns: repeat(3, minmax(2.35rem, 1fr));
+      gap: 0.38rem;
+    }
+
+    .hero-grid > .section-stack:last-child .social-card-grid .social-card-link {
+      justify-content: center;
+      padding-inline: 0.5rem;
+    }
+
+    .hero-grid > .section-stack:last-child .social-card-grid .social-card-link-copy {
+      display: none;
+    }
+
+    .hero-grid > .section-stack:last-child .social-card-icon {
+      width: 1.55rem;
+      height: 1.55rem;
+    }
+
+    .hero-grid > .section-stack:last-child .social-card-link-primary {
+      min-width: 8.75rem;
     }
   }
 

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -37,9 +37,16 @@ describe("guide map interactions", () => {
     expect(guideMap).toContain('<span class="map-toggle-label">Hide map</span>');
     expectCssToContain(css, ".map-toolbar");
     expect(cssBlocks(css, ".map-panel").join("\n")).toContain("position: relative");
-    expect(cssBlocks(css, ".map-actions").join("\n")).toContain("margin-left: auto");
+    expect(cssBlocks(css, ".map-actions").join("\n")).toContain("margin-left: 0");
     expectCssToContain(css, "@media (max-width: 979px)");
-    expectCssToContain(css, ".map-panel {\n    gap: 0;\n    padding: 0.45rem;");
+    expectCssToContain(
+      css,
+      ".map-panel {\n    --mobile-guide-map-height: clamp(22rem, 64svh, 34rem);",
+    );
+    expectCssToContain(
+      css,
+      ".map-panel {\n    --mobile-guide-map-height: clamp(22rem, 64svh, 34rem);\n\n    gap: 0;\n    padding: 0;",
+    );
     expectCssToContain(css, ".map-toolbar {\n    display: contents;");
     expectCssToContain(css, ".map-toggle {\n    position: absolute;\n    top: 0.85rem;");
     expectCssToContain(
@@ -49,6 +56,63 @@ describe("guide map interactions", () => {
     expectCssToContain(css, ".map-feedback-slot {\n    position: absolute;\n    top: 3.35rem;");
     expectCssToContain(css, ".guide-map {\n  width: 100%;\n  min-height: 16rem;");
     expectCssToContain(css, ".map-panel {\n    order: 0;\n    position: sticky;\n    top: 0.5rem;");
+  });
+
+  it("keeps place map popups compact, closeable, and informative", () => {
+    const guideMap = readSource("src/components/GuideMap.astro");
+    const css = readSource("src/styles/global.css");
+
+    expect(guideMap).toContain("rating: place.rating");
+    expect(guideMap).toContain("userRatingCount: place.user_rating_count");
+    expect(guideMap).toContain("const popupCompactReviewFormatter = new Intl.NumberFormat");
+    expect(guideMap).toContain('class="guide-map-popup-place-card"');
+    expect(guideMap).toContain('class="guide-map-popup-rating"');
+    expect(guideMap).toContain('class="guide-map-popup-map-action"');
+    expect(guideMap).toContain('class="guide-map-popup-details-action"');
+    expect(guideMap).toContain("data-guide-map-popup-close");
+    expect(guideMap).toContain("data-guide-map-popup-details");
+    expect(guideMap).not.toContain(">Open in Google Maps<");
+    expect(guideMap).not.toContain("<span>Maps</span>");
+    expect(guideMap).toContain("closeButton: false");
+    expect(guideMap).toContain("headerDisabled: true");
+    expect(guideMap).toContain('target?.closest("[data-guide-map-popup-close]")');
+    expect(guideMap).toContain('target?.closest<HTMLElement>("[data-guide-map-popup-details]")');
+    expectCssToContain(css, ".guide-map-popup-close");
+    expectCssToContain(
+      css,
+      ".guide-map .gm-style-iw-c:has(.guide-map-popup-close) .gm-style-iw-chr",
+    );
+    expectCssToContain(css, ".guide-map-popup-place-card");
+    expectCssToContain(css, ".guide-map-popup-map-action");
+    expectCssToContain(css, ".guide-map-popup-details-action");
+    expectCssToContain(css, "@media (min-width: 1280px)");
+    expectCssToContain(css, "@media (max-width: 979px)");
+    expectCssToContain(css, "width: min(78vw, 16rem);");
+    expectCssToContain(css, ".guide-map-popup-copy");
+    expectCssToContain(css, ".guide-map-popup-photo img");
+    expect(cssBlocks(css, ".guide-map-popup-photo img").join("\n")).toContain(
+      "object-position: center top",
+    );
+    expectCssToContain(css, ".guide-map-popup-content .guide-map-popup-rating");
+    expectCssToContain(css, "font-size: 0.68rem;");
+    expectCssToContain(css, "white-space: nowrap;");
+  });
+
+  it("focuses the full place card when a map marker is selected", () => {
+    const guideMap = readSource("src/components/GuideMap.astro");
+
+    expect(guideMap).toContain(
+      "const shouldAutoFocusCardFromMarker = () => window.matchMedia(SIDE_BY_SIDE_MAP_MEDIA_QUERY)",
+    );
+    expect(guideMap).toContain(
+      "selectPlace(placeId, { focusCard: shouldAutoFocusCardFromMarker() })",
+    );
+    expect(guideMap).toContain("const focusPlaceCard = (placeId: string) => {");
+    expect(guideMap).toContain("card.focus({ preventScroll: true });");
+    expect(guideMap).toContain(
+      'card.scrollIntoView({ behavior: "smooth", block: "center", inline: "nearest" });',
+    );
+    expect(guideMap).toContain("selectPlace(placeId, { expandCollapsed: true });");
   });
 
   it("tightens the mobile guide chrome to save vertical space", () => {
@@ -115,8 +179,10 @@ describe("guide map interactions", () => {
     const placeCard = readSource("src/components/PlaceCard.astro");
     const css = readSource("src/styles/global.css");
 
-    expect(placeCard).toContain("(siteConfig.placeCard.showRating && ratingValue !== null)");
-    expect(placeCard).toContain("(siteConfig.placeCard.showReviewCount && reviewCount !== null)");
+    expect(placeCard).toContain("const placeRatingMetaLabel = [");
+    expect(placeCard).toContain("siteConfig.placeCard.showRating && ratingValue !== null");
+    expect(placeCard).toContain("siteConfig.placeCard.showReviewCount ? compactReviewLabel : null");
+    expect(placeCard).toContain('class="stat-pill ui-pill place-card-rating-pill"');
     expect(placeCard).toContain('class="place-card-meta-row"');
     expect(placeCard).toContain(
       'class="stats-row ui-meta-row place-card-stats place-card-meta-stats"',
@@ -125,6 +191,7 @@ describe("guide map interactions", () => {
     expect(placeCard).not.toContain("{!hasPhoto && hasStats && (");
     expectCssToContain(css, ".place-card-meta-row");
     expectCssToContain(css, ".place-card-meta-stats");
+    expectCssToContain(css, ".place-card-rating-pill");
     expectCssToContain(css, "container-type: inline-size;");
     expectCssToContain(css, "@container (min-width: 26rem)");
   });
@@ -151,8 +218,11 @@ describe("guide map interactions", () => {
     expect(guideMap).toContain('panel.closest<HTMLElement>("[data-browse-layout]")');
     expect(guideMap).toContain("layout.dataset.mapCollapsed");
     expectCssToContain(css, '.browse-layout[data-map-collapsed="true"]');
-    expectCssToContain(css, "grid-template-columns: minmax(0, 1fr) 2.75rem");
+    expectCssToContain(css, "grid-template-columns: minmax(0, 1fr);");
     expectCssToContain(css, ".browse-layout > .map-panel {\n    order: 0;\n    position: sticky;");
+    expectCssToContain(css, '.browse-layout > .map-panel[data-collapsed="true"]');
+    expectCssToContain(css, "position: fixed;");
+    expectCssToContain(css, "right: 0;");
     expectCssToContain(css, ".home-map-panel {\n  position: relative;\n  top: auto;");
     expectCssToContain(
       css,
@@ -361,8 +431,11 @@ describe("guide map interactions", () => {
     expect(guideMap).not.toContain("const LEAFLET_WORLD_BOUNDS = L.latLngBounds");
     expect(guideMap).not.toContain("maxBounds: LEAFLET_WORLD_BOUNDS");
     expect(guideMap).not.toContain("maxBoundsViscosity: 1");
-    expect(guideMap).not.toContain("restriction: {");
+    expect(guideMap).toContain("const guideFocusBounds = (places: MapPlace[]) => {");
+    expect(guideMap).toContain("map.setMaxBounds(leafletBoundsFromLiteral(restrictionBounds))");
+    expect(guideMap).toContain("restriction: {");
+    expect(guideMap).toContain("latLngBounds: restrictionBounds");
     expect(guideMap).not.toContain("latLngBounds: WORLD_MAP_BOUNDS");
-    expect(guideMap).not.toContain("strictBounds: true");
+    expect(guideMap).toContain("strictBounds: true");
   });
 });

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -146,10 +146,13 @@ describe("guide map interactions", () => {
     const css = readSource("src/styles/global.css");
 
     expectCssToContain(css, ".hero-grid > .section-stack:last-child:has(.social-card)");
-    expectCssToContain(css, "@media (min-width: 1280px) and (max-width: 1599px)");
+    expectCssToContain(css, "@media (min-width: 980px) and (max-width: 1279px)");
     expectCssToContain(css, "grid-template-columns: minmax(0, 1fr);");
     expectCssToContain(css, "grid-template-columns: minmax(11rem, 1fr) auto;");
     expectCssToContain(css, "margin-top: 0;");
+    expectCssToContain(css, "@media (min-width: 1280px) and (max-width: 1439px)");
+    expectCssToContain(css, "grid-template-columns: minmax(0, 1.45fr) minmax(18rem, 0.55fr);");
+    expectCssToContain(css, "margin-top: clamp(3.75rem, 5vw, 5.25rem);");
     expectCssToContain(
       css,
       ".hero-grid > .section-stack:last-child .social-card-grid .social-card-link-copy",

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -424,6 +424,35 @@ describe("guide map interactions", () => {
     expect(homeBrowser).toContain("No guides are close to you yet.");
   });
 
+  it("shows the home map reset control after the fitted view drifts", () => {
+    const homeMap = readSource("src/components/HomeGuideMap.astro");
+
+    expect(homeMap).toContain("data-home-map-reset");
+    expect(homeMap).toContain(
+      "const homeFocusViewToleranceKm = (bounds: LatLngBoundsLiteral | null) => {",
+    );
+    expect(homeMap).toContain(
+      "const distanceInKm = (fromLat: number, fromLng: number, toLat: number, toLng: number) => {",
+    );
+    expect(homeMap).toContain("let focusCenter: Coordinates | null = null;");
+    expect(homeMap).toContain("let focusZoom: number | null = null;");
+    expect(homeMap).toContain("let focusDistanceToleranceKm = homeFocusViewToleranceKm");
+    expect(homeMap).toContain("const captureFocusView = () => {");
+    expect(homeMap).toContain(
+      "distanceInKm(center.lat, center.lng, focusCenter.lat, focusCenter.lng)",
+    );
+    expect(homeMap).toContain(
+      "distanceInKm(currentCenter.lat, currentCenter.lng, focusCenter.lat, focusCenter.lng)",
+    );
+    expect(homeMap).toContain("Math.abs(zoom - focusZoom) > 0.75");
+    expect(homeMap).toContain("resetButton.hidden = !runtime?.isOutsideFocusBounds();");
+    expect(homeMap).toContain("runtime.onViewChanged(syncResetButton);");
+    expect(homeMap).toContain('resetButton?.addEventListener("click", () => {');
+    expect(homeMap).toContain("runtime?.resetView();");
+    expect(homeMap).toContain('map.addListener("idle", handler);');
+    expect(homeMap).not.toContain('map.addListener("bounds_changed", handler);');
+  });
+
   it("constrains map panning before the world scrolls into grey tile space", () => {
     const homeMap = readSource("src/components/HomeGuideMap.astro");
     const guideMap = readSource("src/components/GuideMap.astro");

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -86,8 +86,11 @@ describe("guide map interactions", () => {
     expectCssToContain(css, ".guide-map-popup-map-action");
     expectCssToContain(css, ".guide-map-popup-details-action");
     expectCssToContain(css, "@media (min-width: 1280px)");
-    expectCssToContain(css, "@media (max-width: 979px)");
-    expectCssToContain(css, "width: min(78vw, 16rem);");
+    expectCssToContain(css, "@media (max-width: 1279px)");
+    expectCssToContain(css, "width: min(74vw, 15.5rem);");
+    expectCssToContain(css, "max-height: min(54svh, 16rem);");
+    expectCssToContain(css, "overflow-y: auto;");
+    expectCssToContain(css, "height: clamp(4.75rem, 16svh, 6rem);");
     expectCssToContain(css, ".guide-map-popup-copy");
     expectCssToContain(css, ".guide-map-popup-photo img");
     expect(cssBlocks(css, ".guide-map-popup-photo img").join("\n")).toContain(
@@ -137,6 +140,20 @@ describe("guide map interactions", () => {
     expectCssToContain(css, ".social-card-copy {\n    font-size: 0.88rem;");
     expectCssToContain(css, ".social-card-link {\n    padding: 0.42rem 0.45rem;");
     expectCssToContain(css, ".social-card-icon {\n    width: 1.5rem;");
+  });
+
+  it("keeps the guide hero aside compact at intermediate desktop widths", () => {
+    const css = readSource("src/styles/global.css");
+
+    expectCssToContain(css, ".hero-grid > .section-stack:last-child:has(.social-card)");
+    expectCssToContain(css, "@media (min-width: 1280px) and (max-width: 1599px)");
+    expectCssToContain(css, "grid-template-columns: minmax(0, 1fr);");
+    expectCssToContain(css, "grid-template-columns: minmax(11rem, 1fr) auto;");
+    expectCssToContain(css, "margin-top: 0;");
+    expectCssToContain(
+      css,
+      ".hero-grid > .section-stack:last-child .social-card-grid .social-card-link-copy",
+    );
   });
 
   it("renders the Google Maps action as a compact icon button beside the place name", () => {

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -146,13 +146,13 @@ describe("guide map interactions", () => {
     const css = readSource("src/styles/global.css");
 
     expectCssToContain(css, ".hero-grid > .section-stack:last-child:has(.social-card)");
-    expectCssToContain(css, "@media (min-width: 980px) and (max-width: 1279px)");
+    expectCssToContain(css, "@media (min-width: 720px) and (max-width: 1279px)");
     expectCssToContain(css, "grid-template-columns: minmax(0, 1fr);");
-    expectCssToContain(css, "grid-template-columns: minmax(11rem, 1fr) auto;");
+    expectCssToContain(css, "width: min(100%, 34rem);");
+    expectCssToContain(css, "grid-template-columns: repeat(3, minmax(0, 1fr));");
     expectCssToContain(css, "margin-top: 0;");
-    expectCssToContain(css, "@media (min-width: 1280px) and (max-width: 1439px)");
-    expectCssToContain(css, "grid-template-columns: minmax(0, 1.45fr) minmax(18rem, 0.55fr);");
-    expectCssToContain(css, "margin-top: clamp(3.75rem, 5vw, 5.25rem);");
+    expectCssToContain(css, "font-size: 0.95rem;");
+    expect(css).not.toContain("@media (min-width: 1280px) and (max-width: 1439px)");
     expectCssToContain(
       css,
       ".hero-grid > .section-stack:last-child .social-card-grid .social-card-link-copy",


### PR DESCRIPTION
## Description
Polishes guide map and home map interactions, with compact place popups that include ratings/reviews, close affordances, mobile details behavior, and tighter responsive map controls. Carries the compact rating treatment onto place cards and adjusts guide hero/link-hub breakpoints so narrower layouts waste less vertical space without changing the full-width presentation. Adds frontend coverage for popup behavior, marker/card focus, responsive controls, and the guide hero aside breakpoint.

## Related Issue
N/A

## How Has This Been Tested?
- `bun run test:frontend`
- `bun run check`
- `bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map popups now display Google ratings and review counts.
  * Dynamic "Reset Map" button shows/hides based on current map view state.

* **Improvements**
  * Enhanced map view focus and bounds management.
  * Improved place card rating display formatting.
  * Better map panel state persistence across device breakpoints.
  * Refined responsive mobile and desktop layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->