### PR TITLE
Fix map popup actions and reset zoom caps

### DIFF
--- a/src/components/GuideCard.astro
+++ b/src/components/GuideCard.astro
@@ -100,7 +100,12 @@ const guideDisplayTitle = trimCountryFromTitle(guide.title);
   {siteConfig.guideCard.showPlaceCount && (
     <div class="guide-card-footer ui-card-footer">
       <div class="stats-row ui-meta-row">
-        {siteConfig.guideCard.showPlaceCount && <span class="stat-pill ui-pill">{guide.place_count} places</span>}
+        {siteConfig.guideCard.showPlaceCount && (
+          <span class="count-chip guide-card-place-count">
+            <strong>{guide.place_count}</strong>
+            <span>place{guide.place_count === 1 ? "" : "s"}</span>
+          </span>
+        )}
       </div>
     </div>
   )}

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -785,6 +785,7 @@ const mapPlaces = places
     mapElement: HTMLElement,
     places: MapPlace[],
     onSelectPlace: (placeId: string) => void,
+    onShowPlaceDetails: (placeId: string) => void,
   ): MapRuntime => {
     const placePhotosEnabled = mapElement.dataset.placePhotosEnabled === "true";
     const map = L.map(mapElement, {
@@ -839,16 +840,20 @@ const mapPlaces = places
     const bindLeafletPopupActions = (marker: L.Marker, place: MapPlace) => {
       marker.on("popupopen", (event: L.PopupEvent) => {
         const popupElement = event.popup.getElement();
-        popupElement?.querySelector<HTMLButtonElement>("[data-guide-map-popup-close]")?.addEventListener("click", () => {
-          map.closePopup();
-        });
-        popupElement
-          ?.querySelector<HTMLButtonElement>("[data-guide-map-popup-details]")
-          ?.addEventListener("click", (clickEvent) => {
+        const closeButton = popupElement?.querySelector<HTMLButtonElement>("[data-guide-map-popup-close]");
+        const detailsButton = popupElement?.querySelector<HTMLButtonElement>("[data-guide-map-popup-details]");
+        if (closeButton) {
+          closeButton.onclick = () => {
+            map.closePopup();
+          };
+        }
+        if (detailsButton) {
+          detailsButton.onclick = (clickEvent) => {
             clickEvent.preventDefault();
             clickEvent.stopPropagation();
-            onSelectPlace(place.id);
-          });
+            onShowPlaceDetails(place.id);
+          };
+        }
       });
     };
     places.forEach((place) => {
@@ -1282,6 +1287,7 @@ const mapPlaces = places
     const shouldAutoFocusCardFromMarker = () => window.matchMedia(SIDE_BY_SIDE_MAP_MEDIA_QUERY).matches;
     const handleMarkerSelect = (placeId: string) =>
       selectPlace(placeId, { focusCard: shouldAutoFocusCardFromMarker() });
+    const handlePopupDetailsSelect = (placeId: string) => selectPlace(placeId, { focusCard: true });
     let runtime: MapRuntime | null = null;
 
     const syncFullAreaButton = () => {
@@ -1361,9 +1367,9 @@ const mapPlaces = places
       runtime =
         requestedProvider === "google" && apiKey
           ? await initGoogleRuntime(mapElement, places, apiKey, handleMarkerSelect).catch(() =>
-              initLeafletRuntime(mapElement, places, handleMarkerSelect),
+              initLeafletRuntime(mapElement, places, handleMarkerSelect, handlePopupDetailsSelect),
             )
-          : initLeafletRuntime(mapElement, places, handleMarkerSelect);
+          : initLeafletRuntime(mapElement, places, handleMarkerSelect, handlePopupDetailsSelect);
 
       runtime.setVisiblePlaces(currentVisiblePlaceIds);
       mapElement.guideMap = runtime.rawMap;

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -836,9 +836,25 @@ const mapPlaces = places
       focusCenter = { lat: center.lat, lng: center.lng };
       focusZoom = map.getZoom();
     };
+    const bindLeafletPopupActions = (marker: L.Marker, place: MapPlace) => {
+      marker.on("popupopen", (event: L.PopupEvent) => {
+        const popupElement = event.popup.getElement();
+        popupElement?.querySelector<HTMLButtonElement>("[data-guide-map-popup-close]")?.addEventListener("click", () => {
+          map.closePopup();
+        });
+        popupElement
+          ?.querySelector<HTMLButtonElement>("[data-guide-map-popup-details]")
+          ?.addEventListener("click", (clickEvent) => {
+            clickEvent.preventDefault();
+            clickEvent.stopPropagation();
+            onSelectPlace(place.id);
+          });
+      });
+    };
     places.forEach((place) => {
       const marker = placeMarker(place, placePhotosEnabled).addTo(map);
       marker.on("click", () => onSelectPlace(place.id));
+      bindLeafletPopupActions(marker, place);
       markers.set(place.id, marker);
     });
 
@@ -1078,6 +1094,16 @@ const mapPlaces = places
         window.requestAnimationFrame(captureFocusView);
       });
     };
+    const capFittedZoomAndCapture = () => {
+      const idleListener = map.addListener("idle", () => {
+        idleListener.remove();
+        const zoom = map.getZoom();
+        if (zoom !== undefined && zoom > focusMaxResetZoom) {
+          map.setZoom(focusMaxResetZoom);
+        }
+        scheduleFocusViewCapture();
+      });
+    };
 
     return {
       rawMap: map,
@@ -1088,14 +1114,14 @@ const mapPlaces = places
         if (visiblePlaces.length === 1) {
           map.setCenter({ lat: visiblePlaces[0].lat, lng: visiblePlaces[0].lng });
           map.setZoom(14);
-          scheduleFocusViewCapture();
+          capFittedZoomAndCapture();
           return;
         }
 
         const bounds = new google.maps.LatLngBounds();
         visiblePlaces.forEach((place) => bounds.extend({ lat: place.lat, lng: place.lng }));
         map.fitBounds(bounds, 28);
-        scheduleFocusViewCapture();
+        capFittedZoomAndCapture();
       },
       getBoundsContains: (place) => map.getBounds()?.contains({ lat: place.lat, lng: place.lng }) ?? true,
       getCenter: () => {

--- a/src/components/HomeGuideMap.astro
+++ b/src/components/HomeGuideMap.astro
@@ -139,7 +139,7 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
         element: HTMLElement,
         options: Record<string, unknown>,
       ) => {
-        addListener: (eventName: string, handler: () => void) => void;
+        addListener: (eventName: string, handler: () => void) => { remove?: () => void } | undefined;
         fitBounds: (bounds: unknown, padding?: number | { top: number; right: number; bottom: number; left: number }) => void;
         getBounds: () => { intersects: (bounds: unknown) => boolean } | undefined;
         getCenter: () =>
@@ -647,13 +647,23 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
         window.requestAnimationFrame(captureFocusView);
       });
     };
+    const capFittedZoomAndCapture = () => {
+      const idleListener = map.addListener("idle", () => {
+        idleListener?.remove?.();
+        const zoom = map.getZoom();
+        if (zoom !== undefined && zoom > focusMaxResetZoom) {
+          map.setZoom(focusMaxResetZoom);
+        }
+        scheduleFocusViewCapture();
+      });
+    };
 
     return {
       fitGuides: (visibleGuides) => {
         focusGuides = visibleGuides;
         applyFocusBounds(visibleGuides);
         fitGoogleGuides(visibleGuides);
-        scheduleFocusViewCapture();
+        capFittedZoomAndCapture();
       },
       invalidateSize: () => {
         window.dispatchEvent(new Event("resize"));
@@ -690,7 +700,7 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
       resetView: () => {
         applyFocusBounds(focusGuides);
         fitGoogleGuides(focusGuides);
-        scheduleFocusViewCapture();
+        capFittedZoomAndCapture();
       },
       setVisibleGuides: (visibleGuideSlugs) => {
         markers.forEach((marker, guideSlug) => marker.setMap(visibleGuideSlugs.has(guideSlug) ? map : null));

--- a/src/components/HomeGuideMap.astro
+++ b/src/components/HomeGuideMap.astro
@@ -700,6 +700,7 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
       },
       resetView: () => {
         applyFocusBounds(focusGuides);
+        if (focusGuides.length === 0) return;
         fitGoogleGuides(focusGuides);
         capFittedZoomAndCapture();
       },

--- a/src/components/HomeGuideMap.astro
+++ b/src/components/HomeGuideMap.astro
@@ -139,7 +139,7 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
         element: HTMLElement,
         options: Record<string, unknown>,
       ) => {
-        addListener: (eventName: string, handler: () => void) => { remove?: () => void } | undefined;
+        addListener: (eventName: string, handler: () => void) => { remove: () => void };
         fitBounds: (bounds: unknown, padding?: number | { top: number; right: number; bottom: number; left: number }) => void;
         getBounds: () => { intersects: (bounds: unknown) => boolean } | undefined;
         getCenter: () =>
@@ -649,7 +649,7 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
     };
     const capFittedZoomAndCapture = () => {
       const idleListener = map.addListener("idle", () => {
-        idleListener?.remove?.();
+        idleListener.remove();
         const zoom = map.getZoom();
         if (zoom !== undefined && zoom > focusMaxResetZoom) {
           map.setZoom(focusMaxResetZoom);
@@ -662,6 +662,7 @@ const mapGuides = guides.filter((guide) => Number.isFinite(guide.lat) && Number.
       fitGuides: (visibleGuides) => {
         focusGuides = visibleGuides;
         applyFocusBounds(visibleGuides);
+        if (visibleGuides.length === 0) return;
         fitGoogleGuides(visibleGuides);
         capFittedZoomAndCapture();
       },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -346,15 +346,15 @@ const homeJsonLd = [
 
     {guidesByCountry.map(({ countryName, countryGuides, countryFlag }) => (
       <div class="country-block ui-country-block" data-country-block data-country={countryName.toLowerCase()}>
-        <SectionHeading
-          title={countryFlag ? `${countryName} ${countryFlag}` : countryName}
-          level={3}
-        >
-          <span slot="aside" class="count-chip country-guide-count">
-            <strong>{countryGuides.length}</strong>
-            <span>guide{countryGuides.length === 1 ? "" : "s"}</span>
-          </span>
-        </SectionHeading>
+        <div class="ui-section-head country-section-head">
+          <div class="country-title-row">
+            <h3 class="ui-section-title">{countryFlag ? `${countryName} ${countryFlag}` : countryName}</h3>
+            <span class="count-chip country-guide-count">
+              <strong>{countryGuides.length}</strong>
+              <span>guide{countryGuides.length === 1 ? "" : "s"}</span>
+            </span>
+          </div>
+        </div>
 
         <div class="card-grid ui-card-grid">
           {countryGuides.map((guide) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -348,9 +348,12 @@ const homeJsonLd = [
       <div class="country-block ui-country-block" data-country-block data-country={countryName.toLowerCase()}>
         <SectionHeading
           title={countryFlag ? `${countryName} ${countryFlag}` : countryName}
-          copy={`${countryGuides.length} guide${countryGuides.length === 1 ? "" : "s"}`}
           level={3}
-        />
+        >
+          <span slot="aside" class="country-guide-count ui-pill">
+            {countryGuides.length} guide{countryGuides.length === 1 ? "" : "s"}
+          </span>
+        </SectionHeading>
 
         <div class="card-grid ui-card-grid">
           {countryGuides.map((guide) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -350,8 +350,9 @@ const homeJsonLd = [
           title={countryFlag ? `${countryName} ${countryFlag}` : countryName}
           level={3}
         >
-          <span slot="aside" class="country-guide-count ui-pill">
-            {countryGuides.length} guide{countryGuides.length === 1 ? "" : "s"}
+          <span slot="aside" class="count-chip country-guide-count">
+            <strong>{countryGuides.length}</strong>
+            <span>guide{countryGuides.length === 1 ? "" : "s"}</span>
           </span>
         </SectionHeading>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -347,8 +347,8 @@ const homeJsonLd = [
     {guidesByCountry.map(({ countryName, countryGuides, countryFlag }) => (
       <div class="country-block ui-country-block" data-country-block data-country={countryName.toLowerCase()}>
         <SectionHeading
-          eyebrow={`${countryGuides.length} guide${countryGuides.length === 1 ? "" : "s"}`}
           title={countryFlag ? `${countryName} ${countryFlag}` : countryName}
+          copy={`${countryGuides.length} guide${countryGuides.length === 1 ? "" : "s"}`}
           level={3}
         />
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -332,13 +332,40 @@
     scroll-margin-top: 8rem;
   }
 
+  .count-chip {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.38rem;
+    color: var(--muted);
+    line-height: 1;
+  }
+
+  .count-chip strong {
+    color: var(--ink);
+    font-family: Raleway, Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 1.18rem;
+    font-weight: 900;
+    letter-spacing: -0.02em;
+  }
+
+  .count-chip span {
+    color: var(--muted);
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
   .country-guide-count {
     flex-shrink: 0;
-    margin-bottom: 0.12rem;
-    border-color: color-mix(in srgb, var(--accent) 28%, var(--line));
-    background: color-mix(in srgb, var(--accent-soft) 52%, var(--surface));
-    color: var(--accent-strong);
-    font-weight: 800;
+    margin-bottom: 0.25rem;
+    padding-left: 1rem;
+    border-left: 3px solid var(--accent-soft);
+  }
+
+  .guide-card-place-count {
+    padding-top: 0.65rem;
+    border-top: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
   }
 
   .country-browser {
@@ -1683,7 +1710,7 @@
     position: relative;
     top: auto;
     order: 0;
-    margin-bottom: clamp(2.25rem, 5vw, 4rem);
+    margin-bottom: clamp(1.1rem, 2.5vw, 2rem);
     padding: 1rem;
     background: color-mix(in srgb, var(--surface) 94%, var(--surface-strong));
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -328,6 +328,12 @@
     margin-top: 2rem;
   }
 
+  .home-map-panel + .country-block {
+    margin-top: clamp(1.75rem, 4vw, 3rem);
+    padding-top: clamp(1.25rem, 3vw, 2rem);
+    border-top: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
+  }
+
   .country-block {
     scroll-margin-top: 8rem;
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -332,10 +332,27 @@
     scroll-margin-top: 8rem;
   }
 
+  .country-section-head {
+    justify-content: flex-start;
+  }
+
+  .country-title-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.7rem;
+    min-width: 0;
+  }
+
   .count-chip {
     display: inline-flex;
-    align-items: baseline;
+    align-items: center;
     gap: 0.38rem;
+    min-height: 1.85rem;
+    padding: 0.2rem 0.58rem;
+    border: 1px solid color-mix(in srgb, var(--accent) 20%, var(--line));
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--accent-soft) 28%, var(--surface));
     color: var(--muted);
     line-height: 1;
   }
@@ -343,29 +360,27 @@
   .count-chip strong {
     color: var(--ink);
     font-family: Raleway, Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 1.18rem;
-    font-weight: 900;
-    letter-spacing: -0.02em;
+    font-size: 0.95rem;
+    font-weight: 800;
+    letter-spacing: -0.01em;
   }
 
   .count-chip span {
     color: var(--muted);
-    font-size: 0.7rem;
+    font-size: 0.68rem;
     font-weight: 800;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.07em;
     text-transform: uppercase;
   }
 
   .country-guide-count {
     flex-shrink: 0;
-    margin-bottom: 0.25rem;
-    padding-left: 1rem;
-    border-left: 3px solid var(--accent-soft);
+    transform: translateY(0.02rem);
   }
 
   .guide-card-place-count {
-    padding-top: 0.65rem;
-    border-top: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
+    align-self: flex-start;
+    background: color-mix(in srgb, var(--surface-strong) 54%, var(--surface));
   }
 
   .country-browser {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -328,14 +328,17 @@
     margin-top: 2rem;
   }
 
-  .home-map-panel + .country-block {
-    margin-top: clamp(1.75rem, 4vw, 3rem);
-    padding-top: clamp(1.25rem, 3vw, 2rem);
-    border-top: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
-  }
-
   .country-block {
     scroll-margin-top: 8rem;
+  }
+
+  .country-guide-count {
+    flex-shrink: 0;
+    margin-bottom: 0.12rem;
+    border-color: color-mix(in srgb, var(--accent) 28%, var(--line));
+    background: color-mix(in srgb, var(--accent-soft) 52%, var(--surface));
+    color: var(--accent-strong);
+    font-weight: 800;
   }
 
   .country-browser {
@@ -1680,6 +1683,7 @@
     position: relative;
     top: auto;
     order: 0;
+    margin-bottom: clamp(2.25rem, 5vw, 4rem);
     padding: 1rem;
     background: color-mix(in srgb, var(--surface) 94%, var(--surface-strong));
   }

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -470,6 +470,7 @@ describe("guide map interactions", () => {
     expect(homeMap).toContain("if (zoom !== undefined && zoom > focusMaxResetZoom) {");
     expect(homeMap).toContain("map.setZoom(focusMaxResetZoom);");
     expect(homeMap).toContain("if (visibleGuides.length === 0) return;");
+    expect(homeMap).toContain("if (focusGuides.length === 0) return;");
     expect(homeMap).toContain("capFittedZoomAndCapture();");
     expect(homeMap).toContain("resetButton.hidden = !runtime?.isOutsideFocusBounds();");
     expect(homeMap).toContain("runtime.onViewChanged(syncResetButton);");

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -80,12 +80,18 @@ describe("guide map interactions", () => {
     );
     expect(guideMap).toContain('marker.on("popupopen", (event: L.PopupEvent) => {');
     expect(guideMap).toContain(
-      'popupElement?.querySelector<HTMLButtonElement>("[data-guide-map-popup-close]")',
+      'const closeButton = popupElement?.querySelector<HTMLButtonElement>("[data-guide-map-popup-close]");',
     );
     expect(guideMap).toContain(
-      '?.querySelector<HTMLButtonElement>("[data-guide-map-popup-details]")',
+      'const detailsButton = popupElement?.querySelector<HTMLButtonElement>("[data-guide-map-popup-details]");',
     );
-    expect(guideMap).toContain("onSelectPlace(place.id);");
+    expect(guideMap).toContain("closeButton.onclick = () => {");
+    expect(guideMap).toContain("detailsButton.onclick = (clickEvent) => {");
+    expect(guideMap).toContain("onShowPlaceDetails(place.id);");
+    expect(guideMap).toContain(
+      "const handlePopupDetailsSelect = (placeId: string) => selectPlace(placeId, { focusCard: true });",
+    );
+    expect(guideMap).toContain('marker.on("click", () => onSelectPlace(place.id));');
     expect(guideMap).toContain('target?.closest("[data-guide-map-popup-close]")');
     expect(guideMap).toContain('target?.closest<HTMLElement>("[data-guide-map-popup-details]")');
     expectCssToContain(css, ".guide-map-popup-close");
@@ -463,6 +469,7 @@ describe("guide map interactions", () => {
     expect(homeMap).toContain("const capFittedZoomAndCapture = () => {");
     expect(homeMap).toContain("if (zoom !== undefined && zoom > focusMaxResetZoom) {");
     expect(homeMap).toContain("map.setZoom(focusMaxResetZoom);");
+    expect(homeMap).toContain("if (visibleGuides.length === 0) return;");
     expect(homeMap).toContain("capFittedZoomAndCapture();");
     expect(homeMap).toContain("resetButton.hidden = !runtime?.isOutsideFocusBounds();");
     expect(homeMap).toContain("runtime.onViewChanged(syncResetButton);");

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -75,6 +75,17 @@ describe("guide map interactions", () => {
     expect(guideMap).not.toContain("<span>Maps</span>");
     expect(guideMap).toContain("closeButton: false");
     expect(guideMap).toContain("headerDisabled: true");
+    expect(guideMap).toContain(
+      "const bindLeafletPopupActions = (marker: L.Marker, place: MapPlace) => {",
+    );
+    expect(guideMap).toContain('marker.on("popupopen", (event: L.PopupEvent) => {');
+    expect(guideMap).toContain(
+      'popupElement?.querySelector<HTMLButtonElement>("[data-guide-map-popup-close]")',
+    );
+    expect(guideMap).toContain(
+      '?.querySelector<HTMLButtonElement>("[data-guide-map-popup-details]")',
+    );
+    expect(guideMap).toContain("onSelectPlace(place.id);");
     expect(guideMap).toContain('target?.closest("[data-guide-map-popup-close]")');
     expect(guideMap).toContain('target?.closest<HTMLElement>("[data-guide-map-popup-details]")');
     expectCssToContain(css, ".guide-map-popup-close");
@@ -269,6 +280,10 @@ describe("guide map interactions", () => {
     expect(guideMap).toContain("data-map-frame-filter");
     expect(guideMap).toContain("data-map-full-area");
     expect(guideMap).toContain(">Reset Map</button>");
+    expect(guideMap).toContain("const capFittedZoomAndCapture = () => {");
+    expect(guideMap).toContain("if (zoom !== undefined && zoom > focusMaxResetZoom) {");
+    expect(guideMap).toContain("map.setZoom(focusMaxResetZoom);");
+    expect(guideMap).toContain("capFittedZoomAndCapture();");
     expect(guideMap).toContain('new CustomEvent("guide:map-frame-reset-request"');
     expect(guideMap).toContain('new CustomEvent("guide:map-frame-filter"');
     expect(filters).toContain("countMatchingCards");
@@ -445,6 +460,10 @@ describe("guide map interactions", () => {
       "distanceInKm(currentCenter.lat, currentCenter.lng, focusCenter.lat, focusCenter.lng)",
     );
     expect(homeMap).toContain("Math.abs(zoom - focusZoom) > 0.75");
+    expect(homeMap).toContain("const capFittedZoomAndCapture = () => {");
+    expect(homeMap).toContain("if (zoom !== undefined && zoom > focusMaxResetZoom) {");
+    expect(homeMap).toContain("map.setZoom(focusMaxResetZoom);");
+    expect(homeMap).toContain("capFittedZoomAndCapture();");
     expect(homeMap).toContain("resetButton.hidden = !runtime?.isOutsideFocusBounds();");
     expect(homeMap).toContain("runtime.onViewChanged(syncResetButton);");
     expect(homeMap).toContain('resetButton?.addEventListener("click", () => {');


### PR DESCRIPTION
## Summary
- bind Leaflet popup close/details actions directly inside popup DOM
- cap Google fit zoom before capturing guide/home reset focus state
- add frontend source assertions for the reviewed interaction paths

## Tests
- bun run test:frontend
- bun run check
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map popups now include a "Details" button to focus on selected places.

* **Bug Fixes**
  * Improved map zoom behavior when fitting places and resetting view.
  * Enhanced singular/plural handling for place counts in guides and headers.

* **Tests**
  * Added tests for popup interactions and map zoom behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->