### PR TITLE
[codex] Harden Google Maps place enrichment

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6544,6 +6544,11 @@ PLACE_PAGE_ADDRESS_KEYWORD_RE = re.compile(
     r"court|ct|square|sq|suite|ste|unit|floor|fl|plaza|parkway|pkwy|highway|hwy)\b",
     re.IGNORECASE,
 )
+PLACE_PAGE_STRONG_ADDRESS_KEYWORD_RE = re.compile(
+    r"\b(?:street|st|avenue|ave|road|rd|boulevard|blvd|lane|ln|drive|dr|court|ct|"
+    r"square|sq|suite|ste|unit|floor|fl|plaza|parkway|pkwy|highway|hwy)\b",
+    re.IGNORECASE,
+)
 
 
 def sanitize_place_page_formatted_address(value: Any) -> str | None:
@@ -6652,7 +6657,7 @@ def has_place_page_address_marker(value: str) -> bool:
     return (
         PLACE_PAGE_PLUS_CODE_RE.search(value) is not None
         or PLACE_PAGE_POSTAL_CODE_RE.search(value) is not None
-        or PLACE_PAGE_ADDRESS_KEYWORD_RE.search(value) is not None
+        or PLACE_PAGE_STRONG_ADDRESS_KEYWORD_RE.search(value) is not None
         or "〒" in value
         or value.startswith("Japan, ")
     )

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6641,7 +6641,7 @@ def looks_like_place_page_formatted_address(value: str) -> bool:
     locality_parts = [part.strip() for part in value.split(locality_separator) if part.strip()]
     if len(locality_parts) >= 3 and not re.search(r"[.!?]", value):
         return True
-    if locality_separator == "," and 2 <= len(locality_parts) <= 4 and not re.search(r"[.!?&]", value):
+    if locality_separator == "," and 2 <= len(locality_parts) <= 4 and not re.search(r"[.!?]", value):
         if len(value.split()) > 8:
             return False
         return all(any(character.isalpha() for character in part) and len(part) <= 60 for part in locality_parts)

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -1464,6 +1464,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Force-refresh place enrichment cache entries for every place.",
     )
     parser.add_argument(
+        "--enrich-place",
+        action="append",
+        default=[],
+        help=(
+            "Limit enrichment to a specific place selector. Repeat to target multiple places. "
+            "Matches exact place ids, CIDs, names, Maps URLs, and `guide-slug:<selector>` forms."
+        ),
+    )
+    parser.add_argument(
         "--refresh-photos",
         action="store_true",
         help="Download missing local optimized place photos from cached enrichment photo URLs.",
@@ -2881,12 +2890,15 @@ def enrich_raw_sources(
     *,
     force_refresh: bool,
     missing_only: bool = False,
+    place_selectors: list[str] | None = None,
     refresh_workers: int = DEFAULT_REFRESH_WORKERS,
     refresh_startup_jitter_seconds: float = DEFAULT_REFRESH_STARTUP_JITTER_SECONDS,
 ) -> None:
     api_key = google_places_api_key()
     cache_payloads: dict[str, dict[str, EnrichmentCacheEntry]] = {}
     enrich_jobs: list[tuple[str, str, str, str, dict[str, Any], str | None, str | None]] = []
+    normalized_place_selectors = normalize_place_selectors(place_selectors or [])
+    matched_place_selectors: set[str] = set()
 
     for raw_path in sorted(RAW_DIR.glob("*.json")):
         raw = RawSavedList.model_validate_json(raw_path.read_text(encoding="utf-8"))
@@ -2896,6 +2908,16 @@ def enrich_raw_sources(
         cache_payloads[raw_path.stem] = cache_payload
         for place in raw.places:
             place_id = stable_place_id(place, source_type=raw.configured_source_type)
+            if normalized_place_selectors:
+                selector_matches = place_selector_matches(
+                    raw_path.stem,
+                    place,
+                    place_id=place_id,
+                    selectors=normalized_place_selectors,
+                )
+                matched_place_selectors.update(selector_matches)
+                if not selector_matches:
+                    continue
             refresh_reason = enrichment_refresh_reason(
                 place,
                 cache_payload.get(place_id),
@@ -2918,6 +2940,12 @@ def enrich_raw_sources(
                     country_name,
                 )
             )
+
+    if normalized_place_selectors:
+        missing_selectors = sorted(normalized_place_selectors - matched_place_selectors)
+        if missing_selectors:
+            missing_text = ", ".join(missing_selectors)
+            raise RuntimeError(f"No configured place matched: {missing_text}")
 
     if not enrich_jobs:
         return
@@ -3191,6 +3219,9 @@ def canonicalize_enrichment_place(place: EnrichmentPlace | None) -> EnrichmentPl
 
     place.primary_type_display_name = canonical_display_name
     place.primary_type_display_name_localized = localized_display_name
+    place.formatted_address = sanitize_place_page_formatted_address(place.formatted_address)
+    place.phone = sanitize_place_page_phone(place.phone)
+    place.plus_code = sanitize_place_page_plus_code(place.plus_code)
     place.main_photo_url = sanitize_place_photo_url(place.main_photo_url)
     place.photo_url = sanitize_place_photo_url(place.photo_url)
     return place
@@ -4734,6 +4765,9 @@ def preserve_existing_enrichment(
     if refreshed_place.user_rating_count is None and previous_place.user_rating_count is not None:
         refreshed_place.user_rating_count = previous_place.user_rating_count
         append_unique_reason(preserved_fields, "user_rating_count")
+    if not refreshed_place.formatted_address and previous_place.formatted_address:
+        refreshed_place.formatted_address = previous_place.formatted_address
+        append_unique_reason(preserved_fields, "address")
 
     if not refreshed_place.primary_type_display_name and previous_place.primary_type_display_name:
         refreshed_place.primary_type_display_name = previous_place.primary_type_display_name
@@ -6482,12 +6516,33 @@ PLACE_PAGE_ADDRESS_REJECT_SUBSTRINGS = (
     "faviconv2",
     "imagery ©",
     "map data ©",
+    "saved in",
     "send product feedback",
     "street view",
     "termsprivacy",
 )
 PLACE_PAGE_ADDRESS_REJECT_HOST_FRAGMENTS = ("gstatic.com", "googleusercontent.com")
 PLACE_PAGE_ADDRESS_ENTITY_TOKEN_RE = re.compile(r"^/(?:g|m)/[A-Za-z0-9_-]+$")
+PLACE_PAGE_URL_LIKE_RE = re.compile(r"(?:https?://|www\.)", re.IGNORECASE)
+PLACE_PAGE_PROSE_RE = re.compile(
+    r"\b(?:best|good|great|delicious|dropped|experience|lunch|dinner|"
+    r"burger|burgers|nugget|nuggets|owner|recommend|session)\b",
+    re.IGNORECASE,
+)
+PLACE_PAGE_PLUS_CODE_RE = re.compile(
+    r"\b[23456789CFGHJMPQRVWX]{4,8}\+[23456789CFGHJMPQRVWX]{2,3}"
+    r"(?:\s+[^\n]+)?\b"
+)
+PLACE_PAGE_PHONE_RE = re.compile(r"^\+?[0-9][0-9()\-\s]{7,}$")
+PLACE_PAGE_POSTAL_CODE_RE = re.compile(
+    r"\b(?:\d{5}(?:-\d{4})?|[A-Z]\d[A-Z]\s?\d[A-Z]\d|[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2})\b",
+    re.IGNORECASE,
+)
+PLACE_PAGE_ADDRESS_KEYWORD_RE = re.compile(
+    r"\b(?:street|st|avenue|ave|road|rd|boulevard|blvd|lane|ln|drive|dr|way|place|pl|"
+    r"court|ct|square|sq|suite|ste|unit|floor|fl|plaza|parkway|pkwy|highway|hwy)\b",
+    re.IGNORECASE,
+)
 
 
 def sanitize_place_page_formatted_address(value: Any) -> str | None:
@@ -6496,15 +6551,19 @@ def sanitize_place_page_formatted_address(value: Any) -> str | None:
         return None
 
     lowered = normalized.lower()
-    if lowered.startswith(("http://", "https://", "www.")):
+    if PLACE_PAGE_URL_LIKE_RE.search(normalized) is not None:
         return None
     if any(fragment in lowered for fragment in PLACE_PAGE_ADDRESS_REJECT_SUBSTRINGS):
         return None
     if any(fragment in lowered for fragment in PLACE_PAGE_ADDRESS_REJECT_HOST_FRAGMENTS):
         return None
+    if PLACE_PAGE_PROSE_RE.search(normalized) is not None:
+        return None
     if PLACE_PAGE_ADDRESS_ENTITY_TOKEN_RE.fullmatch(normalized):
         return None
     if re.search(r"\d", normalized) and re.search(r"\breviews?\b", lowered):
+        return None
+    if normalized.endswith(" More"):
         return None
     if normalized.endswith(".") and re.search(r"\b[23456789CFGHJMPQRVWX]{4,8}\+[23456789CFGHJMPQRVWX]{2,3}\b", normalized) is None:
         return None
@@ -6517,7 +6576,61 @@ def sanitize_place_page_formatted_address(value: Any) -> str | None:
                 return cleaned
         return None
 
+    return normalized if looks_like_place_page_formatted_address(normalized) else None
+
+
+def sanitize_place_page_phone(value: Any) -> str | None:
+    normalized = as_string(value)
+    if normalized is None:
+        return None
+    if PLACE_PAGE_PHONE_RE.fullmatch(normalized) is None:
+        return None
+    digit_count = sum(character.isdigit() for character in normalized)
+    if digit_count < 8 or digit_count > 15:
+        return None
+    if normalized.isdigit() and digit_count == 13 and normalized.startswith("17"):
+        return None
     return normalized
+
+
+def sanitize_place_page_plus_code(value: Any) -> str | None:
+    normalized = as_string(value)
+    if normalized is None:
+        return None
+    match = PLACE_PAGE_PLUS_CODE_RE.search(normalized)
+    if match is None:
+        return None
+    return match.group(0).strip()
+
+
+def looks_like_place_page_formatted_address(value: str) -> bool:
+    if len(value) < 5:
+        return False
+    if PLACE_PAGE_PLUS_CODE_RE.search(value) is not None:
+        return True
+    if "〒" in value or value.startswith("Japan, "):
+        return True
+    if PLACE_PAGE_POSTAL_CODE_RE.search(value) is not None and any(character.isalpha() for character in value):
+        return True
+
+    has_digits = re.search(r"\d", value) is not None
+    has_letters = any(character.isalpha() for character in value)
+    if has_digits and has_letters and ("," in value or PLACE_PAGE_ADDRESS_KEYWORD_RE.search(value)):
+        if "," in value and PLACE_PAGE_ADDRESS_KEYWORD_RE.search(value) is None and len(value.split()) > 10:
+            return False
+        return True
+    if PLACE_PAGE_ADDRESS_KEYWORD_RE.search(value) and len(value.split()) <= 5:
+        return True
+
+    locality_separator = " - " if " - " in value else ","
+    locality_parts = [part.strip() for part in value.split(locality_separator) if part.strip()]
+    if len(locality_parts) >= 3 and not re.search(r"[.!?]", value):
+        return True
+    if locality_separator == "," and 2 <= len(locality_parts) <= 4 and not re.search(r"[.!?&]", value):
+        if len(value.split()) > 8:
+            return False
+        return all(any(character.isalpha() for character in part) and len(part) <= 60 for part in locality_parts)
+    return False
 
 
 def coerce_enrichment_address_parts(value: Any) -> AddressParts | None:
@@ -6565,8 +6678,8 @@ def normalize_place_page_enrichment(details: Any) -> EnrichmentPlace:
     rating = as_float(getattr(details, "rating", None))
     user_rating_count = as_int(getattr(details, "review_count", None))
     website = as_string(getattr(details, "website", None))
-    phone = as_string(getattr(details, "phone", None))
-    plus_code = as_string(getattr(details, "plus_code", None))
+    phone = sanitize_place_page_phone(getattr(details, "phone", None))
+    plus_code = sanitize_place_page_plus_code(getattr(details, "plus_code", None))
     if formatted_address is None and plus_code and any(
         separator in plus_code for separator in (" - ", ",", " ")
     ):
@@ -6909,6 +7022,44 @@ def normalize_text(value: str | None) -> str:
     return re.sub(r"[^a-z0-9\s]", " ", value.lower()).strip()
 
 
+def normalize_place_selectors(selectors: list[str]) -> set[str]:
+    return {
+        normalized
+        for selector in selectors
+        if (normalized := as_string(selector.casefold() if isinstance(selector, str) else selector))
+    }
+
+
+def place_selector_matches(
+    slug: str,
+    place: RawPlace,
+    *,
+    place_id: str,
+    selectors: set[str],
+) -> set[str]:
+    if not selectors:
+        return set()
+
+    values = {
+        place_id.casefold(),
+        f"{slug}:{place_id}".casefold(),
+        f"guide-slug:{slug}".casefold(),
+    }
+    for candidate in (
+        place.name,
+        place.maps_url,
+        place.cid,
+        place.google_id,
+        place.maps_place_token,
+    ):
+        normalized = as_string(candidate.casefold() if isinstance(candidate, str) else candidate)
+        if normalized is None:
+            continue
+        values.add(normalized)
+        values.add(f"{slug}:{normalized}".casefold())
+    return selectors & values
+
+
 def token_overlap_score(left: str, right: str) -> int:
     left_tokens = {token for token in left.split() if len(token) > 2}
     right_tokens = {token for token in right.split() if len(token) > 2}
@@ -6947,6 +7098,8 @@ def main() -> int:
 
     if (args.refresh_list or args.refresh_force) and not args.refresh:
         args.refresh = True
+    if args.enrich_place and not (args.enrich or args.enrich_missing or args.refresh_enrichment):
+        args.refresh_enrichment = True
 
     if args.refresh:
         refresh_raw_sources(
@@ -6964,6 +7117,7 @@ def main() -> int:
         enrich_raw_sources(
             force_refresh=args.refresh_enrichment,
             missing_only=args.enrich_missing,
+            place_selectors=args.enrich_place,
             refresh_workers=args.refresh_workers,
             refresh_startup_jitter_seconds=args.refresh_startup_jitter_seconds,
         )

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -1468,7 +1468,8 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         default=[],
         help=(
-            "Limit enrichment to a specific place selector. Repeat to target multiple places. "
+            "Force-refresh enrichment for a specific place selector unless combined with "
+            "--enrich or --enrich-missing. Repeat to target multiple places. "
             "Matches exact place ids, CIDs, names, Maps URLs, and `guide-slug:<selector>` forms."
         ),
     )
@@ -6524,7 +6525,7 @@ PLACE_PAGE_ADDRESS_REJECT_SUBSTRINGS = (
 PLACE_PAGE_ADDRESS_REJECT_HOST_FRAGMENTS = ("gstatic.com", "googleusercontent.com")
 PLACE_PAGE_ADDRESS_ENTITY_TOKEN_RE = re.compile(r"^/(?:g|m)/[A-Za-z0-9_-]+$")
 PLACE_PAGE_URL_LIKE_RE = re.compile(r"(?:https?://|www\.)", re.IGNORECASE)
-PLACE_PAGE_PROSE_RE = re.compile(
+PLACE_PAGE_PROSE_TERM_RE = re.compile(
     r"\b(?:best|good|great|delicious|dropped|experience|lunch|dinner|"
     r"burger|burgers|nugget|nuggets|owner|recommend|session)\b",
     re.IGNORECASE,
@@ -6557,7 +6558,7 @@ def sanitize_place_page_formatted_address(value: Any) -> str | None:
         return None
     if any(fragment in lowered for fragment in PLACE_PAGE_ADDRESS_REJECT_HOST_FRAGMENTS):
         return None
-    if PLACE_PAGE_PROSE_RE.search(normalized) is not None:
+    if looks_like_place_page_review_snippet(normalized):
         return None
     if PLACE_PAGE_ADDRESS_ENTITY_TOKEN_RE.fullmatch(normalized):
         return None
@@ -6577,6 +6578,20 @@ def sanitize_place_page_formatted_address(value: Any) -> str | None:
         return None
 
     return normalized if looks_like_place_page_formatted_address(normalized) else None
+
+
+def looks_like_place_page_review_snippet(value: str) -> bool:
+    if has_place_page_address_marker(value):
+        return False
+    if value.endswith(" More"):
+        return True
+    terms = PLACE_PAGE_PROSE_TERM_RE.findall(value)
+    word_count = len(value.split())
+    if word_count >= 10 and len(terms) >= 2:
+        return True
+    if word_count >= 10 and re.search(r"[.!?]", value) and terms:
+        return True
+    return False
 
 
 def sanitize_place_page_phone(value: Any) -> str | None:
@@ -6631,6 +6646,16 @@ def looks_like_place_page_formatted_address(value: str) -> bool:
             return False
         return all(any(character.isalpha() for character in part) and len(part) <= 60 for part in locality_parts)
     return False
+
+
+def has_place_page_address_marker(value: str) -> bool:
+    return (
+        PLACE_PAGE_PLUS_CODE_RE.search(value) is not None
+        or PLACE_PAGE_POSTAL_CODE_RE.search(value) is not None
+        or PLACE_PAGE_ADDRESS_KEYWORD_RE.search(value) is not None
+        or "〒" in value
+        or value.startswith("Japan, ")
+    )
 
 
 def coerce_enrichment_address_parts(value: Any) -> AddressParts | None:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2690,6 +2690,27 @@ class BuildDataTests(unittest.TestCase):
 
                 self.assertIsNone(place.formatted_address)
 
+    def test_normalize_place_page_enrichment_keeps_addresses_with_prose_words(self) -> None:
+        for address in (
+            "Good Burger, 1 Main St, New York, NY 10001",
+            "Session Road, Baguio, Benguet 2600, Philippines",
+        ):
+            with self.subTest(address=address):
+                place = build_data.normalize_place_page_enrichment(
+                    SimpleNamespace(
+                        source_url="https://www.google.com/maps/place/Test",
+                        resolved_url="https://www.google.com/maps/place/Test",
+                        name="Test",
+                        category="Restaurant",
+                        rating=4.6,
+                        review_count=101,
+                        address=address,
+                        limited_view=False,
+                    )
+                )
+
+                self.assertEqual(place.formatted_address, address)
+
     def test_normalize_place_page_enrichment_accepts_locality_only_address(self) -> None:
         place = build_data.normalize_place_page_enrichment(
             SimpleNamespace(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2678,6 +2678,7 @@ class BuildDataTests(unittest.TestCase):
                 "before closing time and the owner took the initiative to cook us More"
             ),
             "The nuggets are massive, good size burgers and probably the best for value in town",
+            "This place has great food, good service, friendly owner, and delicious burgers",
         ):
             with self.subTest(address=address):
                 place = build_data.normalize_place_page_enrichment(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -93,6 +93,24 @@ class BuildDataTests(unittest.TestCase):
             startup_jitter_seconds=build_data.DEFAULT_REFRESH_STARTUP_JITTER_SECONDS,
         )
 
+    def test_main_treats_enrich_place_as_targeted_refresh(self) -> None:
+        with (
+            patch.object(sys, "argv", ["build_data.py", "--enrich-place", "cid:123"]),
+            patch.object(build_data, "sync_local_csv_sources"),
+            patch.object(build_data, "enrich_raw_sources") as enrich_raw_sources,
+            patch.object(build_data, "rebuild_generated_data"),
+        ):
+            result = build_data.main()
+
+        self.assertEqual(result, 0)
+        enrich_raw_sources.assert_called_once_with(
+            force_refresh=True,
+            missing_only=False,
+            place_selectors=["cid:123"],
+            refresh_workers=build_data.DEFAULT_REFRESH_WORKERS,
+            refresh_startup_jitter_seconds=build_data.DEFAULT_REFRESH_STARTUP_JITTER_SECONDS,
+        )
+
     def test_refresh_generated_guide_photos_skips_artifact_rewrite_when_photo_state_is_unchanged(self) -> None:
         guide = Guide(
             slug="tokyo-japan",
@@ -2610,6 +2628,100 @@ class BuildDataTests(unittest.TestCase):
         self.assertIsNone(street_view.formatted_address)
         self.assertEqual(prefixed.formatted_address, "Exit 37 - Sheikh Mohammed Bin Zayed Rd")
 
+    def test_normalize_place_page_enrichment_rejects_fixaddress_url_addresses(self) -> None:
+        place = build_data.normalize_place_page_enrichment(
+            SimpleNamespace(
+                source_url="https://www.google.com/maps/place/Nizami+Street",
+                resolved_url="https://www.google.com/maps/place/Nizami+Street",
+                name="Nizami Street",
+                category="Transportation",
+                rating=4.7,
+                review_count=1825,
+                address=(
+                    "Address https://www.google.com/local/place/rap/fixaddress?"
+                    "g2lb=72971417,73155522,100805691&hl=en-CA&gl=ca"
+                ),
+                limited_view=False,
+            )
+        )
+
+        self.assertIsNone(place.formatted_address)
+
+    def test_normalize_place_page_enrichment_rejects_review_prose_as_address(self) -> None:
+        place = build_data.normalize_place_page_enrichment(
+            SimpleNamespace(
+                source_url="https://www.google.com/maps/place/Nizami+Street",
+                resolved_url="https://www.google.com/maps/place/Nizami+Street",
+                name="Nizami Street",
+                category="Transportation",
+                rating=4.7,
+                review_count=1842,
+                address=(
+                    "It was amazing street walk experience i hade ever before. "
+                    "Shops and natural bueaty is next level experience 💖"
+                ),
+                limited_view=False,
+            )
+        )
+
+        self.assertIsNone(place.formatted_address)
+
+    def test_normalize_place_page_enrichment_rejects_long_review_snippet_as_address(self) -> None:
+        for address in (
+            (
+                "The best takeout or eat in I recommend this place. We dropped in 5 minutes "
+                "before closing time and the owner took the initiative to cook us More"
+            ),
+            "The nuggets are massive, good size burgers and probably the best for value in town",
+        ):
+            with self.subTest(address=address):
+                place = build_data.normalize_place_page_enrichment(
+                    SimpleNamespace(
+                        source_url="https://www.google.com/maps/place/Tropical+Taste",
+                        resolved_url="https://www.google.com/maps/place/Tropical+Taste",
+                        name="Tropical Taste",
+                        category="Restaurant",
+                        rating=4.6,
+                        review_count=101,
+                        address=address,
+                        limited_view=False,
+                    )
+                )
+
+                self.assertIsNone(place.formatted_address)
+
+    def test_normalize_place_page_enrichment_accepts_locality_only_address(self) -> None:
+        place = build_data.normalize_place_page_enrichment(
+            SimpleNamespace(
+                source_url="https://www.google.com/maps/place/Nizami+Street",
+                resolved_url="https://www.google.com/maps/place/Nizami+Street",
+                name="Nizami St",
+                category="Notable street",
+                rating=4.7,
+                review_count=1842,
+                address="Baku, Azerbaijan",
+                limited_view=False,
+            )
+        )
+
+        self.assertEqual(place.formatted_address, "Baku, Azerbaijan")
+
+    def test_normalize_place_page_enrichment_rejects_saved_list_row_as_address(self) -> None:
+        place = build_data.normalize_place_page_enrichment(
+            SimpleNamespace(
+                source_url="https://www.google.com/maps/place/Nizami+Street",
+                resolved_url="https://www.google.com/maps/place/Nizami+Street",
+                name="Nizami St",
+                category="Notable street",
+                rating=4.7,
+                review_count=1842,
+                address="Saved in Favorites & Baku, Azerbaijan 🇦🇿",
+                limited_view=False,
+            )
+        )
+
+        self.assertIsNone(place.formatted_address)
+
     def test_normalize_place_page_enrichment_falls_back_to_compound_plus_code(self) -> None:
         place = build_data.normalize_place_page_enrichment(
             SimpleNamespace(
@@ -2629,6 +2741,45 @@ class BuildDataTests(unittest.TestCase):
             place.formatted_address,
             "38C5+F57 - Wadi Al Safa 4 - Dubai - United Arab Emirates",
         )
+        self.assertEqual(place.plus_code, "38C5+F57 - Wadi Al Safa 4 - Dubai - United Arab Emirates")
+
+    def test_normalize_place_page_enrichment_sanitizes_phone_and_plus_code(self) -> None:
+        place = build_data.normalize_place_page_enrichment(
+            SimpleNamespace(
+                source_url="https://www.google.com/maps/place/Nar+%26+Sharab",
+                resolved_url="https://www.google.com/maps/place/Nar+%26+Sharab",
+                name="Nar & Sharab",
+                category="Restaurant",
+                rating=4.4,
+                review_count=51,
+                address="Namiq Quliyev, Baku, Azerbaijan",
+                phone="+994 50 241 01 01",
+                plus_code="Plus code: 8R3F+XV Baku, Azerbaijan",
+                limited_view=False,
+            )
+        )
+
+        self.assertEqual(place.phone, "+994 50 241 01 01")
+        self.assertEqual(place.plus_code, "8R3F+XV Baku, Azerbaijan")
+
+    def test_normalize_place_page_enrichment_rejects_invalid_phone_and_plus_code(self) -> None:
+        place = build_data.normalize_place_page_enrichment(
+            SimpleNamespace(
+                source_url="https://www.google.com/maps/place/Nizami+Street",
+                resolved_url="https://www.google.com/maps/place/Nizami+Street",
+                name="Nizami St",
+                category="Notable street",
+                rating=4.7,
+                review_count=1842,
+                address="Baku, Azerbaijan",
+                phone="1776616236980",
+                plus_code="Your Maps history",
+                limited_view=False,
+            )
+        )
+
+        self.assertIsNone(place.phone)
+        self.assertIsNone(place.plus_code)
 
     def test_normalize_place_page_enrichment_uses_address_like_description_when_address_missing(self) -> None:
         place = build_data.normalize_place_page_enrichment(
@@ -4572,6 +4723,134 @@ class BuildDataTests(unittest.TestCase):
                 ["missing-cache-entry", "refresh-window-expired"],
             )
 
+    def test_enrich_raw_sources_filters_to_selected_place(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo",
+            places=[
+                RawPlace(name="First Place", maps_url="https://maps.google.com/?cid=111", cid="111"),
+                RawPlace(name="Second Place", maps_url="https://maps.google.com/?cid=222", cid="222"),
+            ],
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            raw_dir = tmpdir_path / "raw"
+            cache_dir = tmpdir_path / "cache"
+            db_path = tmpdir_path / "places.sqlite"
+            raw_dir.mkdir()
+            cache_dir.mkdir()
+            (raw_dir / "tokyo-japan.json").write_text(
+                json.dumps(raw.model_dump(mode="json"), ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            seen_places: list[str] = []
+
+            def fake_enrich_place_job(_slug, _place_id, place_name, _refresh_reason, _place_payload, **_kwargs):
+                seen_places.append(place_name)
+                return EnrichmentCacheEntry(
+                    fetched_at="2026-04-20T00:00:00+00:00",
+                    query=place_name,
+                    matched=True,
+                    place=EnrichmentPlace(display_name=place_name),
+                )
+
+            with (
+                patch.object(build_data, "RAW_DIR", raw_dir),
+                patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
+                patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
+                patch.object(build_data, "google_places_api_key", return_value=None),
+                patch.object(build_data, "enrich_place_job", side_effect=fake_enrich_place_job),
+            ):
+                build_data.enrich_raw_sources(
+                    force_refresh=True,
+                    place_selectors=["cid:222"],
+                    refresh_workers=1,
+                    refresh_startup_jitter_seconds=0,
+                )
+
+            self.assertEqual(seen_places, ["Second Place"])
+
+    def test_enrich_raw_sources_does_not_match_bare_guide_slug_as_place(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo",
+            places=[RawPlace(name="First Place", maps_url="https://maps.google.com/?cid=111", cid="111")],
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            raw_dir = tmpdir_path / "raw"
+            cache_dir = tmpdir_path / "cache"
+            db_path = tmpdir_path / "places.sqlite"
+            raw_dir.mkdir()
+            cache_dir.mkdir()
+            (raw_dir / "tokyo-japan.json").write_text(
+                json.dumps(raw.model_dump(mode="json"), ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(build_data, "RAW_DIR", raw_dir),
+                patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
+                patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
+                patch.object(build_data, "google_places_api_key", return_value=None),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "No configured place matched: tokyo-japan"):
+                    build_data.enrich_raw_sources(
+                        force_refresh=True,
+                        place_selectors=["tokyo-japan"],
+                        refresh_workers=1,
+                        refresh_startup_jitter_seconds=0,
+                    )
+
+    def test_enrich_raw_sources_matches_explicit_guide_slug_selector(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo",
+            places=[
+                RawPlace(name="First Place", maps_url="https://maps.google.com/?cid=111", cid="111"),
+                RawPlace(name="Second Place", maps_url="https://maps.google.com/?cid=222", cid="222"),
+            ],
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            raw_dir = tmpdir_path / "raw"
+            cache_dir = tmpdir_path / "cache"
+            db_path = tmpdir_path / "places.sqlite"
+            raw_dir.mkdir()
+            cache_dir.mkdir()
+            (raw_dir / "tokyo-japan.json").write_text(
+                json.dumps(raw.model_dump(mode="json"), ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            seen_places: list[str] = []
+
+            def fake_enrich_place_job(_slug, _place_id, place_name, _refresh_reason, _place_payload, **_kwargs):
+                seen_places.append(place_name)
+                return EnrichmentCacheEntry(
+                    fetched_at="2026-04-20T00:00:00+00:00",
+                    query=place_name,
+                    matched=True,
+                    place=EnrichmentPlace(display_name=place_name),
+                )
+
+            with (
+                patch.object(build_data, "RAW_DIR", raw_dir),
+                patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
+                patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
+                patch.object(build_data, "google_places_api_key", return_value=None),
+                patch.object(build_data, "enrich_place_job", side_effect=fake_enrich_place_job),
+            ):
+                build_data.enrich_raw_sources(
+                    force_refresh=True,
+                    place_selectors=["guide-slug:tokyo-japan"],
+                    refresh_workers=1,
+                    refresh_startup_jitter_seconds=0,
+                )
+
+            self.assertEqual(seen_places, ["First Place", "Second Place"])
+
     def test_enrich_raw_sources_parallel_writes_cache_incrementally(self) -> None:
         raw = RawSavedList(
             title="Tokyo",
@@ -5773,6 +6052,106 @@ class BuildDataTests(unittest.TestCase):
             "WARNING: Preserving previous enrichment fields for tokyo-japan:cid:111 [First Place]: "
             "rating, user_rating_count, primary_category, status, maps_url, photo_url.",
         )
+
+    def test_enrich_place_job_preserves_valid_previous_address_when_refresh_loses_it(self) -> None:
+        previous_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="Tropical Taste, Tonga",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="Tropical Taste",
+                formatted_address="VQ4V+29M, Nuku'alofa, Tonga",
+                rating=4.6,
+            ),
+        )
+        refreshed_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-23T00:00:00+00:00",
+            query="Tropical Taste, Tonga",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="Tropical Taste",
+                primary_type_display_name="Restaurant",
+            ),
+        )
+
+        with (
+            patch.object(build_data, "sleep_for_refresh_startup_jitter"),
+            patch.object(build_data, "fetch_places_enrichment", return_value=refreshed_entry),
+            patch("builtins.print") as print_mock,
+        ):
+            result = build_data.enrich_place_job(
+                "tonga",
+                "cid:111",
+                "Tropical Taste",
+                "forced",
+                {
+                    "name": "Tropical Taste",
+                    "address": "VQ4V+29M, Nuku'alofa, Tonga",
+                    "maps_url": "https://maps.google.com/?cid=111",
+                    "cid": "111",
+                },
+                api_key=None,
+                refresh_startup_jitter_seconds=0,
+                existing_entry=previous_entry,
+            )
+
+        self.assertIs(result, refreshed_entry)
+        assert result.place is not None
+        self.assertEqual(result.place.formatted_address, "VQ4V+29M, Nuku'alofa, Tonga")
+        self.assertEqual(print_mock.call_count, 2)
+        self.assertEqual(
+            print_mock.call_args_list[1].args[0],
+            "WARNING: Preserving previous enrichment fields for tonga:cid:111 [Tropical Taste]: "
+            "rating, address.",
+        )
+
+    def test_enrich_place_job_does_not_preserve_suspicious_previous_address(self) -> None:
+        previous_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="Tropical Taste, Tonga",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="Tropical Taste",
+                formatted_address=(
+                    "The best takeout or eat in I recommend this place. We dropped in 5 minutes "
+                    "before closing time and the owner took the initiative to cook us More"
+                ),
+                rating=4.6,
+            ),
+        )
+        refreshed_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-23T00:00:00+00:00",
+            query="Tropical Taste, Tonga",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="Tropical Taste",
+                primary_type_display_name="Restaurant",
+            ),
+        )
+
+        with (
+            patch.object(build_data, "sleep_for_refresh_startup_jitter"),
+            patch.object(build_data, "fetch_places_enrichment", return_value=refreshed_entry),
+            patch("builtins.print"),
+        ):
+            result = build_data.enrich_place_job(
+                "tonga",
+                "cid:111",
+                "Tropical Taste",
+                "forced",
+                {
+                    "name": "Tropical Taste",
+                    "address": "VQ4V+29M, Nuku'alofa, Tonga",
+                    "maps_url": "https://maps.google.com/?cid=111",
+                    "cid": "111",
+                },
+                api_key=None,
+                refresh_startup_jitter_seconds=0,
+                existing_entry=previous_entry,
+            )
+
+        assert result.place is not None
+        self.assertIsNone(result.place.formatted_address)
 
     def test_enrich_place_job_does_not_preserve_suspicious_old_photo_urls(self) -> None:
         previous_entry = EnrichmentCacheEntry(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -98,7 +98,7 @@ class BuildDataTests(unittest.TestCase):
             patch.object(sys, "argv", ["build_data.py", "--enrich-place", "cid:123"]),
             patch.object(build_data, "sync_local_csv_sources"),
             patch.object(build_data, "enrich_raw_sources") as enrich_raw_sources,
-            patch.object(build_data, "rebuild_generated_data"),
+            patch.object(build_data, "rebuild_generated_data") as rebuild_generated_data,
         ):
             result = build_data.main()
 
@@ -109,6 +109,11 @@ class BuildDataTests(unittest.TestCase):
             place_selectors=["cid:123"],
             refresh_workers=build_data.DEFAULT_REFRESH_WORKERS,
             refresh_startup_jitter_seconds=build_data.DEFAULT_REFRESH_STARTUP_JITTER_SECONDS,
+        )
+        rebuild_generated_data.assert_called_once_with(
+            refresh_photos=False,
+            photo_workers=build_data.DEFAULT_REFRESH_WORKERS,
+            startup_jitter_seconds=build_data.DEFAULT_REFRESH_STARTUP_JITTER_SECONDS,
         )
 
     def test_refresh_generated_guide_photos_skips_artifact_rewrite_when_photo_state_is_unchanged(self) -> None:
@@ -2694,6 +2699,9 @@ class BuildDataTests(unittest.TestCase):
         for address in (
             "Good Burger, 1 Main St, New York, NY 10001",
             "Session Road, Baguio, Benguet 2600, Philippines",
+            "Best Avenue, Oakland, CA 94611",
+            "Dinner Plain, Victoria, Australia",
+            "Port of Spain, Trinidad & Tobago",
         ):
             with self.subTest(address=address):
                 place = build_data.normalize_place_page_enrichment(

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -191,14 +191,28 @@ _PLACE_JS_EXTRACTOR = r"""
     `[data-item-id="${itemId}"]`,
   ]);
 
+  const rowValue = (row) => {
+    const value = row?.querySelector(".DkEaL, .Io6YTe")?.innerText?.trim();
+    return value || null;
+  };
+
+  const isAddressIcon = (icon) => {
+    const label = icon?.getAttribute?.("aria-label") || "";
+    const glyph = icon?.innerText?.trim() || icon?.textContent?.trim() || "";
+    return label === "Address" || glyph === "";
+  };
+
   const addressValue = () => {
     const legacy = itemValue("address");
     if (legacy) {
       return legacy;
     }
-    for (const icon of panel.querySelectorAll('[aria-label="Address"][role="img"]')) {
+    for (const icon of panel.querySelectorAll(".google-symbols, [role='img']")) {
+      if (!isAddressIcon(icon)) {
+        continue;
+      }
       const row = icon.closest(".LCF4w, .MngOvd, .RcCsl, [data-section-id]");
-      const value = row?.querySelector(".DkEaL, .Io6YTe")?.innerText?.trim();
+      const value = rowValue(row);
       if (value && value !== "Address") {
         return value;
       }

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -83,12 +83,19 @@ _ADDRESS_REJECT_SUBSTRINGS = (
     "faviconv2",
     "imagery ©",
     "map data ©",
+    "saved in",
     "send product feedback",
     "street view",
     "termsprivacy",
 )
 _ADDRESS_REJECT_HOST_FRAGMENTS = ("gstatic.com", "googleusercontent.com")
 _ADDRESS_ENTITY_TOKEN_PATTERN = re.compile(r"^/(?:g|m)/[A-Za-z0-9_-]+$")
+_URL_LIKE_PATTERN = re.compile(r"(?:https?://|www\.)", re.IGNORECASE)
+_PROSE_PATTERN = re.compile(
+    r"\b(?:best|good|great|delicious|dropped|experience|lunch|dinner|"
+    r"burger|burgers|nugget|nuggets|owner|recommend|session)\b",
+    re.IGNORECASE,
+)
 _PLACE_JS_EXTRACTOR = r"""
 () => {
   const titleSelectors = ["h1.DUwDvf", "h1.lfPIob", "div[role='main'] h1"];
@@ -183,6 +190,21 @@ _PLACE_JS_EXTRACTOR = r"""
     `[data-item-id="${itemId}"] .Io6YTe`,
     `[data-item-id="${itemId}"]`,
   ]);
+
+  const addressValue = () => {
+    const legacy = itemValue("address");
+    if (legacy) {
+      return legacy;
+    }
+    for (const icon of panel.querySelectorAll('[aria-label="Address"][role="img"]')) {
+      const row = icon.closest(".LCF4w, .MngOvd, .RcCsl, [data-section-id]");
+      const value = row?.querySelector(".DkEaL, .Io6YTe")?.innerText?.trim();
+      if (value && value !== "Address") {
+        return value;
+      }
+    }
+    return null;
+  };
 
   const normalizeCount = (value) => {
     if (!value) {
@@ -302,7 +324,7 @@ _PLACE_JS_EXTRACTOR = r"""
       ".skqShb .fontBodyMedium button",
       "button.DkEaL",
     ]),
-    address: itemValue("address"),
+    address: addressValue(),
     located_in: itemValue("locatedin"),
     status: firstText(["div.OqCZI .ZDu9vd", "div.OqCZI .o0Svhf"]),
     website: firstAttr(["a[data-item-id='authority']"], "href", document) || itemValue("authority"),
@@ -696,11 +718,13 @@ def _clean_address_text(value: object) -> str | None:
         return None
 
     lowered = normalized.lower()
-    if lowered.startswith(("http://", "https://", "www.")):
+    if _URL_LIKE_PATTERN.search(normalized) is not None:
         return None
     if any(fragment in lowered for fragment in _ADDRESS_REJECT_SUBSTRINGS):
         return None
     if any(fragment in lowered for fragment in _ADDRESS_REJECT_HOST_FRAGMENTS):
+        return None
+    if _PROSE_PATTERN.search(normalized) is not None:
         return None
     if _ADDRESS_ENTITY_TOKEN_PATTERN.fullmatch(normalized):
         return None
@@ -827,11 +851,21 @@ def _extract_address_from_lines(lines: list[str]) -> str | None:
 
 def _looks_like_address_line(line: str) -> bool:
     lowered = line.lower()
-    if lowered.startswith(("http://", "https://", "www.")):
+    if _URL_LIKE_PATTERN.search(line) is not None:
+        return False
+    if _PROSE_PATTERN.search(line) is not None:
+        return False
+    if "saved in" in lowered or "report a problem" in lowered:
+        return False
+    if line.endswith(" More"):
         return False
     if _looks_like_status_text(line):
         return False
     if _PHONE_PATTERN.match(line):
+        return False
+    if any(keyword in lowered for keyword in _REVIEW_LABEL_KEYWORDS) and any(
+        character.isdigit() for character in line
+    ):
         return False
     if _PLUS_CODE_PATTERN.search(line):
         return False
@@ -843,10 +877,23 @@ def _looks_like_address_line(line: str) -> bool:
     if _POSTAL_CODE_PATTERN.search(line) and any(character.isalpha() for character in line):
         return True
     if re.search(r"\d", line) is None:
-        return False
+        return _looks_like_locality_address_line(line)
     if "," in line and any(character.isalpha() for character in line):
+        if _ADDRESS_KEYWORD_PATTERN.search(line) is None and len(line.split()) > 10:
+            return False
         return True
     return _ADDRESS_KEYWORD_PATTERN.search(line) is not None
+
+
+def _looks_like_locality_address_line(line: str) -> bool:
+    if re.search(r"[.!?&]", line):
+        return False
+    if len(line.split()) > 8:
+        return False
+    parts = [part.strip() for part in line.split(",") if part.strip()]
+    if not 2 <= len(parts) <= 4:
+        return False
+    return all(any(character.isalpha() for character in part) and len(part) <= 60 for part in parts)
 
 
 def _extract_status_from_lines(lines: list[str]) -> str | None:
@@ -1076,7 +1123,7 @@ def _extract_preview_address(strings: list[str]) -> str | None:
             continue
         if "maps/preview/place" in normalized or normalized.startswith("/g/"):
             continue
-        if _clean_address_text(normalized) is not None:
+        if _clean_address_text(normalized) is not None and _looks_like_address_line(normalized):
             candidates.append(normalized)
     if not candidates:
         return None

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -900,7 +900,7 @@ def _looks_like_address_line(line: str) -> bool:
 
 
 def _looks_like_locality_address_line(line: str) -> bool:
-    if re.search(r"[.!?&]", line):
+    if re.search(r"[.!?]", line):
         return False
     if len(line.split()) > 8:
         return False

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -91,7 +91,7 @@ _ADDRESS_REJECT_SUBSTRINGS = (
 _ADDRESS_REJECT_HOST_FRAGMENTS = ("gstatic.com", "googleusercontent.com")
 _ADDRESS_ENTITY_TOKEN_PATTERN = re.compile(r"^/(?:g|m)/[A-Za-z0-9_-]+$")
 _URL_LIKE_PATTERN = re.compile(r"(?:https?://|www\.)", re.IGNORECASE)
-_PROSE_PATTERN = re.compile(
+_PROSE_TERM_PATTERN = re.compile(
     r"\b(?:best|good|great|delicious|dropped|experience|lunch|dinner|"
     r"burger|burgers|nugget|nuggets|owner|recommend|session)\b",
     re.IGNORECASE,
@@ -738,7 +738,7 @@ def _clean_address_text(value: object) -> str | None:
         return None
     if any(fragment in lowered for fragment in _ADDRESS_REJECT_HOST_FRAGMENTS):
         return None
-    if _PROSE_PATTERN.search(normalized) is not None:
+    if _looks_like_review_snippet(normalized):
         return None
     if _ADDRESS_ENTITY_TOKEN_PATTERN.fullmatch(normalized):
         return None
@@ -867,7 +867,7 @@ def _looks_like_address_line(line: str) -> bool:
     lowered = line.lower()
     if _URL_LIKE_PATTERN.search(line) is not None:
         return False
-    if _PROSE_PATTERN.search(line) is not None:
+    if _looks_like_review_snippet(line):
         return False
     if "saved in" in lowered or "report a problem" in lowered:
         return False
@@ -908,6 +908,30 @@ def _looks_like_locality_address_line(line: str) -> bool:
     if not 2 <= len(parts) <= 4:
         return False
     return all(any(character.isalpha() for character in part) and len(part) <= 60 for part in parts)
+
+
+def _has_address_marker(line: str) -> bool:
+    return (
+        _PLUS_CODE_PATTERN.search(line) is not None
+        or _POSTAL_CODE_PATTERN.search(line) is not None
+        or _ADDRESS_KEYWORD_PATTERN.search(line) is not None
+        or "〒" in line
+        or line.startswith("Japan, ")
+    )
+
+
+def _looks_like_review_snippet(line: str) -> bool:
+    if _has_address_marker(line):
+        return False
+    if line.endswith(" More"):
+        return True
+    terms = _PROSE_TERM_PATTERN.findall(line)
+    word_count = len(line.split())
+    if word_count >= 10 and len(terms) >= 2:
+        return True
+    if word_count >= 10 and re.search(r"[.!?]", line) and terms:
+        return True
+    return False
 
 
 def _extract_status_from_lines(lines: list[str]) -> str | None:

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -78,6 +78,11 @@ _ADDRESS_KEYWORD_PATTERN = re.compile(
     r"court|ct|square|sq|suite|ste|unit|floor|fl|plaza|parkway|pkwy|highway|hwy)\b",
     re.IGNORECASE,
 )
+_STRONG_ADDRESS_KEYWORD_PATTERN = re.compile(
+    r"\b(?:street|st|avenue|ave|road|rd|boulevard|blvd|lane|ln|drive|dr|court|ct|"
+    r"square|sq|suite|ste|unit|floor|fl|plaza|parkway|pkwy|highway|hwy)\b",
+    re.IGNORECASE,
+)
 _ADDRESS_REJECT_SUBSTRINGS = (
     "about this data",
     "faviconv2",
@@ -914,7 +919,7 @@ def _has_address_marker(line: str) -> bool:
     return (
         _PLUS_CODE_PATTERN.search(line) is not None
         or _POSTAL_CODE_PATTERN.search(line) is not None
-        or _ADDRESS_KEYWORD_PATTERN.search(line) is not None
+        or _STRONG_ADDRESS_KEYWORD_PATTERN.search(line) is not None
         or "〒" in line
         or line.startswith("Japan, ")
     )

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -31,6 +31,17 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertIn("root.querySelectorAll(selector)", _PLACE_JS_EXTRACTOR)
         self.assertIn(r"return /(^|\W)reviews?(\W|$)/i.test(label);", _PLACE_JS_EXTRACTOR)
 
+    def test_place_js_extractor_reads_icon_labeled_address_rows(self) -> None:
+        self.assertIn('[aria-label="Address"][role="img"]', _PLACE_JS_EXTRACTOR)
+        self.assertIn('icon.closest(".LCF4w', _PLACE_JS_EXTRACTOR)
+        self.assertIn('row?.querySelector(".DkEaL, .Io6YTe")', _PLACE_JS_EXTRACTOR)
+
+    def test_place_js_extractor_reads_structured_info_rows(self) -> None:
+        self.assertIn("button[jsaction*='category']", _PLACE_JS_EXTRACTOR)
+        self.assertIn("button[data-item-id^='phone:'] .Io6YTe", _PLACE_JS_EXTRACTOR)
+        self.assertIn('plus_code: itemValue("oloc")', _PLACE_JS_EXTRACTOR)
+        self.assertIn("a[data-item-id='authority']", _PLACE_JS_EXTRACTOR)
+
     def test_parse_review_count_handles_suffixes(self) -> None:
         self.assertEqual(_parse_review_count("324"), 324)
         self.assertEqual(_parse_review_count("1,296"), 1296)
@@ -368,6 +379,24 @@ class PlaceScraperTests(unittest.TestCase):
             "26-28 Cotham Rd, Kew VIC 3101, Australia",
         )
 
+    def test_extract_preview_address_rejects_review_snippets(self) -> None:
+        self.assertIsNone(
+            _extract_preview_address(
+                [
+                    (
+                        "The best takeout or eat in I recommend this place. We dropped in 5 minutes "
+                        "before closing time and the owner took the initiative to cook us More"
+                    ),
+                    (
+                        "Fascinating 2 hours session introducing Tonga culture and history, way of life, "
+                        "using plants as herbal cues, medicine and food, traditional weapons and utensils, "
+                        "and more."
+                    ),
+                    "The nuggets are massive, good size burgers and probably the best for value in town",
+                ]
+            )
+        )
+
     def test_normalize_phone_candidate_accepts_long_unformatted_international_numbers(self) -> None:
         self.assertEqual(_normalize_phone_candidate("442071838750"), "442071838750")
 
@@ -566,6 +595,53 @@ class PlaceScraperTests(unittest.TestCase):
         )
 
         self.assertEqual(details.address, "26-28 Cotham Rd, Kew VIC 3101, Australia")
+
+    def test_build_place_details_rejects_fixaddress_urls_in_address_field(self) -> None:
+        details = _build_place_details(
+            "https://www.google.com/maps/place/Nizami+Street",
+            resolved_url="https://www.google.com/maps/place/Nizami+Street",
+            snapshot={
+                "name": "Nizami Street",
+                "category": "Transportation",
+                "address": (
+                    "Address https://www.google.com/local/place/rap/fixaddress?"
+                    "g2lb=72971417,73155522,100805691&hl=en-CA&gl=ca"
+                ),
+                "body_text": "\n".join(
+                    [
+                        "Nizami Street",
+                        "Transportation",
+                        "4.7 ★ · 1.8K reviews",
+                        "Address",
+                    ]
+                ),
+            },
+        )
+
+        self.assertIsNone(details.address)
+
+    def test_build_place_details_accepts_locality_only_address_field(self) -> None:
+        details = _build_place_details(
+            "https://www.google.com/maps/place/Nizami+Street",
+            resolved_url="https://www.google.com/maps/place/Nizami+Street",
+            snapshot={
+                "name": "Nizami St",
+                "category": "Notable street",
+                "address": "Baku, Azerbaijan",
+                "body_text": "\n".join(
+                    [
+                        "Nizami St",
+                        "4.7",
+                        "1,842 reviews",
+                        "Notable street",
+                        "Baku, Azerbaijan",
+                        "Report a problem on Nizami St",
+                    ]
+                ),
+            },
+        )
+
+        self.assertEqual(details.address, "Baku, Azerbaijan")
 
     def test_build_place_details_rejects_invalid_snapshot_plus_code_and_falls_back_to_lines(self) -> None:
         details = _build_place_details(

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -36,10 +36,12 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertIn("if (legacy) {", _PLACE_JS_EXTRACTOR)
         self.assertIn('`[data-item-id="${itemId}"] .Io6YTe`', _PLACE_JS_EXTRACTOR)
 
-    def test_place_js_extractor_falls_back_to_icon_labeled_address_rows(self) -> None:
-        self.assertIn('[aria-label="Address"][role="img"]', _PLACE_JS_EXTRACTOR)
+    def test_place_js_extractor_falls_back_to_address_icon_rows(self) -> None:
+        self.assertIn('const isAddressIcon = (icon) => {', _PLACE_JS_EXTRACTOR)
+        self.assertIn('glyph === ""', _PLACE_JS_EXTRACTOR)
+        self.assertIn('panel.querySelectorAll(".google-symbols, [role=', _PLACE_JS_EXTRACTOR)
         self.assertIn('icon.closest(".LCF4w', _PLACE_JS_EXTRACTOR)
-        self.assertIn('row?.querySelector(".DkEaL, .Io6YTe")', _PLACE_JS_EXTRACTOR)
+        self.assertIn('const rowValue = (row) => {', _PLACE_JS_EXTRACTOR)
 
     def test_place_js_extractor_reads_structured_info_rows(self) -> None:
         self.assertIn("button[jsaction*='category']", _PLACE_JS_EXTRACTOR)

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -31,7 +31,12 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertIn("root.querySelectorAll(selector)", _PLACE_JS_EXTRACTOR)
         self.assertIn(r"return /(^|\W)reviews?(\W|$)/i.test(label);", _PLACE_JS_EXTRACTOR)
 
-    def test_place_js_extractor_reads_icon_labeled_address_rows(self) -> None:
+    def test_place_js_extractor_prefers_data_item_address_rows(self) -> None:
+        self.assertIn('const legacy = itemValue("address");', _PLACE_JS_EXTRACTOR)
+        self.assertIn("if (legacy) {", _PLACE_JS_EXTRACTOR)
+        self.assertIn('`[data-item-id="${itemId}"] .Io6YTe`', _PLACE_JS_EXTRACTOR)
+
+    def test_place_js_extractor_falls_back_to_icon_labeled_address_rows(self) -> None:
         self.assertIn('[aria-label="Address"][role="img"]', _PLACE_JS_EXTRACTOR)
         self.assertIn('icon.closest(".LCF4w', _PLACE_JS_EXTRACTOR)
         self.assertIn('row?.querySelector(".DkEaL, .Io6YTe")', _PLACE_JS_EXTRACTOR)

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -400,6 +400,7 @@ class PlaceScraperTests(unittest.TestCase):
                         "and more."
                     ),
                     "The nuggets are massive, good size burgers and probably the best for value in town",
+                    "This place has great food, good service, friendly owner, and delicious burgers",
                 ]
             )
         )

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -404,6 +404,21 @@ class PlaceScraperTests(unittest.TestCase):
             )
         )
 
+    def test_extract_preview_address_keeps_addresses_with_prose_words(self) -> None:
+        self.assertEqual(
+            _extract_preview_address(
+                [
+                    "Good Burger, 1 Main St, New York, NY 10001",
+                    "The nuggets are massive, good size burgers and probably the best for value in town",
+                ]
+            ),
+            "Good Burger, 1 Main St, New York, NY 10001",
+        )
+        self.assertEqual(
+            _extract_preview_address(["Session Road, Baguio, Benguet 2600, Philippines"]),
+            "Session Road, Baguio, Benguet 2600, Philippines",
+        )
+
     def test_normalize_phone_candidate_accepts_long_unformatted_international_numbers(self) -> None:
         self.assertEqual(_normalize_phone_candidate("442071838750"), "442071838750")
 

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -418,6 +418,18 @@ class PlaceScraperTests(unittest.TestCase):
             _extract_preview_address(["Session Road, Baguio, Benguet 2600, Philippines"]),
             "Session Road, Baguio, Benguet 2600, Philippines",
         )
+        self.assertEqual(
+            _extract_preview_address(["Best Avenue, Oakland, CA 94611"]),
+            "Best Avenue, Oakland, CA 94611",
+        )
+        self.assertEqual(
+            _extract_preview_address(["Dinner Plain, Victoria, Australia"]),
+            "Dinner Plain, Victoria, Australia",
+        )
+        self.assertEqual(
+            _extract_preview_address(["Port of Spain, Trinidad & Tobago"]),
+            "Port of Spain, Trinidad & Tobago",
+        )
 
     def test_normalize_phone_candidate_accepts_long_unformatted_international_numbers(self) -> None:
         self.assertEqual(_normalize_phone_candidate("442071838750"), "442071838750")


### PR DESCRIPTION
## Summary

- Reject bogus Google Maps place-page address values such as `fixaddress` URLs, saved-list rows, and review prose.
- Add targeted enrichment with `--enrich-place`, including explicit `guide-slug:<slug>` targeting.
- Harden phone and plus-code normalization before values are written to the enrichment cache.
- Update the vendored scraper extraction logic to prefer structural Google Maps info-panel fields and make preview fallback address extraction stricter.

## Validation

- `PYTHONPATH=vendor/gmaps-scraper/src uv run python -m unittest vendor.gmaps-scraper.tests.test_place_scraper`
- `uv run python3 -m unittest tests.python.test_build_data.BuildDataTests.test_enrich_raw_sources_filters_to_selected_place tests.python.test_build_data.BuildDataTests.test_enrich_raw_sources_does_not_match_bare_guide_slug_as_place tests.python.test_build_data.BuildDataTests.test_enrich_raw_sources_matches_explicit_guide_slug_selector tests.python.test_build_data.BuildDataTests.test_normalize_place_page_enrichment_rejects_fixaddress_url_addresses tests.python.test_build_data.BuildDataTests.test_normalize_place_page_enrichment_rejects_review_prose_as_address tests.python.test_build_data.BuildDataTests.test_normalize_place_page_enrichment_rejects_long_review_snippet_as_address tests.python.test_build_data.BuildDataTests.test_normalize_place_page_enrichment_accepts_locality_only_address tests.python.test_build_data.BuildDataTests.test_normalize_place_page_enrichment_rejects_saved_list_row_as_address tests.python.test_build_data.BuildDataTests.test_normalize_place_page_enrichment_sanitizes_phone_and_plus_code tests.python.test_build_data.BuildDataTests.test_normalize_place_page_enrichment_rejects_invalid_phone_and_plus_code tests.python.test_build_data.BuildDataTests.test_enrich_place_job_preserves_valid_previous_address_when_refresh_loses_it tests.python.test_build_data.BuildDataTests.test_enrich_place_job_does_not_preserve_suspicious_previous_address`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added selective place enrichment option to target specific locations for data refresh
  * Enhanced address information preservation across enrichment cycles

* **Bug Fixes**
  * Strengthened validation of place addresses, phone numbers, and location codes with improved heuristics
  * Improved detection and handling of malformed or review-like data patterns
  * Better preservation of cached address data when refreshing enrichment sources

* **Tests**
  * Added comprehensive test coverage for enrichment workflows and data validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->