### PR TITLE
[codex] Harden targeted enrichment follow-ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
+          version: "0.11.6"
           enable-cache: true
 
       - name: Install Python dependencies
@@ -146,6 +147,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
+          version: "0.11.6"
           enable-cache: true
 
       - name: Install frontend dependencies

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -182,6 +182,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
+          version: "0.11.6"
           enable-cache: true
 
       - name: Install frontend dependencies

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6525,6 +6525,34 @@ PLACE_PAGE_ADDRESS_REJECT_SUBSTRINGS = (
 PLACE_PAGE_ADDRESS_REJECT_HOST_FRAGMENTS = ("gstatic.com", "googleusercontent.com")
 PLACE_PAGE_ADDRESS_ENTITY_TOKEN_RE = re.compile(r"^/(?:g|m)/[A-Za-z0-9_-]+$")
 PLACE_PAGE_URL_LIKE_RE = re.compile(r"(?:https?://|www\.)", re.IGNORECASE)
+PLACE_PAGE_LOCALITY_ABBREVIATION_PERIOD_RE = re.compile(r"(?:\bSt\.|\b[A-Z]\.(?:[A-Z]\.)+)")
+PLACE_PAGE_LOCALITY_ADDRESS_REJECT_VALUES = {
+    "art gallery",
+    "bakery",
+    "bar",
+    "cafe",
+    "coffee shop",
+    "curbside pickup",
+    "delivery",
+    "dessert shop",
+    "dine-in",
+    "dine in",
+    "drive-through",
+    "drive through",
+    "hotel",
+    "ice cream shop",
+    "kerbside pickup",
+    "museum",
+    "no-contact delivery",
+    "outdoor seating",
+    "restaurant",
+    "shop",
+    "shopping mall",
+    "store",
+    "takeaway",
+    "takeout",
+    "tourist attraction",
+}
 PLACE_PAGE_PROSE_TERM_RE = re.compile(
     r"\b(?:best|good|great|delicious|dropped|experience|lunch|dinner|"
     r"burger|burgers|nugget|nuggets|owner|recommend|session)\b",
@@ -6571,7 +6599,11 @@ def sanitize_place_page_formatted_address(value: Any) -> str | None:
         return None
     if normalized.endswith(" More"):
         return None
-    if normalized.endswith(".") and re.search(r"\b[23456789CFGHJMPQRVWX]{4,8}\+[23456789CFGHJMPQRVWX]{2,3}\b", normalized) is None:
+    if (
+        normalized.endswith(".")
+        and re.search(r"\b[23456789CFGHJMPQRVWX]{4,8}\+[23456789CFGHJMPQRVWX]{2,3}\b", normalized) is None
+        and not looks_like_place_page_locality_address(normalized)
+    ):
         return None
 
     if "·" in normalized:
@@ -6642,15 +6674,37 @@ def looks_like_place_page_formatted_address(value: str) -> bool:
     if PLACE_PAGE_ADDRESS_KEYWORD_RE.search(value) and len(value.split()) <= 5:
         return True
 
+    return looks_like_place_page_locality_address(value)
+
+
+def looks_like_place_page_locality_address(value: str) -> bool:
+    if re.search(r"[!?]", value):
+        return False
     locality_separator = " - " if " - " in value else ","
     locality_parts = [part.strip() for part in value.split(locality_separator) if part.strip()]
-    if len(locality_parts) >= 3 and not re.search(r"[.!?]", value):
+    max_words = 12 if locality_separator == " - " else 8
+    if sum(len(part.split()) for part in locality_parts) > max_words:
+        return False
+    max_parts = 6 if locality_separator == " - " else 4
+    if not 2 <= len(locality_parts) <= max_parts:
+        return False
+    if not all(place_page_locality_part_allows_period(part) for part in locality_parts):
+        return False
+    if all(place_page_locality_address_reject_key(part) in PLACE_PAGE_LOCALITY_ADDRESS_REJECT_VALUES for part in locality_parts):
+        return False
+    return all(any(character.isalpha() for character in part) and len(part) <= 60 for part in locality_parts)
+
+
+def place_page_locality_part_allows_period(part: str) -> bool:
+    if "." not in part:
         return True
-    if locality_separator == "," and 2 <= len(locality_parts) <= 4 and not re.search(r"[.!?]", value):
-        if len(value.split()) > 8:
-            return False
-        return all(any(character.isalpha() for character in part) and len(part) <= 60 for part in locality_parts)
-    return False
+    if PLACE_PAGE_LOCALITY_ABBREVIATION_PERIOD_RE.fullmatch(part):
+        return True
+    return part.startswith("St. ") and len(part.split()) <= 3
+
+
+def place_page_locality_address_reject_key(part: str) -> str:
+    return part.casefold().strip(" .")
 
 
 def has_place_page_address_marker(value: str) -> bool:
@@ -7079,8 +7133,10 @@ def place_selector_matches(
         place.name,
         place.maps_url,
         place.cid,
+        extract_maps_cid(place.maps_url),
         place.google_id,
         place.maps_place_token,
+        extract_maps_place_token(place.maps_url),
     ):
         normalized = as_string(candidate.casefold() if isinstance(candidate, str) else candidate)
         if normalized is None:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2736,6 +2736,54 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertEqual(place.formatted_address, "Baku, Azerbaijan")
 
+    def test_normalize_place_page_enrichment_rejects_service_options_as_address(self) -> None:
+        for address in (
+            "Dine-in, Takeout, Delivery",
+            "Dine-in, Takeout, Delivery.",
+            "Takeout, Delivery, Curbside pickup",
+            "Museum, Art gallery",
+            "Friendly staff, good coffee.",
+            "Great food at St. James, highly recommend.",
+        ):
+            with self.subTest(address=address):
+                place = build_data.normalize_place_page_enrichment(
+                    SimpleNamespace(
+                        source_url="https://www.google.com/maps/place/Test",
+                        resolved_url="https://www.google.com/maps/place/Test",
+                        name="Test",
+                        category="Restaurant",
+                        rating=4.6,
+                        review_count=101,
+                        address=address,
+                        limited_view=False,
+                    )
+                )
+
+                self.assertIsNone(place.formatted_address)
+
+    def test_normalize_place_page_enrichment_keeps_locality_abbreviations(self) -> None:
+        for address in (
+            "St. Louis, MO",
+            "St. John's, NL",
+            "Washington, D.C.",
+            "Jumeirah Beach - Jumeirah - Jumeira Third - Dubai - United Arab Emirates",
+        ):
+            with self.subTest(address=address):
+                place = build_data.normalize_place_page_enrichment(
+                    SimpleNamespace(
+                        source_url="https://www.google.com/maps/place/Test",
+                        resolved_url="https://www.google.com/maps/place/Test",
+                        name="Test",
+                        category="Locality",
+                        rating=4.6,
+                        review_count=101,
+                        address=address,
+                        limited_view=False,
+                    )
+                )
+
+                self.assertEqual(place.formatted_address, address)
+
     def test_normalize_place_page_enrichment_rejects_saved_list_row_as_address(self) -> None:
         place = build_data.normalize_place_page_enrichment(
             SimpleNamespace(
@@ -4759,6 +4807,54 @@ class BuildDataTests(unittest.TestCase):
             places=[
                 RawPlace(name="First Place", maps_url="https://maps.google.com/?cid=111", cid="111"),
                 RawPlace(name="Second Place", maps_url="https://maps.google.com/?cid=222", cid="222"),
+            ],
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            raw_dir = tmpdir_path / "raw"
+            cache_dir = tmpdir_path / "cache"
+            db_path = tmpdir_path / "places.sqlite"
+            raw_dir.mkdir()
+            cache_dir.mkdir()
+            (raw_dir / "tokyo-japan.json").write_text(
+                json.dumps(raw.model_dump(mode="json"), ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            seen_places: list[str] = []
+
+            def fake_enrich_place_job(_slug, _place_id, place_name, _refresh_reason, _place_payload, **_kwargs):
+                seen_places.append(place_name)
+                return EnrichmentCacheEntry(
+                    fetched_at="2026-04-20T00:00:00+00:00",
+                    query=place_name,
+                    matched=True,
+                    place=EnrichmentPlace(display_name=place_name),
+                )
+
+            with (
+                patch.object(build_data, "RAW_DIR", raw_dir),
+                patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
+                patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
+                patch.object(build_data, "google_places_api_key", return_value=None),
+                patch.object(build_data, "enrich_place_job", side_effect=fake_enrich_place_job),
+            ):
+                build_data.enrich_raw_sources(
+                    force_refresh=True,
+                    place_selectors=["222"],
+                    refresh_workers=1,
+                    refresh_startup_jitter_seconds=0,
+                )
+
+            self.assertEqual(seen_places, ["Second Place"])
+
+    def test_enrich_raw_sources_matches_cid_derived_from_maps_url(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo",
+            places=[
+                RawPlace(name="First Place", maps_url="https://maps.google.com/?cid=111"),
+                RawPlace(name="Second Place", maps_url="https://maps.google.com/?cid=222"),
             ],
         )
 

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -93,9 +93,37 @@ _ADDRESS_REJECT_SUBSTRINGS = (
     "street view",
     "termsprivacy",
 )
+_LOCALITY_ADDRESS_REJECT_VALUES = {
+    "art gallery",
+    "bakery",
+    "bar",
+    "cafe",
+    "coffee shop",
+    "curbside pickup",
+    "delivery",
+    "dessert shop",
+    "dine-in",
+    "dine in",
+    "drive-through",
+    "drive through",
+    "hotel",
+    "ice cream shop",
+    "kerbside pickup",
+    "museum",
+    "no-contact delivery",
+    "outdoor seating",
+    "restaurant",
+    "shop",
+    "shopping mall",
+    "store",
+    "takeaway",
+    "takeout",
+    "tourist attraction",
+}
 _ADDRESS_REJECT_HOST_FRAGMENTS = ("gstatic.com", "googleusercontent.com")
 _ADDRESS_ENTITY_TOKEN_PATTERN = re.compile(r"^/(?:g|m)/[A-Za-z0-9_-]+$")
 _URL_LIKE_PATTERN = re.compile(r"(?:https?://|www\.)", re.IGNORECASE)
+_LOCALITY_ABBREVIATION_PERIOD_PATTERN = re.compile(r"(?:\bSt\.|\b[A-Z]\.(?:[A-Z]\.)+)")
 _PROSE_TERM_PATTERN = re.compile(
     r"\b(?:best|good|great|delicious|dropped|experience|lunch|dinner|"
     r"burger|burgers|nugget|nuggets|owner|recommend|session)\b",
@@ -751,7 +779,11 @@ def _clean_address_text(value: object) -> str | None:
         character.isdigit() for character in normalized
     ):
         return None
-    if normalized.endswith(".") and _PLUS_CODE_PATTERN.search(normalized) is None:
+    if (
+        normalized.endswith(".")
+        and _PLUS_CODE_PATTERN.search(normalized) is None
+        and not _looks_like_locality_address_line(normalized)
+    ):
         return None
 
     if "·" in normalized:
@@ -905,14 +937,30 @@ def _looks_like_address_line(line: str) -> bool:
 
 
 def _looks_like_locality_address_line(line: str) -> bool:
-    if re.search(r"[.!?]", line):
+    if re.search(r"[!?]", line):
         return False
     if len(line.split()) > 8:
         return False
     parts = [part.strip() for part in line.split(",") if part.strip()]
     if not 2 <= len(parts) <= 4:
         return False
+    if not all(_locality_part_allows_period(part) for part in parts):
+        return False
+    if all(_locality_address_reject_key(part) in _LOCALITY_ADDRESS_REJECT_VALUES for part in parts):
+        return False
     return all(any(character.isalpha() for character in part) and len(part) <= 60 for part in parts)
+
+
+def _locality_part_allows_period(part: str) -> bool:
+    if "." not in part:
+        return True
+    if _LOCALITY_ABBREVIATION_PERIOD_PATTERN.fullmatch(part):
+        return True
+    return part.startswith("St. ") and len(part.split()) <= 3
+
+
+def _locality_address_reject_key(part: str) -> str:
+    return part.casefold().strip(" .")
 
 
 def _has_address_marker(line: str) -> bool:

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -405,6 +405,19 @@ class PlaceScraperTests(unittest.TestCase):
             )
         )
 
+    def test_extract_preview_address_rejects_service_option_lists(self) -> None:
+        self.assertIsNone(_extract_preview_address(["Dine-in, Takeout, Delivery"]))
+        self.assertIsNone(_extract_preview_address(["Dine-in, Takeout, Delivery."]))
+        self.assertIsNone(_extract_preview_address(["Takeout, Delivery, Curbside pickup"]))
+        self.assertIsNone(_extract_preview_address(["Museum, Art gallery"]))
+        self.assertIsNone(_extract_preview_address(["Friendly staff, good coffee."]))
+        self.assertIsNone(_extract_preview_address(["Great food at St. James, highly recommend."]))
+
+    def test_extract_preview_address_keeps_locality_abbreviations(self) -> None:
+        self.assertEqual(_extract_preview_address(["St. Louis, MO"]), "St. Louis, MO")
+        self.assertEqual(_extract_preview_address(["St. John's, NL"]), "St. John's, NL")
+        self.assertEqual(_extract_preview_address(["Washington, D.C."]), "Washington, D.C.")
+
     def test_extract_preview_address_keeps_addresses_with_prose_words(self) -> None:
         self.assertEqual(
             _extract_preview_address(


### PR DESCRIPTION
## Summary

- Match `--enrich-place` selectors against CIDs and Maps place tokens derived from `maps_url`.
- Reject service-option and category-list strings in locality-style address fallbacks while preserving real locality abbreviations.
- Pin `setup-uv` in CI/data-refresh so validation does not depend on GitHub's latest-release API.
- Add focused regression coverage for selector and address-sanitization cases.

## Validation

- `PYTHONPATH=vendor/gmaps-scraper/src uv run python -m unittest vendor.gmaps-scraper.tests.test_place_scraper`
- `uv run python3 -m unittest tests.python.test_build_data.BuildDataTests.test_enrich_raw_sources_filters_to_selected_place tests.python.test_build_data.BuildDataTests.test_enrich_raw_sources_matches_cid_derived_from_maps_url tests.python.test_build_data.BuildDataTests.test_enrich_raw_sources_does_not_match_bare_guide_slug_as_place`
- `uv run python3 -m unittest tests.python.test_build_data.BuildDataTests.test_normalize_place_page_enrichment_rejects_service_options_as_address tests.python.test_build_data.BuildDataTests.test_normalize_place_page_enrichment_keeps_locality_abbreviations tests.python.test_build_data.BuildDataTests.test_normalize_place_page_enrichment_accepts_locality_only_address tests.python.test_build_data.BuildDataTests.test_enrich_place_job_preserves_valid_previous_address_when_refresh_loses_it tests.python.test_build_data.BuildDataTests.test_enrich_place_job_does_not_preserve_suspicious_previous_address tests.python.test_build_data.BuildDataTests.test_enrich_raw_sources_matches_cid_derived_from_maps_url`
