### PR TITLE
[codex] Reject mixed UI locality fallbacks

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -356,6 +356,7 @@ COUNTRY_LOCALITY_ALIASES = (
     "Taiwan",
     "台灣",
     "台湾",
+    "Trinidad & Tobago",
     "Spain",
     "España",
     "Espanya",
@@ -6545,6 +6546,7 @@ PLACE_PAGE_LOCALITY_ADDRESS_REJECT_VALUES = {
     "museum",
     "no-contact delivery",
     "outdoor seating",
+    "reservations",
     "restaurant",
     "shop",
     "shopping mall",
@@ -6552,10 +6554,11 @@ PLACE_PAGE_LOCALITY_ADDRESS_REJECT_VALUES = {
     "takeaway",
     "takeout",
     "tourist attraction",
+    "wheelchair accessible entrance",
 }
 PLACE_PAGE_PROSE_TERM_RE = re.compile(
     r"\b(?:best|good|great|delicious|dropped|experience|lunch|dinner|"
-    r"burger|burgers|nugget|nuggets|owner|recommend|session)\b",
+    r"burger|burgers|coffee|food|friendly|nugget|nuggets|owner|recommend|session)\b",
     re.IGNORECASE,
 )
 PLACE_PAGE_PLUS_CODE_RE = re.compile(
@@ -6624,6 +6627,8 @@ def looks_like_place_page_review_snippet(value: str) -> bool:
         return True
     terms = PLACE_PAGE_PROSE_TERM_RE.findall(value)
     word_count = len(value.split())
+    if "," in value and len(terms) >= 2:
+        return True
     if word_count >= 10 and len(terms) >= 2:
         return True
     if word_count >= 10 and re.search(r"[.!?]", value) and terms:
@@ -6690,7 +6695,11 @@ def looks_like_place_page_locality_address(value: str) -> bool:
         return False
     if not all(place_page_locality_part_allows_period(part) for part in locality_parts):
         return False
-    if all(place_page_locality_address_reject_key(part) in PLACE_PAGE_LOCALITY_ADDRESS_REJECT_VALUES for part in locality_parts):
+    reject_count = sum(
+        place_page_locality_address_reject_key(part) in PLACE_PAGE_LOCALITY_ADDRESS_REJECT_VALUES
+        for part in locality_parts
+    )
+    if reject_count >= 2:
         return False
     return all(any(character.isalpha() for character in part) and len(part) <= 60 for part in locality_parts)
 
@@ -7133,16 +7142,27 @@ def place_selector_matches(
         place.name,
         place.maps_url,
         place.cid,
-        extract_maps_cid(place.maps_url),
         place.google_id,
         place.maps_place_token,
-        extract_maps_place_token(place.maps_url),
     ):
         normalized = as_string(candidate.casefold() if isinstance(candidate, str) else candidate)
         if normalized is None:
             continue
         values.add(normalized)
         values.add(f"{slug}:{normalized}".casefold())
+    for prefix, candidate in (
+        ("cid", place.cid),
+        ("cid", extract_maps_cid(place.maps_url)),
+        ("gms", place.maps_place_token),
+        ("gms", extract_maps_place_token(place.maps_url)),
+    ):
+        normalized = as_string(candidate.casefold() if isinstance(candidate, str) else candidate)
+        if normalized is None:
+            continue
+        values.add(normalized)
+        values.add(f"{prefix}:{normalized}".casefold())
+        values.add(f"{slug}:{normalized}".casefold())
+        values.add(f"{slug}:{prefix}:{normalized}".casefold())
     return selectors & values
 
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -376,6 +376,7 @@ AUSTRALIAN_SUBNATIONAL_LOCALITY_ALIASES = (
 )
 COUNTRY_LOCALITY_KEYS: set[str] | None = None
 SUBNATIONAL_LOCALITY_KEYS: set[str] | None = None
+SUBNATIONAL_LOCALITY_CODE_KEYS: set[str] | None = None
 LOCATION_TAG_ALIASES: dict[str, tuple[str, ...]] = {
     "geneve": ("geneva",),
     "geneva": ("geneve",),
@@ -1471,7 +1472,8 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Force-refresh enrichment for a specific place selector unless combined with "
             "--enrich or --enrich-missing. Repeat to target multiple places. "
-            "Matches exact place ids, CIDs, names, Maps URLs, and `guide-slug:<selector>` forms."
+            "Matches exact place ids, CIDs, names, Maps URLs, `cid:<value>`/`gms:<value>` "
+            "aliases, and `guide-slug:<selector>` forms."
         ),
     )
     parser.add_argument(
@@ -3937,6 +3939,10 @@ def is_subnational_locality(candidate: str) -> bool:
     return normalize_locality_key(candidate) in get_subnational_locality_keys()
 
 
+def is_subnational_code_locality(candidate: str) -> bool:
+    return candidate.strip().casefold() in get_subnational_locality_code_keys()
+
+
 def get_subnational_locality_keys() -> set[str]:
     global SUBNATIONAL_LOCALITY_KEYS
     if SUBNATIONAL_LOCALITY_KEYS is not None:
@@ -3955,6 +3961,25 @@ def get_subnational_locality_keys() -> set[str]:
         if normalize_locality_key(name)
     }
     return SUBNATIONAL_LOCALITY_KEYS
+
+
+def get_subnational_locality_code_keys() -> set[str]:
+    global SUBNATIONAL_LOCALITY_CODE_KEYS
+    if SUBNATIONAL_LOCALITY_CODE_KEYS is not None:
+        return SUBNATIONAL_LOCALITY_CODE_KEYS
+
+    code_keys: set[str] = set()
+    for subdivision in pycountry.subdivisions:
+        code = getattr(subdivision, "code", None)
+        if not code or "-" not in code:
+            continue
+        suffix = code.rsplit("-", 1)[-1]
+        if 2 <= len(suffix) <= 3 and suffix.isalpha():
+            code_keys.add(suffix.casefold())
+    code_keys.update(code.casefold() for code in AUSTRALIAN_SUBNATIONAL_LOCALITY_ALIASES)
+
+    SUBNATIONAL_LOCALITY_CODE_KEYS = code_keys
+    return SUBNATIONAL_LOCALITY_CODE_KEYS
 
 
 def is_subcity_locality(candidate: str) -> bool:
@@ -6703,13 +6728,22 @@ def looks_like_place_page_locality_address(value: str) -> bool:
         return False
     if not all(place_page_locality_part_allows_period(part) for part in locality_parts):
         return False
-    reject_count = sum(
-        place_page_locality_address_reject_key(part) in PLACE_PAGE_LOCALITY_ADDRESS_REJECT_VALUES
+    reject_keys = {
+        key
         for part in locality_parts
-    )
-    # One segment can be a real place name ("Bar, Montenegro"). Two or more UI
-    # labels are a strong signal this is a Google service/accessibility row.
-    if reject_count >= 2:
+        if (key := place_page_locality_address_reject_key(part)) in PLACE_PAGE_LOCALITY_ADDRESS_REJECT_VALUES
+    }
+    # A reject word can also be a real locality ("Bar, Montenegro"). Keep it
+    # only when that same segment is a known geography; otherwise category rows
+    # like "Museum, Montenegro" or "Hotel, Spain" are still UI text, not
+    # addresses.
+    geography_reject_keys = {
+        place_page_locality_address_reject_key(part)
+        for part in locality_parts
+        if place_page_locality_address_reject_key(part) in reject_keys
+        and has_place_page_locality_geo_signal_part(part)
+    }
+    if reject_keys - geography_reject_keys:
         return False
     if not has_place_page_locality_geo_signal(locality_parts):
         return False
@@ -6719,13 +6753,22 @@ def looks_like_place_page_locality_address(value: str) -> bool:
 def has_place_page_locality_geo_signal(parts: Sequence[str]) -> bool:
     """Return True when the trailing locality chain names a known geography."""
     for part in parts[1:]:
-        if is_country_locality(part) or is_subnational_locality(part):
-            return True
-        if PLACE_PAGE_LOCALITY_ABBREVIATION_PERIOD_RE.fullmatch(part):
-            return True
-        if PLACE_PAGE_REGION_CODE_RE.fullmatch(part.strip()):
+        if has_place_page_locality_geo_signal_part(part):
             return True
     return False
+
+
+def has_place_page_locality_geo_signal_part(part: str) -> bool:
+    if is_country_locality(part) or is_subnational_locality(part):
+        return True
+    if PLACE_PAGE_LOCALITY_ABBREVIATION_PERIOD_RE.fullmatch(part):
+        return True
+    if PLACE_PAGE_REGION_CODE_RE.fullmatch(part.strip()) and is_subnational_code_locality(part):
+        return True
+    # Google can still return localized country/subdivision names despite
+    # hl=en. Non-ASCII trailing geography text is a safer signal than accepting
+    # arbitrary ASCII prose or unknown uppercase tokens such as "XYZ".
+    return any(character.isalpha() and not character.isascii() for character in part)
 
 
 def place_page_locality_part_allows_period(part: str) -> bool:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6527,6 +6527,7 @@ PLACE_PAGE_ADDRESS_REJECT_HOST_FRAGMENTS = ("gstatic.com", "googleusercontent.co
 PLACE_PAGE_ADDRESS_ENTITY_TOKEN_RE = re.compile(r"^/(?:g|m)/[A-Za-z0-9_-]+$")
 PLACE_PAGE_URL_LIKE_RE = re.compile(r"(?:https?://|www\.)", re.IGNORECASE)
 PLACE_PAGE_LOCALITY_ABBREVIATION_PERIOD_RE = re.compile(r"(?:\bSt\.|\b[A-Z]\.(?:[A-Z]\.)+)")
+PLACE_PAGE_REGION_CODE_RE = re.compile(r"[A-Z]{2,3}")
 PLACE_PAGE_LOCALITY_ADDRESS_REJECT_VALUES = {
     "art gallery",
     "bakery",
@@ -6683,6 +6684,13 @@ def looks_like_place_page_formatted_address(value: str) -> bool:
 
 
 def looks_like_place_page_locality_address(value: str) -> bool:
+    """Accept locality-only addresses only when they have a geographic anchor.
+
+    The scraper uses structured Google Maps address rows first. This sanitizer
+    also sees legacy/plain-text payloads, so locality-only fallbacks must be
+    narrower than "short comma-separated phrase"; otherwise review snippets and
+    service-option rows can become cached addresses.
+    """
     if re.search(r"[!?]", value):
         return False
     locality_separator = " - " if " - " in value else ","
@@ -6699,9 +6707,25 @@ def looks_like_place_page_locality_address(value: str) -> bool:
         place_page_locality_address_reject_key(part) in PLACE_PAGE_LOCALITY_ADDRESS_REJECT_VALUES
         for part in locality_parts
     )
+    # One segment can be a real place name ("Bar, Montenegro"). Two or more UI
+    # labels are a strong signal this is a Google service/accessibility row.
     if reject_count >= 2:
         return False
+    if not has_place_page_locality_geo_signal(locality_parts):
+        return False
     return all(any(character.isalpha() for character in part) and len(part) <= 60 for part in locality_parts)
+
+
+def has_place_page_locality_geo_signal(parts: Sequence[str]) -> bool:
+    """Return True when the trailing locality chain names a known geography."""
+    for part in parts[1:]:
+        if is_country_locality(part) or is_subnational_locality(part):
+            return True
+        if PLACE_PAGE_LOCALITY_ABBREVIATION_PERIOD_RE.fullmatch(part):
+            return True
+        if PLACE_PAGE_REGION_CODE_RE.fullmatch(part.strip()):
+            return True
+    return False
 
 
 def place_page_locality_part_allows_period(part: str) -> bool:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2744,6 +2744,9 @@ class BuildDataTests(unittest.TestCase):
             "Takeout, Delivery, Curbside pickup",
             "Wheelchair accessible entrance, Dine-in, Takeout",
             "Museum, Art gallery",
+            "Museum, Montenegro",
+            "Hotel, Spain",
+            "Friendly, XYZ",
             "good food, friendly owner",
             "Friendly staff, good coffee.",
             "Great food at St. James, highly recommend.",
@@ -2770,6 +2773,8 @@ class BuildDataTests(unittest.TestCase):
             "St. John's, NL",
             "Washington, D.C.",
             "Bar, Montenegro",
+            "Bar, Bar, Montenegro",
+            "東京, 日本",
             "Port of Spain, Trinidad & Tobago",
             "Jumeirah Beach - Jumeirah - Jumeira Third - Dubai - United Arab Emirates",
         ):

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2740,8 +2740,11 @@ class BuildDataTests(unittest.TestCase):
         for address in (
             "Dine-in, Takeout, Delivery",
             "Dine-in, Takeout, Delivery.",
+            "Dine-in, Takeout, Reservations",
             "Takeout, Delivery, Curbside pickup",
+            "Wheelchair accessible entrance, Dine-in, Takeout",
             "Museum, Art gallery",
+            "good food, friendly owner",
             "Friendly staff, good coffee.",
             "Great food at St. James, highly recommend.",
         ):
@@ -2766,6 +2769,8 @@ class BuildDataTests(unittest.TestCase):
             "St. Louis, MO",
             "St. John's, NL",
             "Washington, D.C.",
+            "Bar, Montenegro",
+            "Port of Spain, Trinidad & Tobago",
             "Jumeirah Beach - Jumeirah - Jumeira Third - Dubai - United Arab Emirates",
         ):
             with self.subTest(address=address):
@@ -4854,7 +4859,11 @@ class BuildDataTests(unittest.TestCase):
             title="Tokyo",
             places=[
                 RawPlace(name="First Place", maps_url="https://maps.google.com/?cid=111"),
-                RawPlace(name="Second Place", maps_url="https://maps.google.com/?cid=222"),
+                RawPlace(
+                    name="Second Place",
+                    google_id="/g/second",
+                    maps_url="https://maps.google.com/?cid=222",
+                ),
             ],
         )
 
@@ -4891,6 +4900,62 @@ class BuildDataTests(unittest.TestCase):
                 build_data.enrich_raw_sources(
                     force_refresh=True,
                     place_selectors=["cid:222"],
+                    refresh_workers=1,
+                    refresh_startup_jitter_seconds=0,
+                )
+
+            self.assertEqual(seen_places, ["Second Place"])
+
+    def test_enrich_raw_sources_matches_maps_place_token_derived_from_maps_url(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo",
+            places=[
+                RawPlace(
+                    name="First Place",
+                    google_id="/g/first",
+                    maps_url="https://maps.google.com/?q=0x111:0xaaa",
+                ),
+                RawPlace(
+                    name="Second Place",
+                    google_id="/g/second",
+                    maps_url="https://maps.google.com/?q=0x222:0xbbb",
+                ),
+            ],
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            raw_dir = tmpdir_path / "raw"
+            cache_dir = tmpdir_path / "cache"
+            db_path = tmpdir_path / "places.sqlite"
+            raw_dir.mkdir()
+            cache_dir.mkdir()
+            (raw_dir / "tokyo-japan.json").write_text(
+                json.dumps(raw.model_dump(mode="json"), ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            seen_places: list[str] = []
+
+            def fake_enrich_place_job(_slug, _place_id, place_name, _refresh_reason, _place_payload, **_kwargs):
+                seen_places.append(place_name)
+                return EnrichmentCacheEntry(
+                    fetched_at="2026-04-20T00:00:00+00:00",
+                    query=place_name,
+                    matched=True,
+                    place=EnrichmentPlace(display_name=place_name),
+                )
+
+            with (
+                patch.object(build_data, "RAW_DIR", raw_dir),
+                patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
+                patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
+                patch.object(build_data, "google_places_api_key", return_value=None),
+                patch.object(build_data, "enrich_place_job", side_effect=fake_enrich_place_job),
+            ):
+                build_data.enrich_raw_sources(
+                    force_refresh=True,
+                    place_selectors=["gms:0x222:0xbbb"],
                     refresh_workers=1,
                     refresh_startup_jitter_seconds=0,
                 )

--- a/vendor/gmaps-scraper/ARCHITECTURE.md
+++ b/vendor/gmaps-scraper/ARCHITECTURE.md
@@ -1,0 +1,96 @@
+# gmaps-scraper Architecture
+
+## Place Page Extraction Strategy
+
+`gmaps-scraper` treats Google Maps as an unstable HTML application, not a
+stable data API. The extractor therefore prioritizes provenance over simply
+finding text that looks right.
+
+The preferred extraction order is:
+
+1. Structured DOM rows from the loaded Google Maps place page.
+2. Internal preview payloads when the DOM is incomplete or unavailable.
+3. Plain-text fallback from page snapshots as a last resort.
+
+Each lower layer must be more conservative than the layer above it. A fallback
+should prevent obvious bad data from being stored; it should not infer business
+facts from nearby prose.
+
+## Structured DOM Rows
+
+The browser extractor runs in the page and first targets Google Maps detail
+rows. For example, address and website usually appear as `button` or `a`
+elements with `data-item-id` values such as `address`, `authority`, `phone:*`,
+or `oloc`.
+
+This is the strongest source because the row shape says what the value means.
+The extractor may also use stable row structure plus the Google Maps icon glyph
+when labels are localized. It should not depend on English-only `aria-label`
+prefixes such as `Address:` because pages can render localized labels even when
+the requested URL includes `hl=en`.
+
+## Preview Payloads
+
+Preview payloads are Google Maps internal `/maps/preview/place` responses or
+embedded data blobs discovered while loading a place page. They are nested
+JSON-like arrays, not a public schema.
+
+These payloads can contain useful values when the rendered DOM is thin, blocked,
+or only partially available. Because their shape is undocumented, extraction
+from preview payloads should favor strongly typed signals: coordinates, plus
+codes, phone-looking fields, postal addresses, and compact address arrays.
+
+## Legacy Payloads
+
+Legacy payloads are older scraper/cache records or broad page snapshots that do
+not preserve DOM-row provenance. In practice this means fields such as raw body
+text, line lists, or historical `address` strings that were already extracted
+before the current structured row strategy existed.
+
+The sanitizer handles these records so existing downstream caches can be
+refreshed safely. It must be stricter than the structured extractor because it
+cannot tell whether a short line came from an address row, a review, a category
+chip, or a service-option row.
+
+## Address Policy
+
+Address extraction should prefer explicit address rows. A value from a
+structured `data-item-id="address"` row can be accepted even when it is
+locality-only, such as `Baku, Azerbaijan`, because the DOM row provides the
+address meaning.
+
+Plain-text address fallback is intentionally narrow:
+
+- Accept postal-code, plus-code, digit-plus-locality, and street-keyword
+  addresses.
+- Accept locality-only strings only when they are compact and have a geographic
+  signal, such as a country/subdivision name or region abbreviation.
+- Reject URLs, entity tokens, ratings/review counts, status text, phone numbers,
+  service-option rows, categories, and review snippets.
+- Keep plus codes separate from formatted addresses. A plus code can be useful
+  location metadata, but it should not overwrite a real address unless the
+  caller deliberately chooses that fallback.
+
+## Adding Fallbacks
+
+Before adding a regex or denylist entry, prefer a structural extractor change.
+A fallback is appropriate only when there is a fixture showing why structured
+extraction cannot see the value.
+
+New fallback behavior should include:
+
+- A fixture or unit test with the real Google Maps text/HTML shape.
+- A comment explaining which layer it protects and why structural extraction is
+  insufficient.
+- A negative test for nearby UI text that could otherwise be misclassified.
+
+Avoid broad heuristics such as "any short comma-separated phrase is an address".
+Those rules tend to convert reviews like `good food, friendly owner` or service
+options like `Dine-in, Takeout, Delivery` into addresses.
+
+## LLM Use
+
+LLMs can be useful as an offline analysis tool for proposing selectors when
+Google changes the page. They should not run per page in the scraper's normal
+path. The durable output should be deterministic extraction rules plus fixtures
+that can be reviewed, tested, and rerun without model cost or variability.

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -112,6 +112,7 @@ _LOCALITY_ADDRESS_REJECT_VALUES = {
     "museum",
     "no-contact delivery",
     "outdoor seating",
+    "reservations",
     "restaurant",
     "shop",
     "shopping mall",
@@ -119,6 +120,7 @@ _LOCALITY_ADDRESS_REJECT_VALUES = {
     "takeaway",
     "takeout",
     "tourist attraction",
+    "wheelchair accessible entrance",
 }
 _ADDRESS_REJECT_HOST_FRAGMENTS = ("gstatic.com", "googleusercontent.com")
 _ADDRESS_ENTITY_TOKEN_PATTERN = re.compile(r"^/(?:g|m)/[A-Za-z0-9_-]+$")
@@ -126,7 +128,7 @@ _URL_LIKE_PATTERN = re.compile(r"(?:https?://|www\.)", re.IGNORECASE)
 _LOCALITY_ABBREVIATION_PERIOD_PATTERN = re.compile(r"(?:\bSt\.|\b[A-Z]\.(?:[A-Z]\.)+)")
 _PROSE_TERM_PATTERN = re.compile(
     r"\b(?:best|good|great|delicious|dropped|experience|lunch|dinner|"
-    r"burger|burgers|nugget|nuggets|owner|recommend|session)\b",
+    r"burger|burgers|coffee|food|friendly|nugget|nuggets|owner|recommend|session)\b",
     re.IGNORECASE,
 )
 _PLACE_JS_EXTRACTOR = r"""
@@ -946,7 +948,7 @@ def _looks_like_locality_address_line(line: str) -> bool:
         return False
     if not all(_locality_part_allows_period(part) for part in parts):
         return False
-    if all(_locality_address_reject_key(part) in _LOCALITY_ADDRESS_REJECT_VALUES for part in parts):
+    if sum(_locality_address_reject_key(part) in _LOCALITY_ADDRESS_REJECT_VALUES for part in parts) >= 2:
         return False
     return all(any(character.isalpha() for character in part) and len(part) <= 60 for part in parts)
 
@@ -980,6 +982,8 @@ def _looks_like_review_snippet(line: str) -> bool:
         return True
     terms = _PROSE_TERM_PATTERN.findall(line)
     word_count = len(line.split())
+    if "," in line and len(terms) >= 2:
+        return True
     if word_count >= 10 and len(terms) >= 2:
         return True
     if word_count >= 10 and re.search(r"[.!?]", line) and terms:

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -232,7 +232,13 @@ _PLACE_JS_EXTRACTOR = r"""
   ]);
 
   const rowValue = (row) => {
-    const value = row?.querySelector(".DkEaL, .Io6YTe")?.innerText?.trim();
+    // `.DkEaL` can be a localized row label when the value is in `.Io6YTe`.
+    // Prefer the value node and only use `.DkEaL` for older rows where it is
+    // the address text itself.
+    const value = (
+      row?.querySelector(".Io6YTe")?.innerText?.trim()
+      || row?.querySelector(".DkEaL")?.innerText?.trim()
+    );
     return value || null;
   };
 
@@ -967,13 +973,16 @@ def _looks_like_locality_address_line(line: str) -> bool:
         return False
     if not all(_locality_part_allows_period(part) for part in parts):
         return False
-    reject_count = sum(
-        _locality_address_reject_key(part) in _LOCALITY_ADDRESS_REJECT_VALUES
+    reject_keys = {
+        key
         for part in parts
-    )
+        if (key := _locality_address_reject_key(part)) in _LOCALITY_ADDRESS_REJECT_VALUES
+    }
     # One segment can be a real place name ("Bar, Montenegro"). Two or more UI
-    # labels are a strong signal this is a Google service/accessibility row.
-    if reject_count >= 2:
+    # labels are a strong signal this is a Google service/accessibility row. Use
+    # unique matches so repeated locality names like "Bar, Bar, Montenegro"
+    # still survive the fallback.
+    if len(reject_keys) >= 2:
         return False
     return all(any(character.isalpha() for character in part) and len(part) <= 60 for part in parts)
 
@@ -1008,8 +1017,9 @@ def _looks_like_review_snippet(line: str) -> bool:
     terms = _PROSE_TERM_PATTERN.findall(line)
     word_count = len(line.split())
     # Short comma-separated review fragments can otherwise look like locality
-    # pairs, e.g. "good food, friendly owner".
-    if "," in line and len(terms) >= 2:
+    # pairs. Require each segment to be phrase-like so names such as "Friendly,
+    # Coffee Springs" are not rejected only because words overlap review prose.
+    if "," in line and len(terms) >= 2 and all(len(part.split()) >= 2 for part in line.split(",")):
         return True
     if word_count >= 10 and len(terms) >= 2:
         return True

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -83,6 +83,9 @@ _STRONG_ADDRESS_KEYWORD_PATTERN = re.compile(
     r"square|sq|suite|ste|unit|floor|fl|plaza|parkway|pkwy|highway|hwy)\b",
     re.IGNORECASE,
 )
+# These reject lists only apply after structured DOM extraction misses and we
+# are forced to classify plain Google Maps text rows. They intentionally target
+# UI/review vocabulary that commonly appears next to real address rows.
 _ADDRESS_REJECT_SUBSTRINGS = (
     "about this data",
     "faviconv2",
@@ -125,6 +128,8 @@ _LOCALITY_ADDRESS_REJECT_VALUES = {
 _ADDRESS_REJECT_HOST_FRAGMENTS = ("gstatic.com", "googleusercontent.com")
 _ADDRESS_ENTITY_TOKEN_PATTERN = re.compile(r"^/(?:g|m)/[A-Za-z0-9_-]+$")
 _URL_LIKE_PATTERN = re.compile(r"(?:https?://|www\.)", re.IGNORECASE)
+# Locality-only addresses can legitimately contain periods in abbreviations
+# like "St. Louis" or "D.C."; prose with arbitrary periods is rejected later.
 _LOCALITY_ABBREVIATION_PERIOD_PATTERN = re.compile(r"(?:\bSt\.|\b[A-Z]\.(?:[A-Z]\.)+)")
 _PROSE_TERM_PATTERN = re.compile(
     r"\b(?:best|good|great|delicious|dropped|experience|lunch|dinner|"
@@ -238,6 +243,9 @@ _PLACE_JS_EXTRACTOR = r"""
   };
 
   const addressValue = () => {
+    // Prefer Google Maps' structured address row. The icon fallback exists for
+    // localized pages where the aria-label text changes but the address glyph
+    // and row shape remain stable.
     const legacy = itemValue("address");
     if (legacy) {
       return legacy;
@@ -582,6 +590,8 @@ def _build_place_details(
         category=category,
         rating=_parse_rating(snapshot.get("rating")),
         review_count=_parse_review_count(snapshot.get("review_count")),
+        # Structural DOM data is primary. Text-line fallback is a last resort
+        # for preview/limited payloads and is intentionally conservative.
         address=_clean_address_text(snapshot.get("address"))
         or _extract_address_from_lines(combined_lines),
         located_in=_clean_text(snapshot.get("located_in")),
@@ -939,6 +949,15 @@ def _looks_like_address_line(line: str) -> bool:
 
 
 def _looks_like_locality_address_line(line: str) -> bool:
+    """Return True for locality-only addresses when stronger markers are absent.
+
+    Google sometimes exposes places such as notable streets as "Baku,
+    Azerbaijan" with no street number or postal code. This is a fallback for
+    those cases; structured address rows and digit/keyword addresses are handled
+    before this function. Because Google body text also contains service chips
+    and short review snippets, ambiguous text is rejected unless it looks like a
+    compact locality chain.
+    """
     if re.search(r"[!?]", line):
         return False
     if len(line.split()) > 8:
@@ -948,7 +967,13 @@ def _looks_like_locality_address_line(line: str) -> bool:
         return False
     if not all(_locality_part_allows_period(part) for part in parts):
         return False
-    if sum(_locality_address_reject_key(part) in _LOCALITY_ADDRESS_REJECT_VALUES for part in parts) >= 2:
+    reject_count = sum(
+        _locality_address_reject_key(part) in _LOCALITY_ADDRESS_REJECT_VALUES
+        for part in parts
+    )
+    # One segment can be a real place name ("Bar, Montenegro"). Two or more UI
+    # labels are a strong signal this is a Google service/accessibility row.
+    if reject_count >= 2:
         return False
     return all(any(character.isalpha() for character in part) and len(part) <= 60 for part in parts)
 
@@ -982,6 +1007,8 @@ def _looks_like_review_snippet(line: str) -> bool:
         return True
     terms = _PROSE_TERM_PATTERN.findall(line)
     word_count = len(line.split())
+    # Short comma-separated review fragments can otherwise look like locality
+    # pairs, e.g. "good food, friendly owner".
     if "," in line and len(terms) >= 2:
         return True
     if word_count >= 10 and len(terms) >= 2:

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -401,6 +401,7 @@ class PlaceScraperTests(unittest.TestCase):
                     ),
                     "The nuggets are massive, good size burgers and probably the best for value in town",
                     "This place has great food, good service, friendly owner, and delicious burgers",
+                    "good food, friendly owner",
                 ]
             )
         )
@@ -414,7 +415,6 @@ class PlaceScraperTests(unittest.TestCase):
             _extract_preview_address(["Wheelchair accessible entrance, Dine-in, Takeout"])
         )
         self.assertIsNone(_extract_preview_address(["Museum, Art gallery"]))
-        self.assertIsNone(_extract_preview_address(["good food, friendly owner"]))
         self.assertIsNone(_extract_preview_address(["Friendly staff, good coffee."]))
         self.assertIsNone(_extract_preview_address(["Great food at St. James, highly recommend."]))
 
@@ -423,6 +423,11 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertEqual(_extract_preview_address(["St. John's, NL"]), "St. John's, NL")
         self.assertEqual(_extract_preview_address(["Washington, D.C."]), "Washington, D.C.")
         self.assertEqual(_extract_preview_address(["Bar, Montenegro"]), "Bar, Montenegro")
+        self.assertEqual(_extract_preview_address(["Bar, Bar, Montenegro"]), "Bar, Bar, Montenegro")
+        self.assertEqual(
+            _extract_preview_address(["Friendly, Coffee Springs"]),
+            "Friendly, Coffee Springs",
+        )
 
     def test_extract_preview_address_keeps_addresses_with_prose_words(self) -> None:
         self.assertEqual(

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -408,8 +408,13 @@ class PlaceScraperTests(unittest.TestCase):
     def test_extract_preview_address_rejects_service_option_lists(self) -> None:
         self.assertIsNone(_extract_preview_address(["Dine-in, Takeout, Delivery"]))
         self.assertIsNone(_extract_preview_address(["Dine-in, Takeout, Delivery."]))
+        self.assertIsNone(_extract_preview_address(["Dine-in, Takeout, Reservations"]))
         self.assertIsNone(_extract_preview_address(["Takeout, Delivery, Curbside pickup"]))
+        self.assertIsNone(
+            _extract_preview_address(["Wheelchair accessible entrance, Dine-in, Takeout"])
+        )
         self.assertIsNone(_extract_preview_address(["Museum, Art gallery"]))
+        self.assertIsNone(_extract_preview_address(["good food, friendly owner"]))
         self.assertIsNone(_extract_preview_address(["Friendly staff, good coffee."]))
         self.assertIsNone(_extract_preview_address(["Great food at St. James, highly recommend."]))
 
@@ -417,6 +422,7 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertEqual(_extract_preview_address(["St. Louis, MO"]), "St. Louis, MO")
         self.assertEqual(_extract_preview_address(["St. John's, NL"]), "St. John's, NL")
         self.assertEqual(_extract_preview_address(["Washington, D.C."]), "Washington, D.C.")
+        self.assertEqual(_extract_preview_address(["Bar, Montenegro"]), "Bar, Montenegro")
 
     def test_extract_preview_address_keeps_addresses_with_prose_words(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Reject mixed Google Maps UI option rows such as `Dine-in, Takeout, Reservations` as locality-style addresses.
- Match `cid:<value>` and `gms:<value>` selectors for IDs derived from `maps_url`, even when another stable ID wins.
- Sync the vendored scraper fallback with the same mixed-option rejection.

## Validation

- `uv run python3 -m unittest discover -s tests/python -p 'test_*.py'`
- `PYTHONPATH=vendor/gmaps-scraper/src uv run python -m unittest vendor.gmaps-scraper.tests.test_place_scraper`
