### PR TITLE
[codex] Fix mobile header nav on narrow screens

### DIFF
--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -240,4 +240,53 @@
   .template-block {
     @apply my-8 min-w-0 md:my-12;
   }
+
+  @media (max-width: 719px) {
+    .ui-site-header {
+      width: min(calc(100% - 0.5rem), var(--page-width));
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: end;
+      gap: 0.75rem;
+      padding-block: 0.75rem 0.55rem;
+    }
+
+    .ui-site-title {
+      min-width: 0;
+      justify-self: start;
+    }
+
+    .ui-site-title img {
+      width: clamp(96px, 28vw, 124px);
+    }
+
+    .ui-site-nav {
+      min-width: 0;
+      @apply justify-end gap-2 text-[0.68rem];
+    }
+
+    .ui-site-nav a {
+      @apply min-h-9 px-2.5;
+      background: rgba(15, 23, 42, 0.18);
+      border-color: rgba(255, 255, 255, 0.24);
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+    }
+  }
+
+  @media (max-width: 479px) {
+    .ui-site-header {
+      grid-template-columns: minmax(0, 1fr);
+      align-items: start;
+    }
+
+    .ui-site-nav {
+      width: 100%;
+      @apply justify-start;
+    }
+
+    .ui-site-nav a {
+      flex: 1 1 0;
+      justify-content: center;
+    }
+  }
 }

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -242,6 +242,10 @@
   }
 
   @media (max-width: 719px) {
+    .ui-page-shell {
+      width: min(calc(100% - 0.5rem), var(--page-width));
+    }
+
     .ui-site-header {
       width: min(calc(100% - 0.5rem), var(--page-width));
       display: grid;


### PR DESCRIPTION
## Summary
- keep the DEM Flyers logo anchored left at the narrow mobile breakpoint
- preserve bottom alignment between the logo and nav buttons
- improve mobile nav button contrast without changing site data or cache artifacts

## Testing
- bun run check
- bun run build