### PR TITLE
[codex] Add opt-in shared gmaps scraper state dir

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,8 @@ The `data-refresh` workflow is intentionally tied to a self-hosted Linux runner.
 - `GOOGLE_MAPS_JS_API_KEY` is read by Astro during render/build and emitted into the page only when the Google map provider is active. Treat it as the browser Google Maps display key: production usage should be on a separate key restricted by HTTP referrer and limited to `Maps JavaScript API`.
 - `GOOGLE_PLACES_API_KEY` is the optional server/build-time fallback key for Places enrichment when Google Maps place-page scraping cannot recover enough data. Do not expose it to the browser.
 - `PUBLIC_MAP_PROVIDER=leaflet` forces the Leaflet/OpenStreetMap fallback even when `GOOGLE_MAPS_JS_API_KEY` is present.
-- `GMAPS_SCRAPER_PROXY` optionally routes scraper traffic through a proxy. The pipeline keeps proxy-specific scraper sessions under `.context/gmaps-scraper/` and rotates them when they go stale or get blocked.
+- `GMAPS_SCRAPER_PROXY` optionally routes scraper traffic through a proxy. The pipeline keeps proxy-specific scraper sessions under `.context/gmaps-scraper/` by default, rotates them when they go stale or get blocked, and can be pointed at a shared absolute path with `FAVORITE_PLACES_GMAPS_SCRAPER_STATE_DIR` when you want reuse across worktrees or the main checkout.
+- `FAVORITE_PLACES_GMAPS_SCRAPER_STATE_DIR` optionally overrides the scraper browser-profile and HTTP-cookie-jar root. Use the same absolute path from multiple worktrees if you want to share scraper trust state. A headed run with that same path may still be needed to establish consent or signed-in browser state; the browser profile and curl cookie jar are persisted together under this root but are separate artifacts.
 - `FAVORITE_PLACES_SITE_DIR` points both Astro and the Python data pipeline at the site pack. It defaults to `./site`, with `./site.example` as the fresh-checkout fallback.
 
 ## Data Practices
@@ -125,6 +126,6 @@ Guide pages default to Google Maps when `GOOGLE_MAPS_JS_API_KEY` is present at b
 - Manual `vibe_tags` overrides win over rule-derived browser search vibe tags.
 - Place enrichment cache entries now carry `input_signature` and `refresh_after`; invalidation is not a single global TTL anymore.
 - Raw saved-list snapshots now carry `fetched_at`, `refresh_after`, and `source_signature`; URL sources skip network refreshes until the refresh window expires unless the source config changes, while CSV sources can skip rewrites when the input hash is unchanged.
-- The raw-list scraper now uses `gmaps-scraper`, which defaults to `curl_cffi` with browser fallback and supports place-page scraping. The pipeline reuses repo-local scraper sessions, rotates to a fresh identity when `GMAPS_SCRAPER_PROXY` changes, clears sessions after obvious block/cookie-jar failures, and expires idle sessions after 14 days.
+- The raw-list scraper now uses `gmaps-scraper`, which defaults to `curl_cffi` with browser fallback and supports place-page scraping. The pipeline reuses worktree-local scraper sessions by default, can share them across worktrees when `FAVORITE_PLACES_GMAPS_SCRAPER_STATE_DIR` is set, rotates to a fresh identity when `GMAPS_SCRAPER_PROXY` changes, clears sessions after obvious block/cookie-jar failures, and expires idle sessions after 14 days.
 - Enrichment now prefers `gmaps-scraper` place-page scraping and uses `GOOGLE_PLACES_API_KEY` only as a fallback when a place page is blocked, limited, or too thin to trust.
 - Do not reintroduce tracked generated JSON unless the user explicitly asks for fixture-style examples in git.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The behavior is configurable in a few places:
 - `site/enrichment.json` controls site-owned scraper policy. `google_maps_places.llm_repair` defaults to `dom`, while `collect_reviews` and `collect_about` default to `false` so enrichment stays compact unless a site opts into those heavier panels.
 - `GOOGLE_MAPS_PLACES_LLM_REPAIR`, `GOOGLE_MAPS_PLACES_COLLECT_REVIEWS`, and `GOOGLE_MAPS_PLACES_COLLECT_ABOUT` override the site enrichment config for automation or one-off refreshes.
 - `GMAPS_SCRAPER_PROXY` routes Google Maps list and place-page scraping through a proxy.
+- `FAVORITE_PLACES_GMAPS_SCRAPER_STATE_DIR` optionally overrides where scraper browser profiles and HTTP cookie jars are stored. Point multiple worktrees at the same absolute path when you want to reuse scraper session state across them.
 - The command controls refresh scope: `fill:gaps` fills missing enrichment and photos, `enrich:data` fills missing or stale cache entries, `refresh:enrichment` refreshes every entry, `refresh:semantic-enrichment` updates cached semantic neighborhoods/tags from already cached evidence, and `refresh:semantic-descriptions` only updates cached semantic descriptions from already cached enrichment evidence.
 
 Example `site/enrichment.json`:
@@ -220,6 +221,9 @@ GOOGLE_MAPS_PLACES_SEMANTIC_DESCRIPTION_FORCE_REFRESH=false
 # Optional proxy for Google Maps list and place-page scraping.
 GMAPS_SCRAPER_PROXY=...
 
+# Optional shared scraper state root for browser profiles and curl cookies.
+FAVORITE_PLACES_GMAPS_SCRAPER_STATE_DIR=/absolute/path/to/.context/gmaps-scraper
+
 # Force Leaflet/OpenStreetMap rendering.
 PUBLIC_MAP_PROVIDER=leaflet
 
@@ -229,6 +233,14 @@ PUBLIC_PLACE_PHOTOS=off
 # Point at a non-default site pack.
 FAVORITE_PLACES_SITE_DIR=../site
 ```
+
+To share scraper state across Git worktrees and the main checkout, a practical choice is:
+
+```bash
+FAVORITE_PLACES_GMAPS_SCRAPER_STATE_DIR="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/.context/gmaps-scraper"
+```
+
+A fresh persistent profile does not automatically fix limited-view responses on its own. It gives the scraper a durable browser profile and a durable curl cookie jar, but you may still need to run a headed scrape once against that same path to establish consent or trust state.
 
 Use a restricted browser key for `GOOGLE_MAPS_JS_API_KEY`. Do not expose `GOOGLE_PLACES_API_KEY` to the browser.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -250,6 +250,7 @@ Common variables:
 - `PUBLIC_PLACE_PHOTOS=off`: hide place photos in the UI
 - `FAVORITE_PLACES_SITE_DIR`: point the app and Python pipeline at a non-default site pack
 - `GMAPS_SCRAPER_PROXY`: route scraper traffic through a proxy
+- `FAVORITE_PLACES_GMAPS_SCRAPER_STATE_DIR`: optionally override the scraper browser-profile and HTTP-cookie-jar root; point multiple worktrees at the same absolute path to reuse scraper session state
 
 Use a restricted browser key for `GOOGLE_MAPS_JS_API_KEY`. Do not expose `GOOGLE_PLACES_API_KEY` to the browser.
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -66,6 +66,7 @@ except ModuleNotFoundError:
 
 ROOT = Path(__file__).resolve().parent.parent
 SITE_DIR_ENV = "FAVORITE_PLACES_SITE_DIR"
+SCRAPER_STATE_DIR_ENV = "FAVORITE_PLACES_GMAPS_SCRAPER_STATE_DIR"
 
 
 def resolve_site_dir() -> Path:
@@ -83,6 +84,17 @@ def resolve_site_dir() -> Path:
     return ROOT / "site.example"
 
 
+def resolve_scraper_state_dir() -> Path:
+    configured_state_dir = os.environ.get(SCRAPER_STATE_DIR_ENV)
+    if configured_state_dir:
+        path = Path(configured_state_dir).expanduser()
+        if not path.is_absolute():
+            path = ROOT / path
+        return path.resolve()
+
+    return ROOT / ".context" / "gmaps-scraper"
+
+
 SITE_DIR = resolve_site_dir()
 CONFIG_PATH = SITE_DIR / "list_sources.json"
 RAW_DIR = SITE_DIR / "data" / "raw"
@@ -96,7 +108,7 @@ SITE_BUILD_HOOKS_PATH = SITE_DIR / "build_hooks.py"
 SITE_ENRICHMENT_CONFIG_PATH = SITE_DIR / "enrichment.json"
 LIST_OVERRIDES_DIR = SITE_DIR / "overrides" / "lists"
 PLACE_OVERRIDES_DIR = SITE_DIR / "overrides" / "places"
-SCRAPER_STATE_DIR = ROOT / ".context" / "gmaps-scraper"
+SCRAPER_STATE_DIR = resolve_scraper_state_dir()
 PRICE_RATE_CACHE_DIR = ROOT / ".context" / "currency-rates"
 AUTO_REFRESH_WORKER_CAP = 4
 DEFAULT_REFRESH_RETRIES = 2

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -53,6 +53,15 @@ class BuildDataTests(unittest.TestCase):
         with patch.object(build_data.os, "cpu_count", return_value=16):
             self.assertEqual(build_data.default_refresh_workers(), 4)
 
+    def test_resolve_scraper_state_dir_prefers_explicit_env(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            with patch.dict(
+                "os.environ",
+                {build_data.SCRAPER_STATE_DIR_ENV: tmpdir},
+                clear=False,
+            ):
+                self.assertEqual(build_data.resolve_scraper_state_dir(), Path(tmpdir).resolve())
+
     def test_parser_uses_auto_refresh_worker_default(self) -> None:
         parser = build_data.build_parser()
         args = parser.parse_args([])


### PR DESCRIPTION
## Summary

Add an opt-in scraper state directory override so Google Maps scraper browser profiles and curl cookie jars can be shared across worktrees or the main checkout when needed.

## What Changed

- add `FAVORITE_PLACES_GMAPS_SCRAPER_STATE_DIR` support in the Python pipeline
- keep the existing worktree-local `.context/gmaps-scraper` default when the override is unset
- document the shared-path workflow and the headed-run caveat in the repo docs
- cover the new resolver behavior with a unit test

## Why

The current scraper session reuse is anchored to the active worktree, which means trust state, browser consent state, and cookie jars do not carry across worktrees by default. This makes it harder to recover from limited-view responses or reuse a primed scraper session from the main checkout.

## Impact

- no behavior change by default
- operators can point multiple worktrees at the same absolute scraper state path when they want reuse
- the same shared path can also be used from the main checkout

## Validation

- `uv run python -m unittest tests.python.test_build_data.BuildDataTests.test_resolve_scraper_state_dir_prefers_explicit_env`
- `uv run python -m unittest tests.python.test_build_data`
  - currently fails on inherited upstream test `test_fetch_place_page_enrichment_rewrites_cid_url_before_scraping`
  - the branch diff only touches `AGENTS.md`, `README.md`, `docs/ARCHITECTURE.md`, `scripts/build_data.py`, and `tests/python/test_build_data.py` for the new env override and docs
