### PR TITLE
Improve enrichment refresh and Google Maps pane recovery

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -502,6 +502,13 @@ SEMANTIC_NEIGHBORHOOD_DISPLAY_ALIASES = {
     "zhongshan": "Zhongshan",
     "zhishan": "Zhishan",
 }
+SEMANTIC_NEIGHBORHOOD_UPPERCASE_TOKENS = {
+    "cbd",
+    "dc",
+    "dtla",
+    "la",
+    "nyc",
+}
 COUNTRY_LOCALITY_KEYS: set[str] | None = None
 SUBNATIONAL_LOCALITY_KEYS: set[str] | None = None
 SUBNATIONAL_LOCALITY_CODE_KEYS: set[str] | None = None
@@ -1688,6 +1695,14 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--skip-enrichment-source-refresh",
+        action="store_true",
+        help=(
+            "Do not refresh affected raw Google Maps source lists before place-page enrichment. "
+            "Use this when you explicitly want enrichment to run against the existing raw snapshot."
+        ),
+    )
+    parser.add_argument(
         "--refresh-photos",
         action="store_true",
         help="Download missing local optimized place photos from cached enrichment photo URLs.",
@@ -2370,7 +2385,7 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
                 *(enrichment.semantic_tags if use_semantic_enrichment else []),
                 *(enrichment.semantic_types if use_semantic_enrichment else []),
             ]
-            if tag
+            if semantic_tag_slug_is_usable(tag)
         ]
         tags = sorted(
             {
@@ -2470,7 +2485,10 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
         if prefer_enrichment_names and enrichment.display_name:
             preferred_name = enrichment.display_name
         normalized_name = as_string(override.get("name")) or preferred_name
-        normalized_address = enrichment.address_display_en or place.address or enrichment.formatted_address
+        normalized_address = normalize_guide_display_address(
+            enrichment.address_display_en or enrichment.formatted_address or place.address,
+            country_name=country_name,
+        )
         maps_url = build_public_google_maps_url(
             name=normalized_name,
             address=normalized_address,
@@ -2528,6 +2546,7 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
             primary_category_localized=primary_category_localized,
             tags=tags,
             city_name=city_name,
+            country_name=country_name,
             neighborhood_uses_enrichment=neighborhood_uses_enrichment,
             top_pick_override=top_pick_override,
             status=status,
@@ -2605,6 +2624,7 @@ def build_place_provenance(
     primary_category_localized: str | None,
     tags: list[str],
     city_name: str | None,
+    country_name: str | None,
     neighborhood_uses_enrichment: bool,
     top_pick_override: bool | None,
     status: str,
@@ -2625,11 +2645,19 @@ def build_place_provenance(
         else google_list_field(normalized.name, raw)
     )
     if normalized.address:
+        enrichment_display_address = normalize_guide_display_address(
+            enrichment.address_display_en,
+            country_name=country_name,
+        )
+        enrichment_formatted_address = normalize_guide_display_address(
+            enrichment.formatted_address,
+            country_name=country_name,
+        )
         provenance.address = (
             google_places_field(normalized.address, enrichment_cache_entry)
             if (
-                normalized.address == enrichment.address_display_en
-                or (not raw_place.address and normalized.address == enrichment.formatted_address)
+                normalized.address == enrichment_display_address
+                or normalized.address == enrichment_formatted_address
             )
             else google_list_field(normalized.address, raw)
         )
@@ -3279,6 +3307,31 @@ def enrich_raw_sources(
         raise
     finally:
         executor.shutdown(wait=True, cancel_futures=True)
+
+
+def enrichment_source_refresh_lists(place_selectors: Sequence[str] | None) -> list[str]:
+    normalized_place_selectors = normalize_place_selectors(list(place_selectors or []))
+    if not normalized_place_selectors:
+        return []
+
+    refresh_slugs = {
+        selector.removeprefix("guide-slug:")
+        for selector in normalized_place_selectors
+        if selector.startswith("guide-slug:") and selector.removeprefix("guide-slug:")
+    }
+    for raw_path in sorted(RAW_DIR.glob("*.json")):
+        raw = RawSavedList.model_validate_json(raw_path.read_text(encoding="utf-8"))
+        for place in raw.places:
+            place_id = stable_place_id(place, source_type=raw.configured_source_type)
+            if place_selector_matches(
+                raw_path.stem,
+                place,
+                place_id=place_id,
+                selectors=normalized_place_selectors,
+            ):
+                refresh_slugs.add(raw_path.stem)
+                break
+    return sorted(refresh_slugs)
 
 
 def refresh_cached_semantic_descriptions(
@@ -7356,6 +7409,57 @@ def sanitize_place_page_formatted_address(value: Any) -> str | None:
     return normalized if looks_like_place_page_formatted_address(normalized) else None
 
 
+def normalize_guide_display_address(value: Any, *, country_name: str | None) -> str | None:
+    normalized = as_string(value)
+    if normalized is None:
+        return None
+    country_key = normalize_locality_key(country_name)
+    if country_key == "taiwan" or re.search(r"\bTaiwan\b|台灣|台湾", normalized, flags=re.IGNORECASE):
+        normalized = normalize_taiwan_guide_display_address(normalized)
+    return re.sub(r"\s+", " ", normalized).strip() or None
+
+
+def normalize_taiwan_guide_display_address(address: str) -> str:
+    parts = [part.strip() for part in address.split(",") if part.strip()]
+    if len(parts) >= 3 and re.fullmatch(r"\d{3}", parts[0]) and normalize_locality_key(parts[1]) == "taiwan":
+        postal_code = parts[0]
+        parts = [*reversed(parts[2:]), f"Taiwan {postal_code}"]
+    else:
+        parts = [normalize_taiwan_street_number_part(part) for part in parts]
+    parts = [normalize_taiwan_street_number_part(part) for part in parts]
+    return ", ".join(part for part in parts if part)
+
+
+def normalize_taiwan_street_number_part(part: str) -> str:
+    normalized = re.sub(r"\s+", " ", part).strip()
+    duplicate_match = re.fullmatch(
+        r"No\.?\s*(?P<number>\d+[A-Za-z-]*)\s+No\.?\s*(?P=number)號(?P<suffix>[A-Za-z0-9-]*)",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    if duplicate_match:
+        return format_taiwan_street_number(
+            duplicate_match.group("number"),
+            duplicate_match.group("suffix"),
+        )
+    number_match = re.fullmatch(
+        r"(?:No\.?\s*)?(?P<number>\d+[A-Za-z-]*)號(?P<suffix>[A-Za-z0-9-]*)",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    if number_match:
+        return format_taiwan_street_number(number_match.group("number"), number_match.group("suffix"))
+    return normalized
+
+
+def format_taiwan_street_number(number: str, suffix: str | None = None) -> str:
+    normalized_number = number.strip()
+    normalized_suffix = (suffix or "").strip()
+    if normalized_suffix:
+        return f"No. {normalized_number}, {normalized_suffix}"
+    return f"No. {normalized_number}"
+
+
 def looks_like_place_page_review_snippet(value: str) -> bool:
     if has_place_page_address_marker(value):
         return False
@@ -7644,7 +7748,7 @@ def coerce_json_object_list(value: Any) -> list[dict[str, Any]]:
     return items
 
 
-SEMANTIC_LLM_PROMPT_VERSION = "favorite-places-semantic-v2"
+SEMANTIC_LLM_PROMPT_VERSION = "favorite-places-semantic-v3"
 
 
 def apply_semantic_enrichment(
@@ -7797,7 +7901,10 @@ def repair_semantic_enrichment_with_llm(
                 "content": (
                     "You classify saved places for a travel guide. Return only compact JSON. "
                     "Infer the guide-facing neighborhood only from address/geography evidence. Prefer common "
-                    "local area names over the smallest administrative unit. For Taiwan, village/li labels "
+                    "local area names over the smallest administrative unit. The neighborhood must be a "
+                    "human-facing display label, not a tag or slug: use normal local display casing such as "
+                    "Perth CBD, Northbridge, or Margaret River; preserve acronyms like CBD; never return "
+                    "kebab-case, snake_case, or all-lowercase labels. For Taiwan, village/li labels "
                     "such as Kangle Village or Tonghua Village are usually too granular; prefer the district "
                     "such as Zhongshan or Da'an unless the evidence explicitly names a more recognizable local "
                     "area as the neighborhood. Do not infer Ximen, Neihu, Longshan, or similar local areas from "
@@ -8033,10 +8140,40 @@ def normalize_semantic_neighborhood_label(
         shortened = re.sub(r"\s+District$", "", label, flags=re.IGNORECASE).strip()
         if shortened:
             label = shortened
-    alias = SEMANTIC_NEIGHBORHOOD_DISPLAY_ALIASES.get(normalize_locality_key(label))
+    alias = SEMANTIC_NEIGHBORHOOD_DISPLAY_ALIASES.get(semantic_neighborhood_comparison_key(label))
+    if alias:
+        return alias
+    label = display_case_semantic_neighborhood_label(label)
+    alias = SEMANTIC_NEIGHBORHOOD_DISPLAY_ALIASES.get(semantic_neighborhood_comparison_key(label))
     if alias:
         return alias
     return label
+
+
+def semantic_neighborhood_comparison_key(value: str | None) -> str:
+    return normalize_locality_key(value).replace("-", " ")
+
+
+def display_case_semantic_neighborhood_label(label: str) -> str:
+    normalized = re.sub(r"\s+", " ", label.replace("_", " ").strip())
+    slug_like = bool(re.fullmatch(r"[a-z0-9]+(?:[-_][a-z0-9]+)+", label.strip()))
+    if slug_like:
+        normalized = re.sub(r"[-_]+", " ", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    if not normalized or not normalized.isascii():
+        return normalized
+    if not slug_like and normalized != normalized.lower() and normalized != normalized.upper():
+        return normalized
+    return " ".join(display_case_semantic_neighborhood_word(word) for word in normalized.split(" "))
+
+
+def display_case_semantic_neighborhood_word(word: str) -> str:
+    lower_word = word.lower()
+    if lower_word in SEMANTIC_NEIGHBORHOOD_UPPERCASE_TOKENS:
+        return lower_word.upper()
+    if not lower_word:
+        return word
+    return f"{lower_word[0].upper()}{lower_word[1:]}"
 
 
 def refine_semantic_neighborhood_with_address_localities(
@@ -8045,13 +8182,15 @@ def refine_semantic_neighborhood_with_address_localities(
 ) -> str | None:
     if semantic_neighborhood is None:
         return None
-    semantic_key = normalize_locality_key(semantic_neighborhood).replace("-", " ")
+    semantic_key = semantic_neighborhood_comparison_key(semantic_neighborhood)
     if len(semantic_key) < 4:
         return semantic_neighborhood
     for candidate in locality_candidates:
-        candidate_key = normalize_locality_key(candidate).replace("-", " ")
-        if not candidate_key or candidate_key == semantic_key:
+        candidate_key = semantic_neighborhood_comparison_key(candidate)
+        if not candidate_key:
             continue
+        if candidate_key == semantic_key:
+            return candidate
         if (
             candidate_key.endswith(semantic_key)
             or candidate_key.startswith(f"{semantic_key} ")
@@ -8474,11 +8613,19 @@ def normalize_semantic_tag_list(value: Any, *, limit: int) -> list[str]:
         if item_text is None:
             continue
         tag = normalize_tag_slug(item_text)
-        if tag and tag not in tags:
+        if semantic_tag_slug_is_usable(tag) and tag not in tags:
             tags.append(tag)
         if len(tags) >= limit:
             break
     return tags
+
+
+def semantic_tag_slug_is_usable(tag: str | None) -> bool:
+    if not tag or tag == "item":
+        return False
+    if len(tag) == 1 and tag.isalpha():
+        return False
+    return True
 
 
 @lru_cache(maxsize=1)
@@ -8944,6 +9091,23 @@ def main() -> int:
             refresh_retry_backoff_seconds=args.refresh_retry_backoff_seconds,
             refresh_startup_jitter_seconds=args.refresh_startup_jitter_seconds,
         )
+
+    if (
+        (args.enrich or args.enrich_missing or args.refresh_enrichment)
+        and not args.refresh
+        and not args.skip_enrichment_source_refresh
+    ):
+        enrichment_refresh_lists = enrichment_source_refresh_lists(args.enrich_place)
+        if enrichment_refresh_lists or (args.refresh_enrichment and not args.enrich_place):
+            refresh_raw_sources(
+                headed=args.headed,
+                force_refresh=bool(enrichment_refresh_lists),
+                refresh_lists=enrichment_refresh_lists,
+                refresh_workers=args.refresh_workers,
+                refresh_retries=args.refresh_retries,
+                refresh_retry_backoff_seconds=args.refresh_retry_backoff_seconds,
+                refresh_startup_jitter_seconds=args.refresh_startup_jitter_seconds,
+            )
 
     if args.enrich or args.enrich_missing or args.refresh_enrichment:
         sync_local_csv_sources()

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -105,6 +105,8 @@ class BuildDataTests(unittest.TestCase):
     def test_main_treats_enrich_place_as_targeted_refresh(self) -> None:
         with (
             patch.object(sys, "argv", ["build_data.py", "--enrich-place", "cid:123"]),
+            patch.object(build_data, "enrichment_source_refresh_lists", return_value=[]),
+            patch.object(build_data, "refresh_raw_sources") as refresh_raw_sources,
             patch.object(build_data, "sync_local_csv_sources"),
             patch.object(build_data, "enrich_raw_sources") as enrich_raw_sources,
             patch.object(build_data, "rebuild_generated_data") as rebuild_generated_data,
@@ -112,6 +114,7 @@ class BuildDataTests(unittest.TestCase):
             result = build_data.main()
 
         self.assertEqual(result, 0)
+        refresh_raw_sources.assert_not_called()
         enrich_raw_sources.assert_called_once_with(
             force_refresh=True,
             missing_only=False,
@@ -124,6 +127,53 @@ class BuildDataTests(unittest.TestCase):
             photo_workers=build_data.DEFAULT_REFRESH_WORKERS,
             startup_jitter_seconds=build_data.DEFAULT_REFRESH_STARTUP_JITTER_SECONDS,
         )
+
+    def test_main_refreshes_affected_source_before_targeted_enrichment(self) -> None:
+        with (
+            patch.object(sys, "argv", ["build_data.py", "--enrich-place", "guide-slug:tokyo-japan"]),
+            patch.object(build_data, "enrichment_source_refresh_lists", return_value=["tokyo-japan"]),
+            patch.object(build_data, "refresh_raw_sources") as refresh_raw_sources,
+            patch.object(build_data, "sync_local_csv_sources"),
+            patch.object(build_data, "enrich_raw_sources") as enrich_raw_sources,
+            patch.object(build_data, "rebuild_generated_data"),
+        ):
+            result = build_data.main()
+
+        self.assertEqual(result, 0)
+        refresh_raw_sources.assert_called_once_with(
+            headed=False,
+            force_refresh=True,
+            refresh_lists=["tokyo-japan"],
+            refresh_workers=build_data.DEFAULT_REFRESH_WORKERS,
+            refresh_retries=build_data.DEFAULT_REFRESH_RETRIES,
+            refresh_retry_backoff_seconds=build_data.DEFAULT_REFRESH_RETRY_BACKOFF_SECONDS,
+            refresh_startup_jitter_seconds=build_data.DEFAULT_REFRESH_STARTUP_JITTER_SECONDS,
+        )
+        enrich_raw_sources.assert_called_once()
+
+    def test_main_can_skip_source_refresh_before_targeted_enrichment(self) -> None:
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "build_data.py",
+                    "--skip-enrichment-source-refresh",
+                    "--enrich-place",
+                    "guide-slug:tokyo-japan",
+                ],
+            ),
+            patch.object(build_data, "enrichment_source_refresh_lists") as refresh_lists,
+            patch.object(build_data, "refresh_raw_sources") as refresh_raw_sources,
+            patch.object(build_data, "sync_local_csv_sources"),
+            patch.object(build_data, "enrich_raw_sources"),
+            patch.object(build_data, "rebuild_generated_data"),
+        ):
+            result = build_data.main()
+
+        self.assertEqual(result, 0)
+        refresh_lists.assert_not_called()
+        refresh_raw_sources.assert_not_called()
 
     def test_main_force_semantic_descriptions_runs_cache_only_pass(self) -> None:
         with (
@@ -2549,7 +2599,7 @@ class BuildDataTests(unittest.TestCase):
         self.assertIn("specialty", first_place.tags)
         self.assertIn("tokyo", first_place.tags)
         self.assertEqual(first_place.provenance.name.source, "google_list")
-        self.assertEqual(first_place.provenance.address.source, "google_list")
+        self.assertEqual(first_place.provenance.address.source, "google_places")
         self.assertEqual(first_place.provenance.maps_url.source, "google_places")
         self.assertEqual(first_place.provenance.primary_category.source, "manual")
         self.assertEqual(first_place.provenance.note.source, "manual")
@@ -2652,6 +2702,59 @@ class BuildDataTests(unittest.TestCase):
         assert guide.places[0].provenance.address is not None
         self.assertEqual(guide.places[0].provenance.address.source, "google_maps_page")
         self.assertIn("No.+12%2C+Songgao+Rd", guide.places[0].maps_url)
+
+    def test_normalize_guide_prefers_enriched_formatted_address_over_raw_address(self) -> None:
+        raw = RawSavedList(
+            title="Yilan, Taiwan",
+            places=[
+                RawPlace(
+                    name="Coming Home Bar",
+                    address="260, Taiwan, Yilan County, Yilan City, Nongquan Rd, 110號1F",
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                ),
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0])
+        enrichment_cache = {
+            place_id: EnrichmentCacheEntry(
+                fetched_at="2026-05-01T00:00:00+00:00",
+                source="google_maps_page",
+                query="Coming Home Bar, Yilan, Taiwan",
+                matched=True,
+                place=EnrichmentPlace(
+                    display_name="Coming Home Bar",
+                    formatted_address=(
+                        "260, Taiwan, Yilan County, Yilan City, "
+                        "Minquan Village, Nongquan Rd, 110號1F"
+                    ),
+                ),
+            )
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+            with (
+                patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+            ):
+                guide = build_data.normalize_guide(
+                    "yilan-taiwan",
+                    raw,
+                    enrichment_cache=enrichment_cache,
+                )
+
+        self.assertEqual(
+            guide.places[0].address,
+            "No. 110, 1F, Nongquan Rd, Minquan Village, Yilan City, Yilan County, Taiwan 260",
+        )
+        self.assertIsNotNone(guide.places[0].provenance.address)
+        assert guide.places[0].provenance.address is not None
+        self.assertEqual(guide.places[0].provenance.address.source, "google_maps_page")
 
     def test_place_vibe_tags_can_be_manually_overridden(self) -> None:
         raw = RawSavedList(
@@ -3321,6 +3424,84 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(enrichment.semantic_types, ["specialty-cafe"])
         self.assertEqual(enrichment.semantic_source, "llm")
 
+    def test_normalize_semantic_neighborhood_display_cases_slug_outputs(self) -> None:
+        cases = {
+            "perth-cbd": "Perth CBD",
+            "perth_cbd": "Perth CBD",
+            "margaret-river": "Margaret River",
+            "northbridge": "Northbridge",
+            "PERTH CBD": "Perth CBD",
+            "CBD": "CBD",
+            "da-an": "Da'an",
+        }
+        for value, expected in cases.items():
+            with self.subTest(value=value):
+                self.assertEqual(
+                    build_data.normalize_semantic_neighborhood_label(
+                        value,
+                        city_name="Perth",
+                        country_name="Australia",
+                    ),
+                    expected,
+                )
+
+    def test_refine_semantic_neighborhood_prefers_address_candidate_casing(self) -> None:
+        self.assertEqual(
+            build_data.refine_semantic_neighborhood_with_address_localities(
+                "perth-cbd",
+                ["Perth CBD"],
+            ),
+            "Perth CBD",
+        )
+        self.assertEqual(
+            build_data.refine_semantic_neighborhood_with_address_localities(
+                "phố cổ hà nội",
+                ["Phố cổ Hà Nội"],
+            ),
+            "Phố cổ Hà Nội",
+        )
+
+    def test_apply_semantic_enrichment_display_cases_llm_neighborhood_slug(self) -> None:
+        enrichment = EnrichmentPlace(
+            display_name="Wine Bar",
+            formatted_address="Perth CBD, Perth WA, Australia",
+            primary_type_display_name="Wine bar",
+        )
+        raw_place = RawPlace(name="Wine Bar", maps_url="https://maps.example/wine")
+
+        with (
+            patch.object(build_data, "google_maps_place_semantic_llm_enabled", return_value=True),
+            patch.object(build_data, "google_maps_place_semantic_descriptions_enabled", return_value=False),
+            patch.object(build_data, "google_maps_place_semantic_description_force_refresh", return_value=False),
+            patch.object(
+                build_data,
+                "repair_semantic_enrichment_with_llm",
+                return_value={
+                    "neighborhood": "perth-cbd",
+                    "tags": ["wine-bar"],
+                    "vibe_tags": ["date-night"],
+                    "types": ["bar"],
+                },
+            ),
+        ):
+            build_data.apply_semantic_enrichment(
+                enrichment,
+                raw_place=raw_place,
+                city_name="Perth",
+                country_name="Australia",
+            )
+
+        self.assertEqual(enrichment.semantic_neighborhood, "Perth CBD")
+
+    def test_normalize_semantic_tag_list_drops_noise_tags(self) -> None:
+        self.assertEqual(
+            build_data.normalize_semantic_tag_list(
+                ["scallion pancake", "q", "蔥油餅", "street food"],
+                limit=8,
+            ),
+            ["scallion-pancake", "street-food"],
+        )
+
     def test_apply_semantic_enrichment_reuses_description_when_signature_matches(self) -> None:
         raw_place = RawPlace(
             name="Tea House",
@@ -3773,6 +3954,24 @@ class BuildDataTests(unittest.TestCase):
         self.assertIsNone(place.display_name)
         self.assertEqual(place.primary_type_display_name, "Zoo")
         self.assertEqual(place.formatted_address, "No. 30號, Section 2, Xinguang Rd")
+
+    def test_normalize_guide_display_address_formats_taiwan_postal_prefix(self) -> None:
+        self.assertEqual(
+            build_data.normalize_guide_display_address(
+                "260, Taiwan, Yilan County, Yilan City, Minquan Village, Nongquan Rd, 110號1F",
+                country_name="Taiwan",
+            ),
+            "No. 110, 1F, Nongquan Rd, Minquan Village, Yilan City, Yilan County, Taiwan 260",
+        )
+
+    def test_normalize_guide_display_address_collapses_taiwan_duplicate_number(self) -> None:
+        self.assertEqual(
+            build_data.normalize_guide_display_address(
+                "No. 6 No. 6號, Lane 47, Section 3, Dafu Rd, Zhuangwei Township, Yilan County, 263",
+                country_name="Taiwan",
+            ),
+            "No. 6, Lane 47, Section 3, Dafu Rd, Zhuangwei Township, Yilan County, 263",
+        )
 
     def test_normalize_place_page_enrichment_sanitizes_suspicious_addresses(self) -> None:
         chrome = build_data.normalize_place_page_enrichment(

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -230,29 +230,155 @@ _NUMERIC_PRICE_PATTERN = re.compile(
     r")\s*(?P<amount>[0-9][0-9,.\s\u00a0]*)(?=\s|$|·)",
     flags=re.IGNORECASE,
 )
+_PLACE_PANEL_HELPERS_JS = r"""
+  const cleanLine = (value) => (value || "").replace(/\s+/g, " ").trim();
+  const searchResultTitleLabels = new Set([
+    "result",
+    "results",
+    "search result",
+    "search results",
+    "結果",
+    "検索結果",
+  ]);
+  const titleSelectors = ["h1.DUwDvf", "h1.lfPIob", "div[role='main'] h1"];
+  const isSearchResultTitle = (value) => searchResultTitleLabels.has(
+    cleanLine(value).toLowerCase(),
+  );
+  const visibleRect = (element) => {
+    const rect = element.getBoundingClientRect();
+    const width = Math.max(0, Math.min(rect.right, window.innerWidth) - Math.max(rect.left, 0));
+    const height = Math.max(0, Math.min(rect.bottom, window.innerHeight) - Math.max(rect.top, 0));
+    return {rect, visibleArea: width * height};
+  };
+  const matchingTitleElements = (root) => {
+    const elements = [];
+    const seen = new Set();
+    for (const selector of titleSelectors) {
+      const matches = [];
+      if (root.matches?.(selector)) {
+        matches.push(root);
+      }
+      matches.push(...root.querySelectorAll(selector));
+      for (const element of matches) {
+        if (seen.has(element)) {
+          continue;
+        }
+        seen.add(element);
+        elements.push(element);
+      }
+    }
+    return elements;
+  };
+  const placePanelCandidateRoots = () => {
+    const roots = new Set();
+    for (const selector of [
+      "[role='main']",
+      "[role='dialog']",
+      "[role='region'][aria-label]",
+    ]) {
+      for (const element of document.querySelectorAll(selector)) {
+        roots.add(element);
+      }
+    }
+    for (const title of document.querySelectorAll("h1, [role='heading']")) {
+      let current = title;
+      for (let depth = 0; depth < 9 && current && current !== document.body; depth += 1) {
+        roots.add(current);
+        current = current.parentElement;
+      }
+    }
+    return Array.from(roots);
+  };
+  const placePanelRoot = () => {
+    let best = null;
+    for (const root of placePanelCandidateRoots()) {
+      const {rect, visibleArea} = visibleRect(root);
+      if (visibleArea <= 0 || rect.width < 120 || rect.height < 80) {
+        continue;
+      }
+      const titleElements = matchingTitleElements(root);
+      const titleTexts = titleElements
+        .map((element) => cleanLine(element.innerText || element.textContent || ""))
+        .filter(Boolean);
+      const titleElement = titleElements.find((element) => {
+        const title = cleanLine(element.innerText || element.textContent || "");
+        return title && !isSearchResultTitle(title);
+      }) || titleElements.find(
+        (element) => cleanLine(element.innerText || element.textContent || ""),
+      );
+      const title = cleanLine(titleElement?.innerText || titleElement?.textContent || "");
+      const nonResultTitle = title && !isSearchResultTitle(title) ? title : "";
+      const label = cleanLine(root.getAttribute("aria-label") || "");
+      const hasResultsTitle = titleTexts.some(isSearchResultTitle) || /results for/i.test(label);
+      const addressRows = root.querySelectorAll(`[data-item-id="address"]`).length;
+      const ratingSummaries = root.querySelectorAll("div.F7nice").length;
+      const tabLabels = Array.from(
+        root.querySelectorAll("button[role='tab'], div[role='tablist'] button"),
+      ).map((element) => cleanLine(element.getAttribute("aria-label") || element.innerText || ""));
+      const hasOverviewTabs = tabLabels.some((value) => /overview/i.test(value))
+        && tabLabels.some((value) => /reviews?/i.test(value));
+      const articleCount = root.querySelectorAll("[role='article']").length;
+      const placeRows = root.querySelectorAll(
+        `[data-item-id="address"], [data-item-id="authority"], [data-item-id^="phone:"]`,
+      ).length;
+      let score = 0;
+      if (nonResultTitle) {
+        score += 120;
+      }
+      if (addressRows) {
+        score += 45;
+      }
+      if (ratingSummaries) {
+        score += 30;
+      }
+      if (hasOverviewTabs) {
+        score += 25;
+      }
+      score += Math.min(placeRows * 10, 30);
+      if (root.getAttribute("role") === "main" && nonResultTitle) {
+        score += 10;
+      }
+      if (label && nonResultTitle && label === nonResultTitle) {
+        score += 8;
+      }
+      if (hasResultsTitle) {
+        score -= 70;
+      }
+      if (articleCount >= 2 && !addressRows) {
+        score -= 40;
+      }
+      score += Math.min(visibleArea / 20000, 20);
+      const tieBreak = (root.getAttribute("role") === "main" ? 2000000 : 0) + visibleArea;
+      if (!best || score > best.score || (score === best.score && tieBreak > best.tieBreak)) {
+        best = {root, titleElement, title, score, tieBreak};
+      }
+    }
+    if (best && best.score > 0) {
+      return {
+        root: best.root,
+        titleElement: best.titleElement,
+        title: best.title,
+        found: true,
+        score: best.score,
+      };
+    }
+    const fallbackTitle = document.querySelector(titleSelectors.join(","));
+    return {
+      root: document.body,
+      titleElement: fallbackTitle,
+      title: cleanLine(fallbackTitle?.innerText || fallbackTitle?.textContent || ""),
+      found: false,
+      score: 0,
+    };
+  };
+"""
 _PLACE_JS_EXTRACTOR = r"""
 () => {
-  const titleSelectors = ["h1.DUwDvf", "h1.lfPIob", "div[role='main'] h1"];
-  let titleElement = null;
-  for (const selector of titleSelectors) {
-    const element = document.querySelector(selector);
-    if (element?.innerText?.trim()) {
-      titleElement = element;
-      break;
-    }
-  }
+""" + _PLACE_PANEL_HELPERS_JS + r"""
 
-  let panel = document.body;
-  if (titleElement) {
-    let current = titleElement;
-    for (let i = 0; i < 8; i += 1) {
-      if (!current.parentElement || current.parentElement.tagName === "BODY") {
-        break;
-      }
-      current = current.parentElement;
-    }
-    panel = current;
-  }
+  const panelInfo = placePanelRoot();
+  const panel = panelInfo.root;
+  const titleElement = panelInfo.titleElement;
 
   const firstText = (selectors, root = panel) => {
     for (const selector of selectors) {
@@ -438,7 +564,32 @@ _PLACE_JS_EXTRACTOR = r"""
     considerCount(match[1], "f7nice");
   }
 
+  const reviewSummaryBoundaryTop = () => {
+    const addressRow = addressRowElement();
+    if (addressRow) {
+      const rect = addressRow.getBoundingClientRect();
+      if (rect.height > 0) {
+        return rect.top;
+      }
+    }
+    const panelRect = panel.getBoundingClientRect();
+    return panelRect.top + 520;
+  };
+  const isOverviewReviewCountElement = (element) => {
+    if (element.closest("div.F7nice")) {
+      return true;
+    }
+    const rect = element.getBoundingClientRect();
+    if (rect.height <= 0) {
+      return false;
+    }
+    return rect.top < reviewSummaryBoundaryTop();
+  };
+
   for (const element of panel.querySelectorAll("[aria-label]")) {
+    if (!isOverviewReviewCountElement(element)) {
+      continue;
+    }
     const label = element.getAttribute("aria-label") || "";
     if (!reviewKeywords.some((keyword) => label.toLowerCase().includes(keyword.toLowerCase()))) {
       continue;
@@ -482,7 +633,6 @@ _PLACE_JS_EXTRACTOR = r"""
   const photoUrl = mainPhotoUrl
     || firstAttr(["meta[property='og:image']", "meta[itemprop='image']"], "content", document);
 
-  const cleanLine = (value) => (value || "").replace(/\s+/g, " ").trim();
   const shallowPath = (element) => {
     const parts = [];
     let current = element;
@@ -856,26 +1006,9 @@ _PLACE_JS_EXTRACTOR = r"""
 """
 _PLACE_REVIEW_SIGNAL_JS = r"""
 () => {
-  const titleSelectors = ["h1.DUwDvf", "h1.lfPIob", "div[role='main'] h1"];
-  let titleElement = null;
-  for (const selector of titleSelectors) {
-    const element = document.querySelector(selector);
-    if (element?.innerText?.trim()) {
-      titleElement = element;
-      break;
-    }
-  }
-  let panel = document.body;
-  if (titleElement) {
-    let current = titleElement;
-    for (let i = 0; i < 8; i += 1) {
-      if (!current.parentElement || current.parentElement.tagName === "BODY") {
-        break;
-      }
-      current = current.parentElement;
-    }
-    panel = current;
-  }
+""" + _PLACE_PANEL_HELPERS_JS + r"""
+
+  const panel = placePanelRoot().root;
   const f7nice = panel.querySelector("div.F7nice");
   if (f7nice?.innerText?.match(/[0-9]/)) {
     return true;
@@ -896,7 +1029,10 @@ _PLACE_REVIEW_SIGNAL_JS = r"""
 """
 _PLACE_REVIEW_TAB_CLICK_JS = r"""
 () => {
-  for (const tab of document.querySelectorAll("div[role='tablist'] button, button[role='tab']")) {
+""" + _PLACE_PANEL_HELPERS_JS + r"""
+
+  const root = placePanelRoot().root;
+  for (const tab of root.querySelectorAll("div[role='tablist'] button, button[role='tab']")) {
     const text = (tab.innerText || tab.textContent || "").trim();
     const ariaLabel = tab.getAttribute("aria-label") || "";
     if (/(review|reviews|評論|クチコミ)/i.test(`${text} ${ariaLabel}`)) {
@@ -909,8 +1045,9 @@ _PLACE_REVIEW_TAB_CLICK_JS = r"""
 """
 _PLACE_REVIEW_TOPIC_JS = r"""
 () => {
-  const cleanLine = (value) => (value || "").replace(/\s+/g, " ").trim();
-  let root = document.querySelector("div[role='main']") || document.body;
+""" + _PLACE_PANEL_HELPERS_JS + r"""
+
+  const root = placePanelRoot().root;
   for (const button of root.querySelectorAll("button, div[role='button']")) {
     const text = cleanLine(button.innerText || button.textContent || "");
     const ariaLabel = cleanLine(button.getAttribute("aria-label") || "");
@@ -995,6 +1132,8 @@ _PLACE_REVIEW_SNIPPET_JS = r"""
 """
 _PLACE_ABOUT_TAB_CLICK_JS = r"""
 () => {
+""" + _PLACE_PANEL_HELPERS_JS + r"""
+
   const aliases = [
     "about",
     "information",
@@ -1008,7 +1147,8 @@ _PLACE_ABOUT_TAB_CLICK_JS = r"""
     "簡介",
     "简介",
   ];
-  for (const tab of document.querySelectorAll("div[role='tablist'] button, button[role='tab']")) {
+  const root = placePanelRoot().root;
+  for (const tab of root.querySelectorAll("div[role='tablist'] button, button[role='tab']")) {
     const text = ((tab.innerText || tab.textContent || "").trim()).toLowerCase();
     const ariaLabel = ((tab.getAttribute("aria-label") || "").trim()).toLowerCase();
     if (
@@ -1034,7 +1174,9 @@ _PLACE_SEARCH_RESULT_CLICK_JS = r"""
     "結果",
     "検索結果",
   ]);
-  const isSearchResultTitle = (value) => searchResultTitleLabels.has(cleanLine(value).toLowerCase());
+  const isSearchResultTitle = (value) => searchResultTitleLabels.has(
+    cleanLine(value).toLowerCase(),
+  );
   const titleSelectors = ["h1.DUwDvf", "h1.lfPIob", "div[role='main'] h1"];
   for (const selector of titleSelectors) {
     const element = document.querySelector(selector);
@@ -1073,6 +1215,70 @@ _PLACE_SEARCH_RESULT_CLICK_JS = r"""
   const queryTokens = normalizedQuery.split(" ").filter((token) => token.length >= 3);
   const articles = Array.from(document.querySelectorAll("div[role='feed'] [role='article']"));
   let best = null;
+  const cleanSearchLabel = (value) => cleanLine(value)
+    .replace(/\s*·\s*(?:visited\s+)?link$/i, "")
+    .trim();
+  const textLines = (element) => {
+    const text = element.innerText || element.textContent || "";
+    return text.split(/\n+/).map(cleanLine).filter(Boolean);
+  };
+  const parseCardRating = (value) => {
+    const text = cleanLine(value);
+    const match = text.match(/([0-5](?:[.,][0-9]+)?)\s*(?:stars?|★)/i)
+      || text.match(/^([0-5](?:[.,][0-9]+)?)$/);
+    return match?.[1] || null;
+  };
+  const parseCardReviewCount = (value) => {
+    const text = cleanLine(value);
+    const match = text.match(
+      /([0-9][0-9,.\s]*[KM萬万]?)\s*(?:reviews?|評論|クチコミ|件のクチコミ|件の Google クチコミ)/i,
+    ) || text.match(/\(([0-9][0-9,.\s]*[KM萬万]?)\)/);
+    return match?.[1] || null;
+  };
+  const parseCardCategoryAddress = (lines) => {
+    for (const line of lines) {
+      if (!line.includes("·")) {
+        continue;
+      }
+      if (parseCardReviewCount(line) || parseCardRating(line)) {
+        continue;
+      }
+      const segments = line.split("·").map(cleanLine).filter(Boolean);
+      if (segments.length < 2) {
+        continue;
+      }
+      return {
+        category: segments[0] || null,
+        address: segments[segments.length - 1] || null,
+      };
+    }
+    return {category: null, address: null};
+  };
+  const candidateDetails = (article, href, label) => {
+    const lines = textLines(article);
+    const starLabel = cleanLine(
+      article.querySelector("[role='img'][aria-label*='star' i]")?.getAttribute("aria-label")
+        || "",
+    );
+    const rating = parseCardRating(starLabel)
+      || lines.map(parseCardRating).find(Boolean)
+      || null;
+    const reviewCount = parseCardReviewCount(starLabel)
+      || lines.map(parseCardReviewCount).find(Boolean)
+      || null;
+    const categoryAddress = parseCardCategoryAddress(lines);
+    const placeIdMatch = href.match(/!19s([^!?&]+)/) || href.match(/!1s([^!?&]+)/);
+    return {
+      href,
+      google_place_id: placeIdMatch?.[1] ? decodeURIComponent(placeIdMatch[1]) : null,
+      name: cleanSearchLabel(label),
+      rating,
+      review_count: reviewCount,
+      category: categoryAddress.category,
+      address: categoryAddress.address,
+      body_text: lines.join("\n"),
+    };
+  };
 
   for (let index = 0; index < articles.length; index += 1) {
     const article = articles[index];
@@ -1125,14 +1331,73 @@ _PLACE_SEARCH_RESULT_CLICK_JS = r"""
       }
     }
     if (!best || score > best.score) {
-      best = {href, score};
+      best = {score, details: candidateDetails(article, href, label)};
     }
   }
 
   if (!best || best.score <= 0) {
     return null;
   }
-  return best.href || null;
+  return best.details || null;
+}
+"""
+_PLACE_SEARCH_RESULT_OPEN_JS = r"""
+(targetHref) => {
+  const cleanLine = (value) => (value || "").replace(/\s+/g, " ").trim();
+  let target = "";
+  try {
+    target = cleanLine(new URL(targetHref, window.location.href).href);
+  } catch {
+    return false;
+  }
+  if (!target) {
+    return false;
+  }
+  const targetUrl = new URL(target);
+  const targetPlaceIdMatch = target.match(/!19s([^!?&]+)/) || target.match(/!1s([^!?&]+)/);
+  const targetPlaceId = targetPlaceIdMatch?.[1] || "";
+  for (const anchor of document.querySelectorAll(
+    "div[role='feed'] [role='article'] a.hfpxzc, "
+      + "div[role='feed'] [role='article'] a[href*='/maps/place/']",
+  )) {
+    const hrefValue = anchor.getAttribute("href") || anchor.href || "";
+    let href = "";
+    try {
+      href = cleanLine(new URL(hrefValue, window.location.href).href);
+    } catch {
+      continue;
+    }
+    const hrefPlaceIdMatch = href.match(/!19s([^!?&]+)/) || href.match(/!1s([^!?&]+)/);
+    const hrefPlaceId = hrefPlaceIdMatch?.[1] || "";
+    const hrefUrl = new URL(href);
+    const samePlace = (
+      href === target
+      || (targetPlaceId && hrefPlaceId && targetPlaceId === hrefPlaceId)
+      || (hrefUrl.pathname === targetUrl.pathname && hrefUrl.pathname.includes("/maps/place/"))
+    );
+    if (!samePlace) {
+      continue;
+    }
+    const targetElement = anchor.closest("[role='article']") || anchor;
+    targetElement.scrollIntoView({block: "center", inline: "center"});
+    const rect = targetElement.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      return false;
+    }
+    return {
+      x: rect.left + Math.min(Math.max(rect.width / 2, 8), rect.width - 8),
+      y: rect.top + Math.min(Math.max(rect.height / 2, 8), rect.height - 8),
+    };
+  }
+  return false;
+}
+"""
+_PLACE_DETAIL_READY_JS = r"""
+() => {
+""" + _PLACE_PANEL_HELPERS_JS + r"""
+
+  const panelInfo = placePanelRoot();
+  return panelInfo.found && Boolean(panelInfo.title) && !isSearchResultTitle(panelInfo.title);
 }
 """
 _PLACE_ABOUT_PANEL_JS = r"""
@@ -1323,7 +1588,18 @@ def _build_place_details_from_snapshot(
         Mapping[str, object],
         snapshot.get("preview") if isinstance(snapshot.get("preview"), Mapping) else {},
     )
-    merged_snapshot = _merge_place_sources(dom_snapshot, preview_snapshot)
+    search_result_snapshot = cast(
+        Mapping[str, object],
+        snapshot.get("search_result")
+        if isinstance(snapshot.get("search_result"), Mapping)
+        else {},
+    )
+    merged_snapshot = _merge_place_sources(
+        dom_snapshot,
+        search_result_snapshot,
+        secondary_source="search_result",
+    )
+    merged_snapshot = _merge_place_sources(merged_snapshot, preview_snapshot)
     details = _build_place_details(
         place_url,
         resolved_url=resolved_url,
@@ -1701,7 +1977,10 @@ def _collect_place_snapshot_with_context(
         except Exception:
             pass
         _handle_google_consent(page, timeout_ms=timeout_ms)
-        _open_place_result_from_search_page(page, timeout_ms=timeout_ms)
+        search_result_snapshot = _open_place_result_from_search_page(
+            page,
+            timeout_ms=timeout_ms,
+        )
         try:
             page.wait_for_selector(_TITLE_SELECTOR, timeout=timeout_ms, state="attached")
         except Exception:
@@ -1743,6 +2022,7 @@ def _collect_place_snapshot_with_context(
     return {
         "resolved_url": resolved_url,
         "dom": dict(dom_snapshot),
+        "search_result": search_result_snapshot or {},
         "preview": preview_snapshot,
     }
 
@@ -1806,42 +2086,129 @@ def _ensure_review_signal(page: Any, *, timeout_ms: int) -> bool:
     return _wait_for_review_signal(page, timeout_ms=min(timeout_ms, 4_000))
 
 
-def _open_place_result_from_search_page(page: Any, *, timeout_ms: int) -> bool:
-    target_url = _search_result_candidate_url(page, timeout_ms=timeout_ms)
+def _open_place_result_from_search_page(
+    page: Any,
+    *,
+    timeout_ms: int,
+) -> dict[str, object] | None:
+    candidate = _search_result_candidate(page, timeout_ms=timeout_ms)
+    if candidate is None:
+        return None
+    target_url = (
+        candidate
+        if isinstance(candidate, str)
+        else _clean_text(candidate.get("href"))
+    )
     if target_url is None:
-        return False
+        return None
     if not _looks_like_google_maps_place_url(target_url):
-        return False
+        return None
     target_url = _with_google_maps_locale(target_url)
+    clicked = _click_search_result_candidate(page, target_url, timeout_ms=timeout_ms)
+    if not clicked or not _wait_for_place_detail_title(page, timeout_ms=min(timeout_ms, 12_000)):
+        try:
+            page.goto(target_url, wait_until="domcontentloaded", timeout=timeout_ms)
+        except Exception:
+            return None
+        _handle_google_consent(page, timeout_ms=timeout_ms)
+        try:
+            page.wait_for_load_state("load", timeout=min(timeout_ms, 10_000))
+        except Exception:
+            pass
+    if not _wait_for_place_detail_title(page, timeout_ms=min(timeout_ms, 12_000)):
+        return None
+    return _search_result_snapshot(candidate)
+
+
+def _click_search_result_candidate(page: Any, target_url: str, *, timeout_ms: int) -> bool:
     try:
-        page.goto(target_url, wait_until="domcontentloaded", timeout=timeout_ms)
+        click_point = page.evaluate(_PLACE_SEARCH_RESULT_OPEN_JS, target_url)
     except Exception:
         return False
+    if not isinstance(click_point, Mapping):
+        return False
+    x = _parse_float(click_point.get("x"))
+    y = _parse_float(click_point.get("y"))
+    if x is None or y is None:
+        return False
+    mouse = getattr(page, "mouse", None)
+    click = getattr(mouse, "click", None)
+    if click is None:
+        return False
+    try:
+        click(x, y)
+    except Exception:
+        return False
+    page.wait_for_timeout(min(max(timeout_ms // 20, 1_000), 3_000))
     _handle_google_consent(page, timeout_ms=timeout_ms)
     try:
         page.wait_for_load_state("load", timeout=min(timeout_ms, 10_000))
     except Exception:
         pass
-    try:
-        page.wait_for_selector(_TITLE_SELECTOR, timeout=min(timeout_ms, 10_000), state="attached")
-    except Exception:
-        return False
     return True
 
 
+def _wait_for_place_detail_title(page: Any, *, timeout_ms: int) -> bool:
+    polls = max(1, min(24, timeout_ms // 500))
+    for _ in range(polls):
+        try:
+            if page.evaluate(_PLACE_DETAIL_READY_JS) is True:
+                return True
+        except Exception:
+            pass
+        page.wait_for_timeout(500)
+    return False
+
+
 def _search_result_candidate_url(page: Any, *, timeout_ms: int) -> str | None:
+    candidate = _search_result_candidate(page, timeout_ms=timeout_ms)
+    if isinstance(candidate, str):
+        return candidate
+    if isinstance(candidate, Mapping):
+        return _clean_text(candidate.get("href"))
+    return None
+
+
+def _search_result_candidate(
+    page: Any,
+    *,
+    timeout_ms: int,
+) -> str | dict[str, object] | None:
     polls = max(1, min(8, timeout_ms // 500))
     for _ in range(polls):
         try:
-            target_url = page.evaluate(_PLACE_SEARCH_RESULT_CLICK_JS)
+            candidate = page.evaluate(_PLACE_SEARCH_RESULT_CLICK_JS)
         except Exception:
             return None
-        if target_url is False:
+        if candidate is False:
             return None
-        if isinstance(target_url, str) and target_url.strip():
-            return target_url.strip()
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+        if isinstance(candidate, Mapping):
+            href = _clean_text(candidate.get("href"))
+            if href is not None:
+                return {**candidate, "href": href}
         page.wait_for_timeout(500)
     return None
+
+
+def _search_result_snapshot(candidate: str | Mapping[str, object]) -> dict[str, object]:
+    if not isinstance(candidate, Mapping):
+        return {}
+    snapshot: dict[str, object] = {}
+    for key in (
+        "google_place_id",
+        "name",
+        "rating",
+        "review_count",
+        "category",
+        "address",
+        "body_text",
+    ):
+        value = candidate.get(key)
+        if not _is_missing_value(value):
+            snapshot[key] = value
+    return snapshot
 
 
 def _looks_like_google_maps_place_url(value: str) -> bool:
@@ -1928,10 +2295,19 @@ def _build_place_details(
     category = _clean_category_text(snapshot.get("category")) or _extract_category_from_lines(
         search_lines
     )
-    name = _clean_structured_name_text(snapshot.get("name")) or _first_meaningful_name(
+    fallback_name = _first_meaningful_name(
         search_lines,
         excluded_values=(category,),
     )
+    structured_name = _clean_structured_name_text(snapshot.get("name"))
+    if (
+        structured_name is not None
+        and _looks_like_ui_action_label(structured_name)
+        and _snapshot_contains_ui_action_name_candidate(snapshot)
+    ):
+        name = fallback_name
+    else:
+        name = structured_name or fallback_name
     category_display_en, category_display_en_source, category_display_en_confidence = (
         _derive_category_display_en(category, snapshot)
     )
@@ -2048,18 +2424,24 @@ def _seed_google_consent_cookies(page: Any, *, source_url: str) -> None:
 def _merge_place_sources(
     primary: Mapping[str, object],
     secondary: Mapping[str, object],
+    *,
+    secondary_source: str = "preview",
 ) -> dict[str, object]:
     merged = dict(primary)
-    field_sources = {
-        key: "dom" for key, value in primary.items() if not _is_missing_value(value)
-    }
+    raw_field_sources = primary.get("field_sources")
+    field_sources = dict(raw_field_sources) if isinstance(raw_field_sources, Mapping) else {}
+    for key, value in primary.items():
+        if key == "field_sources":
+            continue
+        if key not in field_sources and not _is_missing_value(value):
+            field_sources[key] = "dom"
     for key, value in secondary.items():
         if key == "limited_view":
             merged[key] = _to_bool(merged.get(key)) or _to_bool(value)
             continue
         if _is_missing_value(merged.get(key)) and not _is_missing_value(value):
             merged[key] = value
-            field_sources[key] = "preview"
+            field_sources[key] = secondary_source
     merged["field_sources"] = field_sources
     return merged
 

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -1025,15 +1025,25 @@ _PLACE_ABOUT_TAB_CLICK_JS = r"""
 """
 _PLACE_SEARCH_RESULT_CLICK_JS = r"""
 () => {
+  const cleanLine = (value) => (value || "").replace(/\s+/g, " ").trim();
+  const searchResultTitleLabels = new Set([
+    "result",
+    "results",
+    "search result",
+    "search results",
+    "結果",
+    "検索結果",
+  ]);
+  const isSearchResultTitle = (value) => searchResultTitleLabels.has(cleanLine(value).toLowerCase());
   const titleSelectors = ["h1.DUwDvf", "h1.lfPIob", "div[role='main'] h1"];
   for (const selector of titleSelectors) {
     const element = document.querySelector(selector);
-    if (element?.innerText?.trim()) {
+    const title = cleanLine(element?.innerText || element?.textContent || "");
+    if (title && !isSearchResultTitle(title)) {
       return false;
     }
   }
 
-  const cleanLine = (value) => (value || "").replace(/\s+/g, " ").trim();
   const normalize = (value) => cleanLine(value)
     .toLowerCase()
     .replace(/[^\p{L}\p{N}]+/gu, " ")

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -13,10 +13,12 @@ from gmaps_scraper.models import (
 )
 from gmaps_scraper.place_scraper import (
     _PLACE_ABOUT_TAB_CLICK_JS,
+    _PLACE_DETAIL_READY_JS,
     _PLACE_JS_EXTRACTOR,
     _PLACE_REVIEW_TAB_CLICK_JS,
     _PLACE_REVIEW_TOPIC_JS,
     _PLACE_SEARCH_RESULT_CLICK_JS,
+    _PLACE_SEARCH_RESULT_OPEN_JS,
     _build_place_details,
     _build_place_details_from_snapshot,
     _build_place_diagnostics,
@@ -620,6 +622,14 @@ class PlaceScraperTests(unittest.TestCase):
             "new URL(hrefValue, window.location.href).href",
             _PLACE_SEARCH_RESULT_CLICK_JS,
         )
+        self.assertIn("searchResultTitleLabels", _PLACE_SEARCH_RESULT_CLICK_JS)
+        self.assertIn("parseCardReviewCount", _PLACE_SEARCH_RESULT_CLICK_JS)
+        self.assertIn("getBoundingClientRect()", _PLACE_SEARCH_RESULT_OPEN_JS)
+        self.assertIn("const placePanelRoot = () => {", _PLACE_JS_EXTRACTOR)
+        self.assertIn("visibleArea", _PLACE_JS_EXTRACTOR)
+        self.assertIn("articleCount >= 2", _PLACE_JS_EXTRACTOR)
+        self.assertIn("searchResultTitleLabels", _PLACE_DETAIL_READY_JS)
+        self.assertIn("placePanelRoot", _PLACE_REVIEW_TAB_CLICK_JS)
         self.assertIn("const detailsBoundaryTop = () => {", _PLACE_JS_EXTRACTOR)
         self.assertIn('structural_offer_kind: structuralOffers.kind,', _PLACE_JS_EXTRACTOR)
         self.assertIn(
@@ -842,6 +852,38 @@ class PlaceScraperTests(unittest.TestCase):
         assert details.diagnostics is not None
         self.assertFalse(details.diagnostics.llm_used)
         self.assertEqual(details.diagnostics.repair_source, "cache")
+
+    def test_build_place_details_backfills_from_search_result_card(self) -> None:
+        details = _build_place_details_from_snapshot(
+            "https://www.google.com/maps/search/?api=1&query=Lola+Underground",
+            snapshot={
+                "resolved_url": "https://www.google.com/maps/place/Pooles+Temple",
+                "dom": {
+                    "name": "Pooles Temple",
+                    "category": "Event venue",
+                    "rating": "4.6",
+                    "address": "Hay St &, Cathedral Ave",
+                },
+                "search_result": {
+                    "name": "Pooles Temple",
+                    "rating": "4.6",
+                    "review_count": "16",
+                    "category": "Event venue",
+                    "address": "Hay St &, Cathedral Ave",
+                },
+                "preview": {},
+            },
+            llm_fallback=None,
+            llm_policy="never",
+        )
+
+        self.assertEqual(details.name, "Pooles Temple")
+        self.assertEqual(details.review_count, 16)
+        assert details.diagnostics is not None
+        self.assertEqual(
+            details.diagnostics.field_sources.get("review_count"),
+            "search_result",
+        )
 
     def test_build_place_details_uses_dom_fields_and_body_fallbacks(self) -> None:
         details = _build_place_details(
@@ -1498,20 +1540,22 @@ class PlaceScraperTests(unittest.TestCase):
         assert details.diagnostics is not None
         self.assertIn("missing_name", details.diagnostics.quality_flags)
 
-    def test_build_place_details_preserves_structured_name_that_matches_action_label(
+    def test_build_place_details_rejects_structured_name_that_matches_action_label(
         self,
     ) -> None:
         details = _build_place_details(
-            "https://www.google.com/maps/place/Share",
-            resolved_url="https://www.google.com/maps/place/Share",
+            "https://www.google.com/maps/place/Pooles+Temple",
+            resolved_url="https://www.google.com/maps/place/Pooles+Temple",
             snapshot={
                 "name": "Share",
-                "category": "Restaurant",
-                "body_text": "\n".join(["Share", "Saved", "Directions", "Restaurant"]),
+                "category": "Event venue",
+                "body_text": "\n".join(
+                    ["Share", "Saved", "Directions", "Pooles Temple", "Event venue"]
+                ),
             },
         )
 
-        self.assertEqual(details.name, "Share")
+        self.assertEqual(details.name, "Pooles Temple")
 
     def test_build_place_details_prefers_structured_title_over_action_lines(self) -> None:
         details = _build_place_details(
@@ -1758,11 +1802,23 @@ class PlaceScraperTests(unittest.TestCase):
             def __init__(self) -> None:
                 self.waited: list[object] = []
                 self.visited: list[tuple[str, str, int]] = []
+                self.clicked: list[tuple[float, float]] = []
+                self.detail_checks = 0
+                self.mouse = self
 
-            def evaluate(self, script: object) -> object:
+            def evaluate(self, script: object, *args: object) -> object:
                 if script == _PLACE_SEARCH_RESULT_CLICK_JS:
                     return "https://www.google.com/maps/place/National+Azabu"
+                if script == _PLACE_SEARCH_RESULT_OPEN_JS:
+                    assert args[0] == "https://www.google.com/maps/place/National+Azabu?hl=en&gl=us"
+                    return {"x": 20, "y": 40}
+                if script == _PLACE_DETAIL_READY_JS:
+                    self.detail_checks += 1
+                    return True
                 return None
+
+            def click(self, x: float, y: float) -> None:
+                self.clicked.append((x, y))
 
             def goto(self, url: str, *, wait_until: str, timeout: int) -> None:
                 self.visited.append((url, wait_until, timeout))
@@ -1773,9 +1829,48 @@ class PlaceScraperTests(unittest.TestCase):
             def wait_for_selector(self, selector: str, *, timeout: int, state: str) -> None:
                 self.waited.append(("selector", selector, timeout, state))
 
+            def wait_for_timeout(self, value: int) -> None:
+                self.waited.append(("timeout", value))
+
         page = _FakePage()
         with patch("gmaps_scraper.place_scraper._handle_google_consent"):
-            self.assertTrue(_open_place_result_from_search_page(page, timeout_ms=30_000))
+            self.assertEqual(_open_place_result_from_search_page(page, timeout_ms=30_000), {})
+        self.assertEqual(page.visited, [])
+        self.assertEqual(page.clicked, [(20, 40)])
+        self.assertEqual(page.detail_checks, 2)
+        self.assertIn(("load_state", "load", 10_000), page.waited)
+
+    def test_open_place_result_from_search_page_falls_back_to_goto_when_click_fails(
+        self,
+    ) -> None:
+        class _FakePage:
+            def __init__(self) -> None:
+                self.visited: list[tuple[str, str, int]] = []
+                self.detail_checks = 0
+
+            def evaluate(self, script: object, *_args: object) -> object:
+                if script == _PLACE_SEARCH_RESULT_CLICK_JS:
+                    return "https://www.google.com/maps/place/National+Azabu"
+                if script == _PLACE_SEARCH_RESULT_OPEN_JS:
+                    return {}
+                if script == _PLACE_DETAIL_READY_JS:
+                    self.detail_checks += 1
+                    return True
+                return None
+
+            def goto(self, url: str, *, wait_until: str, timeout: int) -> None:
+                self.visited.append((url, wait_until, timeout))
+
+            def wait_for_load_state(self, _state: str, *, timeout: int) -> None:
+                assert timeout == 10_000
+
+            def wait_for_selector(self, _selector: str, *, timeout: int, state: str) -> None:
+                assert timeout == 10_000
+                assert state == "attached"
+
+        page = _FakePage()
+        with patch("gmaps_scraper.place_scraper._handle_google_consent"):
+            self.assertEqual(_open_place_result_from_search_page(page, timeout_ms=30_000), {})
         self.assertEqual(
             page.visited,
             [
@@ -1786,7 +1881,7 @@ class PlaceScraperTests(unittest.TestCase):
                 )
             ],
         )
-        self.assertIn(("load_state", "load", 10_000), page.waited)
+        self.assertEqual(page.detail_checks, 1)
 
     def test_with_google_maps_locale_replaces_existing_locale(self) -> None:
         self.assertEqual(
@@ -1801,8 +1896,10 @@ class PlaceScraperTests(unittest.TestCase):
             def __init__(self) -> None:
                 self.visited: list[str] = []
 
-            def evaluate(self, _script: object) -> object:
-                return "https://example.com/maps/place/National+Azabu"
+            def evaluate(self, script: object, *_args: object) -> object:
+                if script == _PLACE_SEARCH_RESULT_CLICK_JS:
+                    return "https://example.com/maps/place/National+Azabu"
+                return False
 
             def wait_for_timeout(self, _value: int) -> None:
                 pass
@@ -1856,6 +1953,24 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertEqual(page.evaluate_calls, 1)
         self.assertEqual(page.evaluated_scripts, [_PLACE_SEARCH_RESULT_CLICK_JS])
         self.assertEqual(page.wait_calls, 0)
+
+    def test_search_result_candidate_url_accepts_card_details_object(self) -> None:
+        class _FakePage:
+            def evaluate(self, script: object) -> object:
+                assert script == _PLACE_SEARCH_RESULT_CLICK_JS
+                return {
+                    "href": "https://www.google.com/maps/place/Pooles+Temple",
+                    "name": "Pooles Temple",
+                    "review_count": "16",
+                }
+
+            def wait_for_timeout(self, _value: int) -> None:
+                raise AssertionError("should not poll after a card candidate is found")
+
+        self.assertEqual(
+            _search_result_candidate_url(_FakePage(), timeout_ms=30_000),
+            "https://www.google.com/maps/place/Pooles+Temple",
+        )
 
     def test_extract_secondary_name_aborts_when_rating_line_follows_name(self) -> None:
         self.assertIsNone(


### PR DESCRIPTION
## Summary
- refresh affected source lists once before targeted enrichment, with a skip flag to avoid loops
- harden semantic neighborhood/tag/address cleanup and Taiwan display address normalization
- update vendored gmaps-scraper search-result recovery to click/open the best place card and select the correct pane in wide layouts

## Tests
- uv run python3 -m unittest tests.python.test_build_data.BuildDataTests.test_main_treats_enrich_place_as_targeted_refresh tests.python.test_build_data.BuildDataTests.test_main_refreshes_affected_source_before_targeted_enrichment tests.python.test_build_data.BuildDataTests.test_main_can_skip_source_refresh_before_targeted_enrichment
- uv run python -m unittest tests.test_place_scraper (vendor/gmaps-scraper)
- bun run test:python
- bun run build:data
- bun run check
- bun run build
- bun run test:frontend
- live Lola search scrape resolves Pooles Temple with review_count 16