### PR TITLE
Add configurable guide author bylines

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Supported sources:
 
 Google My Maps URLs are not supported yet.
 
+For Google Maps URL sources, raw snapshots preserve the list `owner` object, including `name`, `photo_url`, `photo_path`, `avatar_mode`, and `profile_id`, plus any `collaborators` the scraper can recover. When the scraped owner is the effective published author, source refresh downloads a square local author image into `site/public/author-photos/` and stores its `photo_path`. Guide list overrides can optionally set, replace, or suppress the generated guide `author`; use `photo_path` to point at a site-owned image under `site/public/`, or set `avatar_mode` to `photo`, `initials`, or `icon`.
+
 ## Build Your Data
 
 Refresh configured sources and rebuild generated site data:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6361,11 +6361,10 @@ def sync_list_author_photo(slug: str, author: ListAuthor | None) -> ListAuthor |
 
 def download_list_author_photo(slug: str, photo_url: str) -> str | None:
     AUTHOR_PHOTOS_DIR.mkdir(parents=True, exist_ok=True)
-    photo_prefix = canonical_author_photo_stem(slug, photo_url)
-    filename = f"{photo_prefix}.webp"
-    output_path = AUTHOR_PHOTOS_DIR / filename
-    if output_path.exists():
-        return public_author_photo_path(filename)
+    photo_stem = canonical_author_photo_stem(slug, photo_url)
+    existing_path = existing_author_photo_path(photo_stem)
+    if existing_path is not None:
+        return public_author_photo_path(existing_path.name)
 
     try:
         request = Request(
@@ -6381,21 +6380,44 @@ def download_list_author_photo(slug: str, photo_url: str) -> str | None:
         print(f"WARNING: Failed to download author photo for {slug} from {photo_url}: {exc}", flush=True)
         return None
 
-    optimized_content = optimize_author_photo_asset(content, content_type=content_type)
-    if optimized_content is None:
+    optimized_content, extension = optimize_author_photo_asset(content, content_type=content_type)
+    if optimized_content is None or extension is None:
         return None
 
+    filename = f"{photo_stem}{extension}"
+    output_path = AUTHOR_PHOTOS_DIR / filename
     temp_path = AUTHOR_PHOTOS_DIR / f".{filename}.tmp"
     temp_path.write_bytes(optimized_content)
     temp_path.replace(output_path)
 
-    author_prefix = f"{safe_author_photo_stem(slug)}-"
-    for stale_path in AUTHOR_PHOTOS_DIR.glob(f"{author_prefix}*.webp"):
-        if stale_path.name == filename or stale_path.name.startswith("."):
-            continue
+    for stale_path in stale_author_photo_paths(slug, keep_filename=filename):
         stale_path.unlink(missing_ok=True)
 
     return public_author_photo_path(filename)
+
+
+def existing_author_photo_path(photo_stem: str) -> Path | None:
+    for extension in (".webp", ".jpg"):
+        photo_path = AUTHOR_PHOTOS_DIR / f"{photo_stem}{extension}"
+        if photo_path.exists():
+            return photo_path
+    return None
+
+
+def stale_author_photo_paths(slug: str, *, keep_filename: str) -> list[Path]:
+    if not AUTHOR_PHOTOS_DIR.exists():
+        return []
+
+    safe_slug = safe_author_photo_stem(slug)
+    current_prefix = f"{safe_slug}--"
+    legacy_pattern = re.compile(rf"^{re.escape(safe_slug)}-[0-9a-f]{{12}}\.(?:webp|jpg)$")
+    stale_paths: list[Path] = []
+    for stale_path in AUTHOR_PHOTOS_DIR.iterdir():
+        if stale_path.name == keep_filename or stale_path.name.startswith(".") or not stale_path.is_file():
+            continue
+        if stale_path.name.startswith(current_prefix) or legacy_pattern.fullmatch(stale_path.name):
+            stale_paths.append(stale_path)
+    return stale_paths
 
 
 def safe_author_photo_stem(slug: str) -> str:
@@ -6405,7 +6427,7 @@ def safe_author_photo_stem(slug: str) -> str:
 
 def canonical_author_photo_stem(slug: str, photo_url: str) -> str:
     photo_hash = hashlib.sha256(photo_url.encode("utf-8")).hexdigest()[:12]
-    return f"{safe_author_photo_stem(slug)}-{photo_hash}"
+    return f"{safe_author_photo_stem(slug)}--{photo_hash}"
 
 
 def populate_place_photos_for_guides(
@@ -6836,7 +6858,11 @@ def optimize_place_photo_asset(
         return None, None
 
 
-def optimize_author_photo_asset(content: bytes, *, content_type: str | None) -> bytes | None:
+def optimize_author_photo_asset(
+    content: bytes,
+    *,
+    content_type: str | None,
+) -> tuple[bytes, str] | tuple[None, None]:
     try:
         with Image.open(io.BytesIO(content)) as image:
             image.load()
@@ -6847,23 +6873,34 @@ def optimize_author_photo_asset(content: bytes, *, content_type: str | None) -> 
                 method=Image.Resampling.LANCZOS,
                 centering=(0.5, 0.5),
             )
-            if resized.mode != "RGB":
-                resized = resized.convert("RGB")
 
             output = io.BytesIO()
+            if image_supports_webp():
+                if resized.mode not in {"RGB", "RGBA"}:
+                    resized = resized.convert("RGB")
+                resized.save(
+                    output,
+                    format="WEBP",
+                    quality=AUTHOR_PHOTO_QUALITY,
+                    method=6,
+                )
+                return output.getvalue(), ".webp"
+
+            if resized.mode != "RGB":
+                resized = resized.convert("RGB")
             resized.save(
                 output,
-                format="WEBP",
+                format="JPEG",
                 quality=AUTHOR_PHOTO_QUALITY,
-                method=6,
+                optimize=True,
             )
-            return output.getvalue()
+            return output.getvalue(), ".jpg"
     except (OSError, UnidentifiedImageError) as exc:
         print(
             f"WARNING: Failed to optimize downloaded author photo ({content_type or 'unknown'}): {exc}",
             flush=True,
         )
-        return None
+        return None, None
 
 
 def image_supports_webp() -> bool:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -38,6 +38,7 @@ try:
         EnrichmentPlace,
         Guide,
         GuideManifest,
+        ListAuthor,
         MarkerIcon,
         NormalizedPlace,
         PlacesSettings,
@@ -54,6 +55,7 @@ except ModuleNotFoundError:
         EnrichmentPlace,
         Guide,
         GuideManifest,
+        ListAuthor,
         MarkerIcon,
         NormalizedPlace,
         PlacesSettings,
@@ -104,6 +106,7 @@ GENERATED_DIR = ROOT / "src" / "data" / "generated"
 GENERATED_LISTS_DIR = GENERATED_DIR / "lists"
 PUBLIC_DATA_DIR = ROOT / "public" / "data"
 PLACE_PHOTOS_DIR = SITE_DIR / "public" / "place-photos"
+AUTHOR_PHOTOS_DIR = SITE_DIR / "public" / "author-photos"
 SITE_BUILD_HOOKS_PATH = SITE_DIR / "build_hooks.py"
 SITE_ENRICHMENT_CONFIG_PATH = SITE_DIR / "enrichment.json"
 LIST_OVERRIDES_DIR = SITE_DIR / "overrides" / "lists"
@@ -144,6 +147,8 @@ PHOTO_DOWNLOAD_TIMEOUT_SECONDS = 20
 PHOTO_CARD_WIDTH = 800
 PHOTO_CARD_HEIGHT = 600
 PHOTO_CARD_QUALITY = 78
+AUTHOR_PHOTO_SIZE = 160
+AUTHOR_PHOTO_QUALITY = 82
 MIN_PLACE_PHOTO_SOURCE_DIMENSION = 200
 PLACE_PHOTO_SOURCE_DIMENSION_RE = re.compile(r"w(?P<width>\d+)-h(?P<height>\d+)")
 PRICE_DISPLAY_SOURCE_FIELDS = ("price_range", "admission_price", "room_price")
@@ -1917,6 +1922,8 @@ def scrape_google_list_url(source: SourceConfig, *, headed: bool) -> RawSavedLis
         if source.title and not payload.title:
             payload.title = source.title
         stamp_raw_saved_list(payload, source, source_signature=raw_source_signature(source))
+        if not list_author_is_overridden(source.slug):
+            payload.owner = sync_list_author_photo(source.slug, payload.owner)
         return payload
     finally:
         release_scraper_session_lock(session_state)
@@ -2327,6 +2334,7 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
 
     title = as_string(list_override.get("title")) or raw.title or slug.replace("-", " ").title()
     description = as_string(list_override.get("description")) or raw.description
+    author = guide_author_for_ui(raw, list_override=list_override)
     description = transform_guide_description_with_site_hook(
         description,
         slug=slug,
@@ -2574,6 +2582,7 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
         slug=slug,
         title=title,
         description=description,
+        author=author,
         source_url=raw.source_url,
         list_id=raw.list_id,
         country_name=country_name or "Unknown",
@@ -2979,6 +2988,7 @@ def summarize_guide(guide: Guide) -> GuideManifest:
         slug=guide.slug,
         title=guide.title,
         description=guide.description,
+        author=guide.author,
         country_name=guide.country_name,
         country_code=guide.country_code,
         center_lat=guide.center_lat,
@@ -4579,6 +4589,48 @@ def normalize_text_blocks(value: str | None) -> str | None:
     normalized = re.sub(r"\n[ \t]*\n(?:[ \t]*\n)+", "\n\n", normalized)
     normalized = normalized.strip()
     return normalized or None
+
+
+def coerce_list_author(value: Any) -> ListAuthor | None:
+    if value is None:
+        return None
+    if isinstance(value, ListAuthor):
+        return value
+    if isinstance(value, str):
+        normalized = as_string(value)
+        return ListAuthor(name=normalized) if normalized else None
+    if isinstance(value, dict):
+        name = as_string(value.get("name"))
+        if not name:
+            return None
+        return ListAuthor(
+            name=name,
+            photo_url=as_string(value.get("photo_url")),
+            photo_path=as_string(value.get("photo_path")),
+            avatar_mode=normalize_author_avatar_mode(value.get("avatar_mode")),
+            profile_id=as_string(value.get("profile_id")),
+        )
+    return None
+
+
+def normalize_author_avatar_mode(value: Any) -> Literal["photo", "initials", "icon"] | None:
+    normalized = as_string(value)
+    if normalized in {"photo", "initials", "icon"}:
+        return normalized
+    return None
+
+
+def list_author_is_overridden(slug: str) -> bool:
+    list_override = read_json(LIST_OVERRIDES_DIR / f"{slug}.json")
+    return "author" in list_override or "owner" in list_override
+
+
+def guide_author_for_ui(raw: RawSavedList, *, list_override: dict[str, Any]) -> ListAuthor | None:
+    if "author" in list_override:
+        return coerce_list_author(list_override.get("author"))
+    if "owner" in list_override:
+        return coerce_list_author(list_override.get("owner"))
+    return raw.owner
 
 
 def load_raw_saved_list(path: Path) -> RawSavedList | None:
@@ -6293,6 +6345,69 @@ def cached_place_photo_url(cache_entry: EnrichmentCacheEntry | None) -> str | No
     return cache_entry.place.main_photo_url or cache_entry.place.photo_url
 
 
+def sync_list_author_photo(slug: str, author: ListAuthor | None) -> ListAuthor | None:
+    if author is None or not author.photo_url:
+        return author
+    if author.photo_path:
+        existing_path = public_asset_absolute_path(author.photo_path)
+        if existing_path is not None and existing_path.exists():
+            return author
+
+    photo_path = download_list_author_photo(slug, author.photo_url)
+    if photo_path is None:
+        return author
+    return author.model_copy(update={"photo_path": photo_path})
+
+
+def download_list_author_photo(slug: str, photo_url: str) -> str | None:
+    AUTHOR_PHOTOS_DIR.mkdir(parents=True, exist_ok=True)
+    photo_prefix = canonical_author_photo_stem(slug, photo_url)
+    filename = f"{photo_prefix}.webp"
+    output_path = AUTHOR_PHOTOS_DIR / filename
+    if output_path.exists():
+        return public_author_photo_path(filename)
+
+    try:
+        request = Request(
+            photo_url,
+            headers={"User-Agent": "Mozilla/5.0 favorite-places author photo fetch"},
+        )
+        with urlopen(request, timeout=PHOTO_DOWNLOAD_TIMEOUT_SECONDS) as response:
+            content = response.read()
+            if not content:
+                return None
+            content_type = response_content_type(response)
+    except (HTTPError, URLError, OSError) as exc:
+        print(f"WARNING: Failed to download author photo for {slug} from {photo_url}: {exc}", flush=True)
+        return None
+
+    optimized_content = optimize_author_photo_asset(content, content_type=content_type)
+    if optimized_content is None:
+        return None
+
+    temp_path = AUTHOR_PHOTOS_DIR / f".{filename}.tmp"
+    temp_path.write_bytes(optimized_content)
+    temp_path.replace(output_path)
+
+    author_prefix = f"{safe_author_photo_stem(slug)}-"
+    for stale_path in AUTHOR_PHOTOS_DIR.glob(f"{author_prefix}*.webp"):
+        if stale_path.name == filename or stale_path.name.startswith("."):
+            continue
+        stale_path.unlink(missing_ok=True)
+
+    return public_author_photo_path(filename)
+
+
+def safe_author_photo_stem(slug: str) -> str:
+    sanitized = re.sub(r"[^A-Za-z0-9._-]+", "-", slug).strip("-._")
+    return sanitized or "author"
+
+
+def canonical_author_photo_stem(slug: str, photo_url: str) -> str:
+    photo_hash = hashlib.sha256(photo_url.encode("utf-8")).hexdigest()[:12]
+    return f"{safe_author_photo_stem(slug)}-{photo_hash}"
+
+
 def populate_place_photos_for_guides(
     guides: list[Guide],
     *,
@@ -6721,12 +6836,46 @@ def optimize_place_photo_asset(
         return None, None
 
 
+def optimize_author_photo_asset(content: bytes, *, content_type: str | None) -> bytes | None:
+    try:
+        with Image.open(io.BytesIO(content)) as image:
+            image.load()
+            working = ImageOps.exif_transpose(image)
+            resized = ImageOps.fit(
+                working,
+                (AUTHOR_PHOTO_SIZE, AUTHOR_PHOTO_SIZE),
+                method=Image.Resampling.LANCZOS,
+                centering=(0.5, 0.5),
+            )
+            if resized.mode != "RGB":
+                resized = resized.convert("RGB")
+
+            output = io.BytesIO()
+            resized.save(
+                output,
+                format="WEBP",
+                quality=AUTHOR_PHOTO_QUALITY,
+                method=6,
+            )
+            return output.getvalue()
+    except (OSError, UnidentifiedImageError) as exc:
+        print(
+            f"WARNING: Failed to optimize downloaded author photo ({content_type or 'unknown'}): {exc}",
+            flush=True,
+        )
+        return None
+
+
 def image_supports_webp() -> bool:
     return bool(features.check("webp"))
 
 
 def public_photo_path(filename: str) -> str:
     return f"/place-photos/{filename}"
+
+
+def public_author_photo_path(filename: str) -> str:
+    return f"/author-photos/{filename}"
 
 
 def place_details_display_field_map(details: Any) -> dict[str, object]:

--- a/scripts/pipeline_models.py
+++ b/scripts/pipeline_models.py
@@ -153,6 +153,14 @@ class RawPlace(PipelineModel):
     maps_place_token: str | None = None
 
 
+class ListAuthor(PipelineModel):
+    name: str
+    photo_url: str | None = None
+    photo_path: str | None = None
+    avatar_mode: Literal["photo", "initials", "icon"] | None = None
+    profile_id: str | None = None
+
+
 class RawSavedList(PipelineModel):
     fetched_at: str | None = None
     refresh_after: str | None = None
@@ -164,6 +172,8 @@ class RawSavedList(PipelineModel):
     list_id: str | None = None
     title: str | None = None
     description: str | None = None
+    owner: ListAuthor | None = None
+    collaborators: list[ListAuthor] = Field(default_factory=list)
     places: list[RawPlace] = Field(default_factory=list)
 
 
@@ -315,6 +325,7 @@ class Guide(PipelineModel):
     slug: str
     title: str
     description: str | None = None
+    author: ListAuthor | None = None
     source_url: str | None = None
     list_id: str | None = None
     country_name: str
@@ -337,6 +348,7 @@ class GuideManifest(PipelineModel):
     slug: str
     title: str
     description: str | None = None
+    author: ListAuthor | None = None
     country_name: str
     country_code: str | None = None
     center_lat: float | None = None

--- a/site.example/config.ts
+++ b/site.example/config.ts
@@ -28,6 +28,7 @@ export const siteConfig = {
   },
   guide: {
     fallbackDescription: "Saved places for this city.",
+    showAuthor: true,
     sidebarContent: ["Guide aside content can come from config or `site/content/templates/`."],
     topPicksEyebrow: "Favorites",
     topPicksHeading: "Top suggestions",
@@ -38,6 +39,7 @@ export const siteConfig = {
   },
   guideCard: {
     showDescription: true,
+    showAuthor: true,
     showTags: true,
     maxTags: 4,
     showPlaceCount: true,

--- a/site.example/overrides/lists/taipei-taiwan.json
+++ b/site.example/overrides/lists/taipei-taiwan.json
@@ -1,5 +1,9 @@
 {
   "description": "A tiny public Google Maps list used by the template demo. It exercises source sync, country filters, guide maps, and place cards.",
+  "author": {
+    "name": "Another Author",
+    "avatar_mode": "initials"
+  },
   "country_name": "Taiwan",
   "country_code": "TW",
   "list_tags": ["landmarks", "seafood", "example"],

--- a/site.example/overrides/lists/tokyo-japan.json
+++ b/site.example/overrides/lists/tokyo-japan.json
@@ -1,5 +1,9 @@
 {
   "description": "A tiny public Google Maps list used by the template demo. It keeps the sample deterministic while showing real list imports.",
+  "author": {
+    "name": "Example Curator",
+    "photo_path": "/author-photos/example-curator.svg"
+  },
   "country_name": "Japan",
   "country_code": "JP",
   "list_tags": ["parks", "burgers", "landmarks", "example"],

--- a/site.example/public/author-photos/example-curator.svg
+++ b/site.example/public/author-photos/example-curator.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-label="Example curator avatar">
+  <path
+    d="M49 105c8-20 22-30 31-30s23 10 31 30"
+    fill="none"
+    stroke="#8e342b"
+    stroke-linecap="round"
+    stroke-width="10"
+  />
+  <circle
+    cx="80"
+    cy="58"
+    r="18"
+    fill="none"
+    stroke="#8e342b"
+    stroke-width="10"
+  />
+</svg>

--- a/src/components/AuthorByline.astro
+++ b/src/components/AuthorByline.astro
@@ -1,0 +1,55 @@
+---
+
+import { getAuthorAvatarMode, getAuthorInitials } from "../lib/authorAvatar";
+import type { ListAuthor } from "../lib/types";
+
+interface Props {
+  author: ListAuthor;
+  label: string;
+  variant: "card" | "hero";
+}
+
+const { author, label, variant } = Astro.props;
+const authorName = author.name.trim();
+const avatarMode = getAuthorAvatarMode(author);
+const photoUrl = avatarMode === "photo" ? author.photo_path?.trim() || null : null;
+const initials = avatarMode === "initials" ? getAuthorInitials(authorName) : null;
+---
+
+<span class={`guide-author guide-author--${variant}`}>
+  <span class="guide-author-mark" aria-hidden="true">
+    <svg
+      class={`guide-author-icon${photoUrl || initials ? " guide-author-icon--hidden" : ""}`}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      focusable="false"
+      data-author-fallback
+    >
+      <path
+        d="M12 6.5a3.2 3.2 0 1 1 0 6.4 3.2 3.2 0 0 1 0-6.4ZM5.8 19.2c.75-2.8 3.05-4.35 6.2-4.35s5.45 1.55 6.2 4.35"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1.9"
+      />
+    </svg>
+    {
+      photoUrl && (
+        <img
+          class="guide-author-photo"
+          src={photoUrl}
+          alt=""
+          loading="lazy"
+          decoding="async"
+          onerror="this.parentElement?.querySelector('[data-author-fallback]')?.classList.remove('guide-author-icon--hidden'); this.remove()"
+        />
+      )
+    }
+    {initials && <span class="guide-author-initials">{initials}</span>}
+  </span>
+  <span class="guide-author-copy">
+    <span class="guide-author-label">{label}</span>
+    <span class="guide-author-name">{authorName}</span>
+  </span>
+</span>

--- a/src/components/GuideCard.astro
+++ b/src/components/GuideCard.astro
@@ -1,6 +1,7 @@
 ---
 
 import { siteConfig } from "../data/site";
+import { getAuthorAvatarMode, getAuthorInitials } from "../lib/authorAvatar";
 import { getDisplayGuideTags, normalizeTagValue } from "../lib/placeTags";
 import { renderRichText } from "../lib/renderRichText";
 import type { GuideManifest } from "../lib/types";
@@ -16,9 +17,14 @@ const displayGuideTags = getDisplayGuideTags(guide.list_tags, {
   countryCode: guide.country_code,
   countryName: guide.country_name,
 });
+const guideAuthorName = guide.author?.name?.trim() || null;
+const guideAuthorAvatarMode = getAuthorAvatarMode(guide.author);
+const guideAuthorPhotoUrl = guideAuthorAvatarMode === "photo" ? guide.author?.photo_path?.trim() || null : null;
+const guideAuthorInitials = guideAuthorAvatarMode === "initials" ? getAuthorInitials(guideAuthorName) : null;
 const guideSearchText = [
   guide.title,
   guide.description,
+  guideAuthorName,
   guide.country_name,
   guide.country_code,
   guide.city_name,
@@ -97,9 +103,39 @@ const guideDisplayTitle = trimCountryFromTitle(guide.title);
     </div>
   )}
 
-  {siteConfig.guideCard.showPlaceCount && (
+  {(siteConfig.guideCard.showPlaceCount || (siteConfig.guideCard.showAuthor && guideAuthorName)) && (
     <div class="guide-card-footer ui-card-footer">
       <div class="stats-row ui-meta-row">
+        {siteConfig.guideCard.showAuthor && guideAuthorName && (
+          <span class="guide-author guide-author--card">
+            <span class="guide-author-mark" aria-hidden="true">
+              <svg class={`guide-author-icon${guideAuthorPhotoUrl || guideAuthorInitials ? " guide-author-icon--hidden" : ""}`} viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false" data-author-fallback>
+                <path
+                  d="M12 6.5a3.2 3.2 0 1 1 0 6.4 3.2 3.2 0 0 1 0-6.4ZM5.8 19.2c.75-2.8 3.05-4.35 6.2-4.35s5.45 1.55 6.2 4.35"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.9"
+                />
+              </svg>
+              {guideAuthorPhotoUrl && (
+                <img
+                  class="guide-author-photo"
+                  src={guideAuthorPhotoUrl}
+                  alt=""
+                  loading="lazy"
+                  decoding="async"
+                  onerror="this.parentElement?.querySelector('[data-author-fallback]')?.classList.remove('guide-author-icon--hidden'); this.remove()"
+                />
+              )}
+              {guideAuthorInitials && <span class="guide-author-initials">{guideAuthorInitials}</span>}
+            </span>
+            <span class="guide-author-copy">
+              <span class="guide-author-label">{siteConfig.guideCard.authorLabel}</span>
+              <span class="guide-author-name">{guideAuthorName}</span>
+            </span>
+          </span>
+        )}
         {siteConfig.guideCard.showPlaceCount && (
           <span class="count-chip guide-card-place-count">
             <strong>{guide.place_count}</strong>

--- a/src/components/GuideCard.astro
+++ b/src/components/GuideCard.astro
@@ -1,10 +1,10 @@
 ---
 
 import { siteConfig } from "../data/site";
-import { getAuthorAvatarMode, getAuthorInitials } from "../lib/authorAvatar";
 import { getDisplayGuideTags, normalizeTagValue } from "../lib/placeTags";
 import { renderRichText } from "../lib/renderRichText";
 import type { GuideManifest } from "../lib/types";
+import AuthorByline from "./AuthorByline.astro";
 
 interface Props {
   guide: GuideManifest;
@@ -18,9 +18,6 @@ const displayGuideTags = getDisplayGuideTags(guide.list_tags, {
   countryName: guide.country_name,
 });
 const guideAuthorName = guide.author?.name?.trim() || null;
-const guideAuthorAvatarMode = getAuthorAvatarMode(guide.author);
-const guideAuthorPhotoUrl = guideAuthorAvatarMode === "photo" ? guide.author?.photo_path?.trim() || null : null;
-const guideAuthorInitials = guideAuthorAvatarMode === "initials" ? getAuthorInitials(guideAuthorName) : null;
 const guideSearchText = [
   guide.title,
   guide.description,
@@ -106,36 +103,7 @@ const guideDisplayTitle = trimCountryFromTitle(guide.title);
   {(siteConfig.guideCard.showPlaceCount || (siteConfig.guideCard.showAuthor && guideAuthorName)) && (
     <div class="guide-card-footer ui-card-footer">
       <div class="stats-row ui-meta-row">
-        {siteConfig.guideCard.showAuthor && guideAuthorName && (
-          <span class="guide-author guide-author--card">
-            <span class="guide-author-mark" aria-hidden="true">
-              <svg class={`guide-author-icon${guideAuthorPhotoUrl || guideAuthorInitials ? " guide-author-icon--hidden" : ""}`} viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false" data-author-fallback>
-                <path
-                  d="M12 6.5a3.2 3.2 0 1 1 0 6.4 3.2 3.2 0 0 1 0-6.4ZM5.8 19.2c.75-2.8 3.05-4.35 6.2-4.35s5.45 1.55 6.2 4.35"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.9"
-                />
-              </svg>
-              {guideAuthorPhotoUrl && (
-                <img
-                  class="guide-author-photo"
-                  src={guideAuthorPhotoUrl}
-                  alt=""
-                  loading="lazy"
-                  decoding="async"
-                  onerror="this.parentElement?.querySelector('[data-author-fallback]')?.classList.remove('guide-author-icon--hidden'); this.remove()"
-                />
-              )}
-              {guideAuthorInitials && <span class="guide-author-initials">{guideAuthorInitials}</span>}
-            </span>
-            <span class="guide-author-copy">
-              <span class="guide-author-label">{siteConfig.guideCard.authorLabel}</span>
-              <span class="guide-author-name">{guideAuthorName}</span>
-            </span>
-          </span>
-        )}
+        {siteConfig.guideCard.showAuthor && guide.author && guideAuthorName && <AuthorByline author={guide.author} label={siteConfig.guideCard.authorLabel} variant="card" />}
         {siteConfig.guideCard.showPlaceCount && (
           <span class="count-chip guide-card-place-count">
             <strong>{guide.place_count}</strong>

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -50,6 +50,8 @@ export interface SiteConfig {
   };
   guide: {
     fallbackDescription: string;
+    showAuthor: boolean;
+    authorLabel: string;
     sidebarContent: string[];
     backLinkLabel: string;
     sourceListLabel: string;
@@ -86,6 +88,8 @@ export interface SiteConfig {
   guideCard: {
     showDescription: boolean;
     fallbackDescription: string;
+    showAuthor: boolean;
+    authorLabel: string;
     showTags: boolean;
     maxTags: number;
     showPlaceCount: boolean;
@@ -164,6 +168,8 @@ const defaultSiteConfig: SiteConfig = {
   },
   guide: {
     fallbackDescription: "Saved places for this city.",
+    showAuthor: false,
+    authorLabel: "By",
     sidebarContent: [],
     backLinkLabel: "Back to all guides",
     sourceListLabel: "View source list",
@@ -200,6 +206,8 @@ const defaultSiteConfig: SiteConfig = {
   guideCard: {
     showDescription: true,
     fallbackDescription: "Saved places for this guide.",
+    showAuthor: false,
+    authorLabel: "By",
     showTags: true,
     maxTags: 4,
     showPlaceCount: true,

--- a/src/lib/authorAvatar.ts
+++ b/src/lib/authorAvatar.ts
@@ -1,0 +1,31 @@
+import type { ListAuthor } from "./types";
+
+export type AuthorAvatarMode = "photo" | "initials" | "icon";
+
+export function getAuthorInitials(name: string | null | undefined): string {
+  const normalizedName = name?.trim();
+  if (!normalizedName) {
+    return "";
+  }
+
+  const words = normalizedName
+    .split(/[\s._-]+/u)
+    .map((word) => Array.from(word.replace(/[^\p{L}\p{N}]/gu, "")))
+    .filter((letters) => letters.length > 0);
+
+  if (words.length === 0) {
+    return "";
+  }
+
+  const initials =
+    words.length === 1 ? words[0].slice(0, 2) : [words[0][0], words[words.length - 1][0]];
+
+  return initials.join("").toLocaleUpperCase();
+}
+
+export function getAuthorAvatarMode(author: ListAuthor | null | undefined): AuthorAvatarMode {
+  if (author?.avatar_mode === "initials" || author?.avatar_mode === "icon") {
+    return author.avatar_mode;
+  }
+  return author?.photo_path?.trim() ? "photo" : "icon";
+}

--- a/src/lib/authorAvatar.ts
+++ b/src/lib/authorAvatar.ts
@@ -20,7 +20,7 @@ export function getAuthorInitials(name: string | null | undefined): string {
   const initials =
     words.length === 1 ? words[0].slice(0, 2) : [words[0][0], words[words.length - 1][0]];
 
-  return initials.join("").toLocaleUpperCase();
+  return initials.join("").toUpperCase();
 }
 
 export function getAuthorAvatarMode(author: ListAuthor | null | undefined): AuthorAvatarMode {

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -43,6 +43,7 @@ function summarizeGuide(guide: Guide): GuideManifest {
     slug: guide.slug,
     title: guide.title,
     description: guide.description,
+    author: guide.author,
     country_name: getDisplayCountryName(guide),
     country_code: guide.country_code,
     center_lat: guide.center_lat ?? null,

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -214,6 +214,20 @@ export function buildGuideJsonLd({
     position: index + 1,
     item: buildPlaceEntity(place),
   }));
+  const guideAuthor = guide.author?.name?.trim()
+    ? {
+        "@type": "Person",
+        name: normalizeWhitespace(guide.author.name),
+        ...(guide.author.photo_path || guide.author.photo_url
+          ? {
+              image: new URL(
+                guide.author.photo_path ?? guide.author.photo_url ?? "",
+                siteUrl,
+              ).toString(),
+            }
+          : {}),
+      }
+    : null;
 
   return [
     {
@@ -244,6 +258,7 @@ export function buildGuideJsonLd({
       isPartOf: {
         "@id": `${siteUrl}#website`,
       },
+      ...(guideAuthor ? { author: guideAuthor } : {}),
       about: {
         "@type": "Place",
         name: [guide.city_name, countryName].filter(Boolean).join(", "),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -84,10 +84,19 @@ export interface Place {
   provenance: PlaceProvenance;
 }
 
+export interface ListAuthor {
+  name: string;
+  photo_url?: string | null;
+  photo_path?: string | null;
+  avatar_mode?: "photo" | "initials" | "icon" | null;
+  profile_id?: string | null;
+}
+
 export interface Guide {
   slug: string;
   title: string;
   description: string | null;
+  author?: ListAuthor | null;
   source_url: string | null;
   list_id: string | null;
   country_name: string;
@@ -110,6 +119,7 @@ export interface GuideManifest {
   slug: string;
   title: string;
   description: string | null;
+  author?: ListAuthor | null;
   country_name: string;
   country_code: string | null;
   center_lat: number | null;

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -5,6 +5,7 @@ import Layout from "../../components/Layout.astro";
 import PlaceCard from "../../components/PlaceCard.astro";
 import SectionHeading from "../../components/ui/SectionHeading.astro";
 import { siteConfig } from "../../data/site";
+import { getAuthorAvatarMode, getAuthorInitials } from "../../lib/authorAvatar";
 import { getDisplayCountryName, getGuides } from "../../lib/data";
 import { getGuideAsideHtml, getTemplateHtml } from "../../lib/heroAsideContent";
 import {
@@ -117,6 +118,10 @@ const areaFilters = areaFilterGroups.primary;
 const broaderAreaFilters = areaFilterGroups.secondary;
 const displayGuideTags = getDisplayGuideTags(guide.list_tags, placeTagGuideContext);
 const displayCountryName = getDisplayCountryName(guide);
+const guideAuthorName = guide.author?.name?.trim() || null;
+const guideAuthorAvatarMode = getAuthorAvatarMode(guide.author);
+const guideAuthorPhotoUrl = guideAuthorAvatarMode === "photo" ? guide.author?.photo_path?.trim() || null : null;
+const guideAuthorInitials = guideAuthorAvatarMode === "initials" ? getAuthorInitials(guideAuthorName) : null;
 const explicitTypes = [
   ...visiblePlaces.reduce((typeCounts, place) => {
     if (place.primary_category) {
@@ -253,6 +258,36 @@ const guideJsonLd = [
             <p class="lede ui-lede">{siteConfig.guide.fallbackDescription}</p>
           )
         }
+        {siteConfig.guide.showAuthor && guideAuthorName && (
+          <div class="guide-author guide-author--hero">
+            <span class="guide-author-mark" aria-hidden="true">
+              <svg class={`guide-author-icon${guideAuthorPhotoUrl || guideAuthorInitials ? " guide-author-icon--hidden" : ""}`} viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false" data-author-fallback>
+                <path
+                  d="M12 6.5a3.2 3.2 0 1 1 0 6.4 3.2 3.2 0 0 1 0-6.4ZM5.8 19.2c.75-2.8 3.05-4.35 6.2-4.35s5.45 1.55 6.2 4.35"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.9"
+                />
+              </svg>
+              {guideAuthorPhotoUrl && (
+                <img
+                  class="guide-author-photo"
+                  src={guideAuthorPhotoUrl}
+                  alt=""
+                  loading="lazy"
+                  decoding="async"
+                  onerror="this.parentElement?.querySelector('[data-author-fallback]')?.classList.remove('guide-author-icon--hidden'); this.remove()"
+                />
+              )}
+              {guideAuthorInitials && <span class="guide-author-initials">{guideAuthorInitials}</span>}
+            </span>
+            <span class="guide-author-copy">
+              <span class="guide-author-label">{siteConfig.guide.authorLabel}</span>
+              <span class="guide-author-name">{guideAuthorName}</span>
+            </span>
+          </div>
+        )}
         <div class="hero-meta ui-meta-row">
           <span class="stat-pill ui-pill">{guide.place_count} places</span>
           {guide.source_url && (

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -1,11 +1,11 @@
 ---
 
+import AuthorByline from "../../components/AuthorByline.astro";
 import GuideMap from "../../components/GuideMap.astro";
 import Layout from "../../components/Layout.astro";
 import PlaceCard from "../../components/PlaceCard.astro";
 import SectionHeading from "../../components/ui/SectionHeading.astro";
 import { siteConfig } from "../../data/site";
-import { getAuthorAvatarMode, getAuthorInitials } from "../../lib/authorAvatar";
 import { getDisplayCountryName, getGuides } from "../../lib/data";
 import { getGuideAsideHtml, getTemplateHtml } from "../../lib/heroAsideContent";
 import {
@@ -119,9 +119,6 @@ const broaderAreaFilters = areaFilterGroups.secondary;
 const displayGuideTags = getDisplayGuideTags(guide.list_tags, placeTagGuideContext);
 const displayCountryName = getDisplayCountryName(guide);
 const guideAuthorName = guide.author?.name?.trim() || null;
-const guideAuthorAvatarMode = getAuthorAvatarMode(guide.author);
-const guideAuthorPhotoUrl = guideAuthorAvatarMode === "photo" ? guide.author?.photo_path?.trim() || null : null;
-const guideAuthorInitials = guideAuthorAvatarMode === "initials" ? getAuthorInitials(guideAuthorName) : null;
 const explicitTypes = [
   ...visiblePlaces.reduce((typeCounts, place) => {
     if (place.primary_category) {
@@ -258,36 +255,7 @@ const guideJsonLd = [
             <p class="lede ui-lede">{siteConfig.guide.fallbackDescription}</p>
           )
         }
-        {siteConfig.guide.showAuthor && guideAuthorName && (
-          <div class="guide-author guide-author--hero">
-            <span class="guide-author-mark" aria-hidden="true">
-              <svg class={`guide-author-icon${guideAuthorPhotoUrl || guideAuthorInitials ? " guide-author-icon--hidden" : ""}`} viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false" data-author-fallback>
-                <path
-                  d="M12 6.5a3.2 3.2 0 1 1 0 6.4 3.2 3.2 0 0 1 0-6.4ZM5.8 19.2c.75-2.8 3.05-4.35 6.2-4.35s5.45 1.55 6.2 4.35"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.9"
-                />
-              </svg>
-              {guideAuthorPhotoUrl && (
-                <img
-                  class="guide-author-photo"
-                  src={guideAuthorPhotoUrl}
-                  alt=""
-                  loading="lazy"
-                  decoding="async"
-                  onerror="this.parentElement?.querySelector('[data-author-fallback]')?.classList.remove('guide-author-icon--hidden'); this.remove()"
-                />
-              )}
-              {guideAuthorInitials && <span class="guide-author-initials">{guideAuthorInitials}</span>}
-            </span>
-            <span class="guide-author-copy">
-              <span class="guide-author-label">{siteConfig.guide.authorLabel}</span>
-              <span class="guide-author-name">{guideAuthorName}</span>
-            </span>
-          </div>
-        )}
+        {siteConfig.guide.showAuthor && guide.author && guideAuthorName && <AuthorByline author={guide.author} label={siteConfig.guide.authorLabel} variant="hero" />}
         <div class="hero-meta ui-meta-row">
           <span class="stat-pill ui-pill">{guide.place_count} places</span>
           {guide.source_url && (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -383,6 +383,117 @@
     background: color-mix(in srgb, var(--surface-strong) 54%, var(--surface));
   }
 
+  .guide-author {
+    display: inline-flex;
+    min-width: 0;
+    max-width: 100%;
+    align-items: center;
+    gap: 0.55rem;
+    color: var(--muted);
+    font-size: 0.82rem;
+    line-height: 1.35;
+  }
+
+  .guide-author-mark {
+    position: relative;
+    display: inline-grid;
+    width: 1.65rem;
+    height: 1.65rem;
+    flex: 0 0 auto;
+    place-items: center;
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--line));
+    border-radius: 999px;
+    background:
+      linear-gradient(
+        135deg,
+        color-mix(in srgb, var(--surface) 82%, white),
+        color-mix(in srgb, var(--accent-soft) 42%, var(--surface))
+      ),
+      var(--surface);
+    color: var(--accent-strong);
+    box-shadow: inset 0 1px 0 color-mix(in srgb, white 78%, transparent);
+  }
+
+  .guide-author-icon {
+    width: 0.98rem;
+    height: 0.98rem;
+  }
+
+  .guide-author-icon--hidden {
+    display: none;
+  }
+
+  .guide-author-photo {
+    position: absolute;
+    inset: 0;
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+  }
+
+  .guide-author-initials {
+    color: var(--accent-strong);
+    font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 0.68rem;
+    font-weight: 900;
+    letter-spacing: 0.02em;
+  }
+
+  .guide-author-copy {
+    display: flex;
+    min-width: 0;
+    flex-wrap: wrap;
+    align-items: baseline;
+    column-gap: 0.35rem;
+    row-gap: 0.08rem;
+  }
+
+  .guide-author-label {
+    flex: 0 0 auto;
+    color: color-mix(in srgb, var(--muted) 78%, var(--ink));
+    font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: inherit;
+    font-weight: 700;
+    letter-spacing: 0;
+  }
+
+  .guide-author-name {
+    color: var(--ink);
+    font-size: inherit;
+    font-weight: 900;
+    overflow-wrap: anywhere;
+  }
+
+  .guide-author--hero {
+    margin-top: -0.15rem;
+    font-size: 0.95rem;
+  }
+
+  .guide-author--hero .guide-author-mark {
+    width: 1.9rem;
+    height: 1.9rem;
+  }
+
+  .guide-author--hero .guide-author-icon {
+    width: 1.08rem;
+    height: 1.08rem;
+  }
+
+  .guide-author--hero .guide-author-initials {
+    font-size: 0.78rem;
+  }
+
+  .guide-author--card {
+    flex: 1 1 12rem;
+    color: var(--muted);
+  }
+
+  .guide-card-footer .stats-row {
+    width: 100%;
+    justify-content: space-between;
+  }
+
   .country-browser {
     margin-bottom: 1rem;
     position: sticky;

--- a/tests/frontend/authorAvatar.test.ts
+++ b/tests/frontend/authorAvatar.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { getAuthorAvatarMode, getAuthorInitials } from "../../src/lib/authorAvatar";
+
+describe("author avatar helpers", () => {
+  it("builds one or two initials from author names", () => {
+    expect(getAuthorInitials("Another Author")).toBe("AA");
+    expect(getAuthorInitials("Example Curator")).toBe("EC");
+    expect(getAuthorInitials("Prince")).toBe("PR");
+  });
+
+  it("uses explicit avatar mode before photo fallback", () => {
+    expect(getAuthorAvatarMode({ name: "Another Author", avatar_mode: "initials" })).toBe(
+      "initials",
+    );
+    expect(getAuthorAvatarMode({ name: "Example Curator", photo_path: "/author.svg" })).toBe(
+      "photo",
+    );
+    expect(getAuthorAvatarMode({ name: "Example Curator" })).toBe("icon");
+  });
+});

--- a/tests/frontend/seo.test.ts
+++ b/tests/frontend/seo.test.ts
@@ -203,6 +203,29 @@ describe("seo helpers", () => {
     expect(itemList.itemListElement).toHaveLength(25);
   });
 
+  it("includes guide author metadata in guide JSON-LD when available", () => {
+    const [, collectionPage] = buildGuideJsonLd({
+      siteUrl: "https://favorite-places.pages.dev/",
+      pageUrl: "https://favorite-places.pages.dev/guides/tokyo-japan/",
+      description: "Guide description",
+      guide: createGuide({
+        author: {
+          name: "Curator Name",
+          photo_path: "/author-photos/curator.webp",
+          photo_url: "https://example.com/curator.jpg",
+        },
+      }),
+      countryName: "Japan",
+      visiblePlaces: [],
+    });
+
+    expect((collectionPage as Record<string, unknown>).author).toEqual({
+      "@type": "Person",
+      name: "Curator Name",
+      image: "https://favorite-places.pages.dev/author-photos/curator.webp",
+    });
+  });
+
   it("prefers why_recommended over note for place JSON-LD descriptions", () => {
     const [, collectionJsonLd] = buildGuideJsonLd({
       siteUrl: "https://favorite-places.pages.dev/",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -177,6 +177,91 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(synced.photo_path, "/author-photos/tokyo-japan-example.webp")
         download_photo.assert_called_once_with("tokyo-japan", "https://example.com/curator.jpg")
 
+    def test_download_list_author_photo_uses_optimizer_extension(self) -> None:
+        class FakeHeaders:
+            def get_content_type(self) -> str:
+                return "image/png"
+
+        class FakeResponse:
+            headers = FakeHeaders()
+
+            def read(self) -> bytes:
+                return b"source-image"
+
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> bool:
+                return False
+
+        photo_url = "https://example.com/curator.jpg"
+        photo_hash = hashlib.sha256(photo_url.encode("utf-8")).hexdigest()[:12]
+        with TemporaryDirectory() as tmpdir:
+            author_photo_dir = Path(tmpdir)
+            expected_path = author_photo_dir / f"tokyo--{photo_hash}.jpg"
+            with (
+                patch.object(build_data, "AUTHOR_PHOTOS_DIR", author_photo_dir),
+                patch.object(build_data, "urlopen", return_value=FakeResponse()),
+                patch.object(build_data, "optimize_author_photo_asset", return_value=(b"optimized", ".jpg")),
+            ):
+                result = build_data.download_list_author_photo("tokyo", photo_url)
+
+            self.assertEqual(result, f"/author-photos/{expected_path.name}")
+            self.assertEqual(expected_path.read_bytes(), b"optimized")
+
+    def test_author_photo_stale_cleanup_does_not_match_slug_prefixes(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            author_photo_dir = Path(tmpdir)
+            keep_path = author_photo_dir / "tokyo--keep.webp"
+            same_slug_current = author_photo_dir / "tokyo--stale.webp"
+            same_slug_current_jpg = author_photo_dir / "tokyo--stale.jpg"
+            same_slug_legacy = author_photo_dir / "tokyo-123456789abc.webp"
+            prefixed_slug_current = author_photo_dir / "tokyo-japan--stale.webp"
+            prefixed_slug_legacy = author_photo_dir / "tokyo-japan-123456789abc.webp"
+            for path in [
+                keep_path,
+                same_slug_current,
+                same_slug_current_jpg,
+                same_slug_legacy,
+                prefixed_slug_current,
+                prefixed_slug_legacy,
+            ]:
+                path.write_bytes(b"image")
+
+            with patch.object(build_data, "AUTHOR_PHOTOS_DIR", author_photo_dir):
+                stale_names = {
+                    path.name
+                    for path in build_data.stale_author_photo_paths("tokyo", keep_filename=keep_path.name)
+                }
+
+        self.assertEqual(
+            stale_names,
+            {
+                same_slug_current.name,
+                same_slug_current_jpg.name,
+                same_slug_legacy.name,
+            },
+        )
+
+    def test_optimize_author_photo_asset_falls_back_to_jpeg_without_webp(self) -> None:
+        source = BytesIO()
+        Image.new("RGB", (500, 300), color=(160, 80, 40)).save(source, format="PNG")
+
+        with patch.object(build_data, "image_supports_webp", return_value=False):
+            optimized_content, extension = build_data.optimize_author_photo_asset(
+                source.getvalue(),
+                content_type="image/png",
+            )
+
+        self.assertIsNotNone(optimized_content)
+        self.assertEqual(extension, ".jpg")
+        assert optimized_content is not None
+        with Image.open(BytesIO(optimized_content)) as optimized_image:
+            self.assertEqual(
+                optimized_image.size,
+                (build_data.AUTHOR_PHOTO_SIZE, build_data.AUTHOR_PHOTO_SIZE),
+            )
+
     def test_list_author_override_skips_scraped_owner_photo_download(self) -> None:
         def read_json_side_effect(path: Path) -> dict[str, object]:
             if path == build_data.LIST_OVERRIDES_DIR / "tokyo-japan.json":

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -22,6 +22,7 @@ from scripts.pipeline_models import (
     EnrichmentCacheEntry,
     EnrichmentPlace,
     Guide,
+    ListAuthor,
     NormalizedPlace,
     RawPlace,
     RawSavedList,
@@ -30,6 +31,161 @@ from scripts.pipeline_models import (
 
 
 class BuildDataTests(unittest.TestCase):
+    def test_raw_saved_list_keeps_owner_metadata_from_json(self) -> None:
+        saved_list = RawSavedList.model_validate(
+            {
+                "title": "Tokyo, Japan",
+                "owner": {
+                    "name": "Curator Name",
+                    "photo_url": "https://example.com/curator.jpg",
+                    "photo_path": "/author-photos/curator.webp",
+                    "avatar_mode": "photo",
+                    "profile_id": "curator-id",
+                },
+                "collaborators": [
+                    {
+                        "name": "Second Curator",
+                        "photo_url": "https://example.com/second.jpg",
+                    }
+                ],
+                "places": [],
+            }
+        )
+
+        self.assertIsNotNone(saved_list.owner)
+        assert saved_list.owner is not None
+        self.assertEqual(saved_list.owner.name, "Curator Name")
+        self.assertEqual(saved_list.owner.photo_url, "https://example.com/curator.jpg")
+        self.assertEqual(saved_list.owner.photo_path, "/author-photos/curator.webp")
+        self.assertEqual(saved_list.owner.avatar_mode, "photo")
+        self.assertEqual(saved_list.owner.profile_id, "curator-id")
+        self.assertEqual(len(saved_list.collaborators), 1)
+        self.assertEqual(saved_list.collaborators[0].name, "Second Curator")
+        self.assertEqual(saved_list.collaborators[0].photo_url, "https://example.com/second.jpg")
+
+    def test_normalize_guide_uses_raw_owner_as_author(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo, Japan",
+            owner=ListAuthor(
+                name="Curator Name",
+                photo_url="https://example.com/curator.jpg",
+                profile_id="curator-id",
+            ),
+            places=[
+                RawPlace(
+                    name="Coffee Spot",
+                    maps_url="https://maps.example/coffee",
+                )
+            ],
+        )
+
+        def read_json_side_effect(path: Path) -> dict[str, object]:
+            if path == build_data.LIST_OVERRIDES_DIR / "tokyo-japan.json":
+                return {}
+            if path == build_data.PLACE_OVERRIDES_DIR / "tokyo-japan.json":
+                return {}
+            return {}
+
+        with patch.object(build_data, "read_json", side_effect=read_json_side_effect):
+            guide = build_data.normalize_guide("tokyo-japan", raw, enrichment_cache={})
+
+        self.assertIsNotNone(guide.author)
+        assert guide.author is not None
+        self.assertEqual(guide.author.name, "Curator Name")
+        self.assertEqual(guide.author.photo_url, "https://example.com/curator.jpg")
+        self.assertEqual(guide.author.profile_id, "curator-id")
+
+    def test_normalize_guide_allows_author_override(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo, Japan",
+            owner=ListAuthor(name="Original Curator"),
+            places=[
+                RawPlace(
+                    name="Coffee Spot",
+                    maps_url="https://maps.example/coffee",
+                )
+            ],
+        )
+
+        def read_json_side_effect(path: Path) -> dict[str, object]:
+            if path == build_data.LIST_OVERRIDES_DIR / "tokyo-japan.json":
+                return {
+                    "author": {
+                        "name": "Override Curator",
+                        "photo_path": "/author-photos/override.svg",
+                        "avatar_mode": "photo",
+                    }
+                }
+            if path == build_data.PLACE_OVERRIDES_DIR / "tokyo-japan.json":
+                return {}
+            return {}
+
+        with patch.object(build_data, "read_json", side_effect=read_json_side_effect):
+            guide = build_data.normalize_guide("tokyo-japan", raw, enrichment_cache={})
+
+        self.assertIsNotNone(guide.author)
+        assert guide.author is not None
+        self.assertEqual(guide.author.name, "Override Curator")
+        self.assertEqual(guide.author.photo_path, "/author-photos/override.svg")
+        self.assertEqual(guide.author.avatar_mode, "photo")
+
+    def test_normalize_guide_author_override_does_not_merge_raw_photo(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo, Japan",
+            owner=ListAuthor(
+                name="Original Curator",
+                photo_url="https://example.com/original.jpg",
+                photo_path="/author-photos/original.webp",
+            ),
+            places=[
+                RawPlace(
+                    name="Coffee Spot",
+                    maps_url="https://maps.example/coffee",
+                )
+            ],
+        )
+
+        def read_json_side_effect(path: Path) -> dict[str, object]:
+            if path == build_data.LIST_OVERRIDES_DIR / "tokyo-japan.json":
+                return {"author": {"name": "Override Curator", "avatar_mode": "initials"}}
+            if path == build_data.PLACE_OVERRIDES_DIR / "tokyo-japan.json":
+                return {}
+            return {}
+
+        with patch.object(build_data, "read_json", side_effect=read_json_side_effect):
+            guide = build_data.normalize_guide("tokyo-japan", raw, enrichment_cache={})
+
+        self.assertIsNotNone(guide.author)
+        assert guide.author is not None
+        self.assertEqual(guide.author.name, "Override Curator")
+        self.assertEqual(guide.author.avatar_mode, "initials")
+        self.assertIsNone(guide.author.photo_url)
+        self.assertIsNone(guide.author.photo_path)
+
+    def test_sync_list_author_photo_downloads_local_photo_path(self) -> None:
+        author = ListAuthor(name="Curator Name", photo_url="https://example.com/curator.jpg")
+
+        with patch.object(
+            build_data,
+            "download_list_author_photo",
+            return_value="/author-photos/tokyo-japan-example.webp",
+        ) as download_photo:
+            synced = build_data.sync_list_author_photo("tokyo-japan", author)
+
+        self.assertIsNotNone(synced)
+        assert synced is not None
+        self.assertEqual(synced.photo_path, "/author-photos/tokyo-japan-example.webp")
+        download_photo.assert_called_once_with("tokyo-japan", "https://example.com/curator.jpg")
+
+    def test_list_author_override_skips_scraped_owner_photo_download(self) -> None:
+        def read_json_side_effect(path: Path) -> dict[str, object]:
+            if path == build_data.LIST_OVERRIDES_DIR / "tokyo-japan.json":
+                return {"author": "Example Curator"}
+            return {}
+
+        with patch.object(build_data, "read_json", side_effect=read_json_side_effect):
+            self.assertTrue(build_data.list_author_is_overridden("tokyo-japan"))
+
     def test_format_duration_seconds_formats_short_and_long_values(self) -> None:
         self.assertEqual(build_data.format_duration_seconds(9.34), "9.3s")
         self.assertEqual(build_data.format_duration_seconds(68.25), "1m 08.3s")


### PR DESCRIPTION
## Description
Adds configurable guide author bylines to guide cards and guide pages, backed by scraped Google Maps list owner metadata and list-level overrides. Author avatars can render as a downloaded/local photo, initials, or the default icon, and guide JSON-LD now includes author metadata when present. The example site enables author display with two privacy-safe demo authors and documents the new override fields.

## Related Issue
None found in `508-dev/favorite-places` after checking open issues.

## How Has This Been Tested?
- `bun run build:data`
- `bun run test`
- `bun run check`
- `bun run build`
- Commit hooks: Biome, Ruff, mypy
