### PR TITLE
Deduplicate author photos by profile ID

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -14,6 +14,7 @@ import shutil
 import sqlite3
 import time
 import unicodedata
+import uuid
 from collections import Counter
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -6392,11 +6393,14 @@ def download_list_author_photo(
 
     filename = f"{photo_stem}{extension}"
     output_path = AUTHOR_PHOTOS_DIR / filename
-    temp_path = AUTHOR_PHOTOS_DIR / f".{filename}.tmp"
-    temp_path.write_bytes(optimized_content)
-    temp_path.replace(output_path)
+    temp_path = author_photo_temp_path(filename)
+    try:
+        temp_path.write_bytes(optimized_content)
+        temp_path.replace(output_path)
+    finally:
+        temp_path.unlink(missing_ok=True)
 
-    for stale_path in stale_author_photo_paths(slug, keep_filename=filename):
+    for stale_path in stale_legacy_author_photo_paths(slug, keep_filename=filename):
         stale_path.unlink(missing_ok=True)
 
     return public_author_photo_path(filename)
@@ -6410,7 +6414,11 @@ def existing_author_photo_path(photo_stem: str) -> Path | None:
     return None
 
 
-def stale_author_photo_paths(slug: str, *, keep_filename: str) -> list[Path]:
+def author_photo_temp_path(filename: str) -> Path:
+    return AUTHOR_PHOTOS_DIR / f".{filename}.{uuid.uuid4().hex}.tmp"
+
+
+def stale_legacy_author_photo_paths(slug: str, *, keep_filename: str) -> list[Path]:
     if not AUTHOR_PHOTOS_DIR.exists():
         return []
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6348,20 +6348,26 @@ def cached_place_photo_url(cache_entry: EnrichmentCacheEntry | None) -> str | No
 def sync_list_author_photo(slug: str, author: ListAuthor | None) -> ListAuthor | None:
     if author is None or not author.photo_url:
         return author
-    if author.photo_path:
-        existing_path = public_asset_absolute_path(author.photo_path)
-        if existing_path is not None and existing_path.exists():
-            return author
-
-    photo_path = download_list_author_photo(slug, author.photo_url)
+    photo_path = download_list_author_photo(
+        slug,
+        author.photo_url,
+        profile_id=author.profile_id,
+    )
     if photo_path is None:
+        return author
+    if photo_path == author.photo_path:
         return author
     return author.model_copy(update={"photo_path": photo_path})
 
 
-def download_list_author_photo(slug: str, photo_url: str) -> str | None:
+def download_list_author_photo(
+    slug: str,
+    photo_url: str,
+    *,
+    profile_id: str | None = None,
+) -> str | None:
     AUTHOR_PHOTOS_DIR.mkdir(parents=True, exist_ok=True)
-    photo_stem = canonical_author_photo_stem(slug, photo_url)
+    photo_stem = canonical_author_photo_stem(profile_id=profile_id, photo_url=photo_url)
     existing_path = existing_author_photo_path(photo_stem)
     if existing_path is not None:
         return public_author_photo_path(existing_path.name)
@@ -6425,9 +6431,11 @@ def safe_author_photo_stem(slug: str) -> str:
     return sanitized or "author"
 
 
-def canonical_author_photo_stem(slug: str, photo_url: str) -> str:
+def canonical_author_photo_stem(*, profile_id: str | None, photo_url: str) -> str:
     photo_hash = hashlib.sha256(photo_url.encode("utf-8")).hexdigest()[:12]
-    return f"{safe_author_photo_stem(slug)}--{photo_hash}"
+    if profile_id:
+        return f"profile-{safe_author_photo_stem(profile_id)}--{photo_hash}"
+    return f"photo-{photo_hash}"
 
 
 def populate_place_photos_for_guides(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -249,7 +249,23 @@ class BuildDataTests(unittest.TestCase):
             self.assertEqual(result, f"/author-photos/{expected_path.name}")
             self.assertEqual(expected_path.read_bytes(), b"optimized")
 
-    def test_author_photo_stale_cleanup_does_not_match_slug_prefixes(self) -> None:
+    def test_author_photo_temp_path_is_unique_per_invocation(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            author_photo_dir = Path(tmpdir)
+            first_uuid = SimpleNamespace(hex="first")
+            second_uuid = SimpleNamespace(hex="second")
+            with (
+                patch.object(build_data, "AUTHOR_PHOTOS_DIR", author_photo_dir),
+                patch.object(build_data.uuid, "uuid4", side_effect=[first_uuid, second_uuid]),
+            ):
+                first_path = build_data.author_photo_temp_path("profile-curator--abc.webp")
+                second_path = build_data.author_photo_temp_path("profile-curator--abc.webp")
+
+        self.assertEqual(first_path.name, ".profile-curator--abc.webp.first.tmp")
+        self.assertEqual(second_path.name, ".profile-curator--abc.webp.second.tmp")
+        self.assertNotEqual(first_path, second_path)
+
+    def test_author_photo_legacy_stale_cleanup_does_not_match_slug_prefixes_or_shared_paths(self) -> None:
         with TemporaryDirectory() as tmpdir:
             author_photo_dir = Path(tmpdir)
             keep_path = author_photo_dir / "tokyo--keep.webp"
@@ -258,6 +274,8 @@ class BuildDataTests(unittest.TestCase):
             same_slug_legacy = author_photo_dir / "tokyo-123456789abc.webp"
             prefixed_slug_current = author_photo_dir / "tokyo-japan--stale.webp"
             prefixed_slug_legacy = author_photo_dir / "tokyo-japan-123456789abc.webp"
+            shared_profile = author_photo_dir / "profile-curator-id--123456789abc.webp"
+            shared_photo_hash = author_photo_dir / "photo-123456789abc.webp"
             for path in [
                 keep_path,
                 same_slug_current,
@@ -265,13 +283,15 @@ class BuildDataTests(unittest.TestCase):
                 same_slug_legacy,
                 prefixed_slug_current,
                 prefixed_slug_legacy,
+                shared_profile,
+                shared_photo_hash,
             ]:
                 path.write_bytes(b"image")
 
             with patch.object(build_data, "AUTHOR_PHOTOS_DIR", author_photo_dir):
                 stale_names = {
                     path.name
-                    for path in build_data.stale_author_photo_paths("tokyo", keep_filename=keep_path.name)
+                    for path in build_data.stale_legacy_author_photo_paths("tokyo", keep_filename=keep_path.name)
                 }
 
         self.assertEqual(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -163,7 +163,11 @@ class BuildDataTests(unittest.TestCase):
         self.assertIsNone(guide.author.photo_path)
 
     def test_sync_list_author_photo_downloads_local_photo_path(self) -> None:
-        author = ListAuthor(name="Curator Name", photo_url="https://example.com/curator.jpg")
+        author = ListAuthor(
+            name="Curator Name",
+            photo_url="https://example.com/curator.jpg",
+            profile_id="curator-id",
+        )
 
         with patch.object(
             build_data,
@@ -175,7 +179,11 @@ class BuildDataTests(unittest.TestCase):
         self.assertIsNotNone(synced)
         assert synced is not None
         self.assertEqual(synced.photo_path, "/author-photos/tokyo-japan-example.webp")
-        download_photo.assert_called_once_with("tokyo-japan", "https://example.com/curator.jpg")
+        download_photo.assert_called_once_with(
+            "tokyo-japan",
+            "https://example.com/curator.jpg",
+            profile_id="curator-id",
+        )
 
     def test_download_list_author_photo_uses_optimizer_extension(self) -> None:
         class FakeHeaders:
@@ -198,7 +206,39 @@ class BuildDataTests(unittest.TestCase):
         photo_hash = hashlib.sha256(photo_url.encode("utf-8")).hexdigest()[:12]
         with TemporaryDirectory() as tmpdir:
             author_photo_dir = Path(tmpdir)
-            expected_path = author_photo_dir / f"tokyo--{photo_hash}.jpg"
+            expected_path = author_photo_dir / f"profile-curator-id--{photo_hash}.jpg"
+            with (
+                patch.object(build_data, "AUTHOR_PHOTOS_DIR", author_photo_dir),
+                patch.object(build_data, "urlopen", return_value=FakeResponse()),
+                patch.object(build_data, "optimize_author_photo_asset", return_value=(b"optimized", ".jpg")),
+            ):
+                result = build_data.download_list_author_photo("tokyo", photo_url, profile_id="curator-id")
+
+            self.assertEqual(result, f"/author-photos/{expected_path.name}")
+            self.assertEqual(expected_path.read_bytes(), b"optimized")
+
+    def test_download_list_author_photo_falls_back_to_photo_hash_without_profile_id(self) -> None:
+        class FakeHeaders:
+            def get_content_type(self) -> str:
+                return "image/png"
+
+        class FakeResponse:
+            headers = FakeHeaders()
+
+            def read(self) -> bytes:
+                return b"source-image"
+
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> bool:
+                return False
+
+        photo_url = "https://example.com/curator.jpg"
+        photo_hash = hashlib.sha256(photo_url.encode("utf-8")).hexdigest()[:12]
+        with TemporaryDirectory() as tmpdir:
+            author_photo_dir = Path(tmpdir)
+            expected_path = author_photo_dir / f"photo-{photo_hash}.jpg"
             with (
                 patch.object(build_data, "AUTHOR_PHOTOS_DIR", author_photo_dir),
                 patch.object(build_data, "urlopen", return_value=FakeResponse()),


### PR DESCRIPTION
## Description
Use shared author-photo filenames keyed by `profile_id` plus the photo URL hash instead of namespacing the asset by guide slug, so the same Google Maps owner photo is reused across guides. Keep the non-`profile_id` fallback deterministic with a photo-hash-only filename, and add Python coverage for both naming paths plus the updated sync call contract.

## Related Issue
No related issue found after searching the repo's GitHub issues.

## How Has This Been Tested?
`uv run python -m unittest tests.python.test_build_data`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved author photo synchronization with safer file handling
  * Prevented redundant photo downloads
  * Enhanced cleanup of legacy photo files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->