### PR TITLE
Enable author bylines by default

### DIFF
--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -168,7 +168,7 @@ const defaultSiteConfig: SiteConfig = {
   },
   guide: {
     fallbackDescription: "Saved places for this city.",
-    showAuthor: false,
+    showAuthor: true,
     authorLabel: "By",
     sidebarContent: [],
     backLinkLabel: "Back to all guides",
@@ -206,7 +206,7 @@ const defaultSiteConfig: SiteConfig = {
   guideCard: {
     showDescription: true,
     fallbackDescription: "Saved places for this guide.",
-    showAuthor: false,
+    showAuthor: true,
     authorLabel: "By",
     showTags: true,
     maxTags: 4,


### PR DESCRIPTION
## Description
Turn on author bylines in the default site config for both guide pages and guide cards.
This makes author attribution visible by default for site packs that provide author data, while still allowing explicit config overrides to opt out.

## Related Issue
No verified related issue found in `508-dev/favorite-places`.

## How Has This Been Tested?
- `bun run check`
- `bun run build`
