### PR TITLE
Move homepage guide card config under home

### DIFF
--- a/site.example/config.ts
+++ b/site.example/config.ts
@@ -25,6 +25,13 @@ export const siteConfig = {
     searchPlaceholder: "Search seafood, sunrise, markets, coffee",
     showHeroStats: true,
     showMap: true,
+    guideCard: {
+      showDescription: true,
+      showAuthor: true,
+      showTags: true,
+      maxTags: 4,
+      showPlaceCount: true,
+    },
   },
   guide: {
     fallbackDescription: "Saved places for this city.",
@@ -36,13 +43,6 @@ export const siteConfig = {
     bestHitsHeading: "Best hits",
     browseEyebrow: "Browse",
     placesHeading: "Places",
-  },
-  guideCard: {
-    showDescription: true,
-    showAuthor: true,
-    showTags: true,
-    maxTags: 4,
-    showPlaceCount: true,
   },
   placeCard: {
     showPhoto: true,

--- a/src/components/GuideCard.astro
+++ b/src/components/GuideCard.astro
@@ -44,9 +44,10 @@ const countryNameAliases: Record<string, string[]> = {
   "United Kingdom": ["UK"],
   "United States": ["USA"],
 };
+const guideCardConfig = siteConfig.home.guideCard;
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 const trimCountryFromTitle = (title: string) => {
-  if (!siteConfig.guideCard.trimCountryFromTitle) {
+  if (!guideCardConfig.trimCountryFromTitle) {
     return title;
   }
 
@@ -78,17 +79,17 @@ const guideDisplayTitle = trimCountryFromTitle(guide.title);
   <div class="section-stack ui-stack">
     <h3 class="ui-card-title">{guideDisplayTitle}</h3>
     {
-      siteConfig.guideCard.showDescription && guideDescriptionHtml ? (
+      guideCardConfig.showDescription && guideDescriptionHtml ? (
         <p class="rich-copy ui-copy" set:html={guideDescriptionHtml} />
-      ) : siteConfig.guideCard.showDescription ? (
-        <p class="ui-copy">{siteConfig.guideCard.fallbackDescription}</p>
+      ) : guideCardConfig.showDescription ? (
+        <p class="ui-copy">{guideCardConfig.fallbackDescription}</p>
       ) : null
     }
   </div>
 
-  {siteConfig.guideCard.showTags && displayGuideTags.length > 0 && (
+  {guideCardConfig.showTags && displayGuideTags.length > 0 && (
     <div class="tag-row ui-tag-row">
-      {displayGuideTags.slice(0, siteConfig.guideCard.maxTags).map((tag) => (
+      {displayGuideTags.slice(0, guideCardConfig.maxTags).map((tag) => (
         <a
           class="tag-pill ui-tag-pill guide-card-tag-link"
           href={`/guides/${guide.slug}/?tag=${encodeURIComponent(normalizeTagValue(tag))}`}
@@ -100,11 +101,11 @@ const guideDisplayTitle = trimCountryFromTitle(guide.title);
     </div>
   )}
 
-  {(siteConfig.guideCard.showPlaceCount || (siteConfig.guideCard.showAuthor && guideAuthorName)) && (
+  {(guideCardConfig.showPlaceCount || (guideCardConfig.showAuthor && guideAuthorName)) && (
     <div class="guide-card-footer ui-card-footer">
       <div class="stats-row ui-meta-row">
-        {siteConfig.guideCard.showAuthor && guide.author && guideAuthorName && <AuthorByline author={guide.author} label={siteConfig.guideCard.authorLabel} variant="card" />}
-        {siteConfig.guideCard.showPlaceCount && (
+        {guideCardConfig.showAuthor && guide.author && guideAuthorName && <AuthorByline author={guide.author} label={guideCardConfig.authorLabel} variant="card" />}
+        {guideCardConfig.showPlaceCount && (
           <span class="count-chip guide-card-place-count">
             <strong>{guide.place_count}</strong>
             <span>place{guide.place_count === 1 ? "" : "s"}</span>

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -1,5 +1,105 @@
 import { siteConfig as configuredSiteConfig } from "favorite-places:site-config";
 
+interface GuideCardConfig {
+  showDescription: boolean;
+  fallbackDescription: string;
+  showAuthor: boolean;
+  authorLabel: string;
+  showTags: boolean;
+  maxTags: number;
+  showPlaceCount: boolean;
+  trimCountryFromTitle: boolean;
+}
+
+interface HomeConfig {
+  eyebrow: string;
+  title: string;
+  intro: string;
+  highlightsHeading: string;
+  highlights: string[];
+  guidesEyebrow: string;
+  guidesHeading: string;
+  guidesLinkText: string | null;
+  searchPlaceholder: string;
+  showHero: boolean;
+  showHeroStats: boolean;
+  showGuideBrowser: boolean;
+  showGuideBrowserControls: boolean;
+  showMap: boolean;
+  showCountrySections: boolean;
+  searchLabel: string;
+  showingLabel: string;
+  nearMeLabel: string;
+  countriesLabel: string;
+  allCountriesLabel: string;
+  emptyStateText: string;
+  searchResultsEyebrow: string;
+  searchResultsHeading: string;
+  searchResultsGroupedLabel: string;
+  searchResultsIndividualLabel: string;
+  searchResultsEmptyText: string;
+  guideCard: GuideCardConfig;
+}
+
+interface GuideConfig {
+  fallbackDescription: string;
+  showAuthor: boolean;
+  authorLabel: string;
+  sidebarContent: string[];
+  backLinkLabel: string;
+  sourceListLabel: string;
+  topPicksEyebrow: string;
+  topPicksHeading: string;
+  bestHitsEyebrow: string;
+  bestHitsHeading: string;
+  browseEyebrow: string;
+  placesHeading: string;
+  showTopPicks: boolean;
+  showBestHits: boolean;
+  showGuideTags: boolean;
+  listTagsHeading: string;
+  searchLabel: string;
+  searchHint: string;
+  searchPlaceholder: string;
+  areaLabel: string;
+  broaderAreaLabel: string;
+  typeLabel: string;
+  popularTagsLabel: string;
+  popularTagsHint: string;
+  allFilterLabel: string;
+  resultsSortLabel: string;
+  sortCuratedLabel: string;
+  sortNearMeLabel: string;
+  sortRatingLabel: string;
+  sortNameLabel: string;
+  sortNeighborhoodLabel: string;
+  locationSortFallbackText: string;
+  resetMapLabel: string;
+  mapFilteredText: string;
+  emptyStateText: string;
+}
+
+interface PlaceCardConfig {
+  showPhoto: boolean;
+  showMapLink: boolean;
+  showCategory: boolean;
+  showNeighborhood: boolean;
+  showRating: boolean;
+  showReviewCount: boolean;
+  showPriceRange: boolean;
+  showTopPickBadge: boolean;
+  showWhyRecommended: boolean;
+  showAddress: boolean;
+  showTags: boolean;
+  maxTags: number;
+  showStatus: boolean;
+  bestHitLabel: string;
+  topPickLabel: string;
+  mapsLabel: string;
+  savedPlaceLabel: string;
+  photoPlaceholderFallback: string;
+}
+
 export interface SiteConfig {
   siteName: string;
   ownerName: string;
@@ -20,113 +120,22 @@ export interface SiteConfig {
     href: string;
   }[];
   mapProvider: "auto" | "google" | "leaflet";
-  home: {
-    eyebrow: string;
-    title: string;
-    intro: string;
-    highlightsHeading: string;
-    highlights: string[];
-    guidesEyebrow: string;
-    guidesHeading: string;
-    guidesLinkText: string | null;
-    searchPlaceholder: string;
-    showHero: boolean;
-    showHeroStats: boolean;
-    showGuideBrowser: boolean;
-    showGuideBrowserControls: boolean;
-    showMap: boolean;
-    showCountrySections: boolean;
-    searchLabel: string;
-    showingLabel: string;
-    nearMeLabel: string;
-    countriesLabel: string;
-    allCountriesLabel: string;
-    emptyStateText: string;
-    searchResultsEyebrow: string;
-    searchResultsHeading: string;
-    searchResultsGroupedLabel: string;
-    searchResultsIndividualLabel: string;
-    searchResultsEmptyText: string;
-  };
-  guide: {
-    fallbackDescription: string;
-    showAuthor: boolean;
-    authorLabel: string;
-    sidebarContent: string[];
-    backLinkLabel: string;
-    sourceListLabel: string;
-    topPicksEyebrow: string;
-    topPicksHeading: string;
-    bestHitsEyebrow: string;
-    bestHitsHeading: string;
-    browseEyebrow: string;
-    placesHeading: string;
-    showTopPicks: boolean;
-    showBestHits: boolean;
-    showGuideTags: boolean;
-    listTagsHeading: string;
-    searchLabel: string;
-    searchHint: string;
-    searchPlaceholder: string;
-    areaLabel: string;
-    broaderAreaLabel: string;
-    typeLabel: string;
-    popularTagsLabel: string;
-    popularTagsHint: string;
-    allFilterLabel: string;
-    resultsSortLabel: string;
-    sortCuratedLabel: string;
-    sortNearMeLabel: string;
-    sortRatingLabel: string;
-    sortNameLabel: string;
-    sortNeighborhoodLabel: string;
-    locationSortFallbackText: string;
-    resetMapLabel: string;
-    mapFilteredText: string;
-    emptyStateText: string;
-  };
-  guideCard: {
-    showDescription: boolean;
-    fallbackDescription: string;
-    showAuthor: boolean;
-    authorLabel: string;
-    showTags: boolean;
-    maxTags: number;
-    showPlaceCount: boolean;
-    trimCountryFromTitle: boolean;
-  };
-  placeCard: {
-    showPhoto: boolean;
-    showMapLink: boolean;
-    showCategory: boolean;
-    showNeighborhood: boolean;
-    showRating: boolean;
-    showReviewCount: boolean;
-    showPriceRange: boolean;
-    showTopPickBadge: boolean;
-    showWhyRecommended: boolean;
-    showAddress: boolean;
-    showTags: boolean;
-    maxTags: number;
-    showStatus: boolean;
-    bestHitLabel: string;
-    topPickLabel: string;
-    mapsLabel: string;
-    savedPlaceLabel: string;
-    photoPlaceholderFallback: string;
-  };
+  home: HomeConfig;
+  guide: GuideConfig;
+  placeCard: PlaceCardConfig;
 }
 
 export type SiteConfigInput = Partial<
-  Omit<SiteConfig, "favicon" | "logo" | "navLinks" | "home" | "guide" | "guideCard" | "placeCard">
+  Omit<SiteConfig, "favicon" | "logo" | "navLinks" | "home" | "guide" | "placeCard">
 > & {
   favicon?: SiteConfig["favicon"];
   logo?: SiteConfig["logo"];
   navLinks?: SiteConfig["navLinks"];
-  home?: Partial<SiteConfig["home"]>;
-  guide?: Partial<SiteConfig["guide"]>;
-  guideCard?: Partial<SiteConfig["guideCard"]>;
-  placeCard?: Partial<SiteConfig["placeCard"]>;
+  home?: Partial<Omit<HomeConfig, "guideCard">> & {
+    guideCard?: Partial<GuideCardConfig>;
+  };
+  guide?: Partial<GuideConfig>;
+  placeCard?: Partial<PlaceCardConfig>;
 };
 
 const defaultSiteConfig: SiteConfig = {
@@ -165,6 +174,16 @@ const defaultSiteConfig: SiteConfig = {
     searchResultsGroupedLabel: "By country",
     searchResultsIndividualLabel: "Individual",
     searchResultsEmptyText: "No matching places. Try a broader search.",
+    guideCard: {
+      showDescription: true,
+      fallbackDescription: "Saved places for this guide.",
+      showAuthor: true,
+      authorLabel: "By",
+      showTags: true,
+      maxTags: 4,
+      showPlaceCount: true,
+      trimCountryFromTitle: true,
+    },
   },
   guide: {
     fallbackDescription: "Saved places for this city.",
@@ -203,16 +222,6 @@ const defaultSiteConfig: SiteConfig = {
     mapFilteredText: "Filtered to the visible map area.",
     emptyStateText: "No matches. Try a broader search or clear the tag filter.",
   },
-  guideCard: {
-    showDescription: true,
-    fallbackDescription: "Saved places for this guide.",
-    showAuthor: true,
-    authorLabel: "By",
-    showTags: true,
-    maxTags: 4,
-    showPlaceCount: true,
-    trimCountryFromTitle: true,
-  },
   placeCard: {
     showPhoto: true,
     showMapLink: true,
@@ -245,14 +254,14 @@ function mergeSiteConfig(config: SiteConfigInput): SiteConfig {
     home: {
       ...defaultSiteConfig.home,
       ...config.home,
+      guideCard: {
+        ...defaultSiteConfig.home.guideCard,
+        ...config.home?.guideCard,
+      },
     },
     guide: {
       ...defaultSiteConfig.guide,
       ...config.guide,
-    },
-    guideCard: {
-      ...defaultSiteConfig.guideCard,
-      ...config.guideCard,
     },
     placeCard: {
       ...defaultSiteConfig.placeCard,


### PR DESCRIPTION
## Description
Move the guide card configuration under `home` so homepage-specific card copy and display settings live with the rest of the homepage config.
Update the site config types, defaults, and merge logic to use `home.guideCard`, and switch the guide card component to read from that nested config.
Move the example site pack to the new config shape.

## Related Issue
No related issue found.

## How Has This Been Tested?
- `bun run check`
- `bun run build`
