### PR TITLE
fix: avoid browser-unsafe worktree dev ports

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -3,7 +3,6 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 import {
-  isBrowserUnsafePort,
   resolveWorktreeDevPort,
   WORKTREE_DEV_PORT_ENV,
   WORKTREE_DEV_PORT_OFFSET_ENV,
@@ -73,7 +72,7 @@ const source = portConfig.usingExplicitPort
   : `base ${portConfig.basePort} + offset ${portConfig.offset}`;
 
 console.log(`Starting Astro on port ${portConfig.port} (${source})`);
-if (portConfig.portIsBrowserUnsafe || isBrowserUnsafePort(portConfig.port)) {
+if (portConfig.portIsBrowserUnsafe) {
   console.warn(
     `Warning: port ${portConfig.port} is blocked by browsers and may fail with ERR_UNSAFE_PORT.`,
   );

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 import {
+  isBrowserUnsafePort,
   resolveWorktreeDevPort,
   WORKTREE_DEV_PORT_ENV,
   WORKTREE_DEV_PORT_OFFSET_ENV,
@@ -72,6 +73,11 @@ const source = portConfig.usingExplicitPort
   : `base ${portConfig.basePort} + offset ${portConfig.offset}`;
 
 console.log(`Starting Astro on port ${portConfig.port} (${source})`);
+if (portConfig.portIsBrowserUnsafe || isBrowserUnsafePort(portConfig.port)) {
+  console.warn(
+    `Warning: port ${portConfig.port} is blocked by browsers and may fail with ERR_UNSAFE_PORT.`,
+  );
+}
 
 const child = spawn(command, astroArgs, {
   env: childEnv,

--- a/scripts/worktree_dev_port.mjs
+++ b/scripts/worktree_dev_port.mjs
@@ -10,6 +10,13 @@ export const WORKTREE_DEV_PORT_SPAN_ENV = "WORKTREE_DEV_PORT_SPAN";
 export const WORKTREE_DEV_ROOT_ENV = "WORKTREE_DEV_ROOT";
 
 const MAX_PORT = 65535;
+const BROWSER_UNSAFE_PORTS = new Set([
+  1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79, 87, 95, 101, 102,
+  103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 137, 139, 143, 161, 179, 389, 427, 465,
+  512, 513, 514, 515, 526, 530, 531, 532, 540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993,
+  995, 1719, 1720, 1723, 2049, 3659, 4045, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668, 6669,
+  6697, 10080,
+]);
 
 function parsePortLike(value, name) {
   if (value === undefined || value === "") {
@@ -49,6 +56,21 @@ export function worktreePortOffset(worktreeRoot, span) {
   return digest.readUInt32BE(0) % span;
 }
 
+export function isBrowserUnsafePort(port) {
+  return BROWSER_UNSAFE_PORTS.has(port);
+}
+
+function safePortsInRange(basePort, span) {
+  const safePorts = [];
+  for (let port = basePort; port < basePort + span; port += 1) {
+    if (!isBrowserUnsafePort(port)) {
+      safePorts.push(port);
+    }
+  }
+
+  return safePorts;
+}
+
 export function resolveWorktreeDevPort({ env = process.env, worktreeRoot }) {
   if (!worktreeRoot) {
     throw new Error("worktreeRoot is required to resolve the dev server port.");
@@ -66,6 +88,7 @@ export function resolveWorktreeDevPort({ env = process.env, worktreeRoot }) {
       offset: worktreePortOffset(worktreeRoot, span),
       pathKey,
       port: explicitPort,
+      portIsBrowserUnsafe: isBrowserUnsafePort(explicitPort),
       span,
       usingExplicitPort: true,
     };
@@ -84,14 +107,22 @@ export function resolveWorktreeDevPort({ env = process.env, worktreeRoot }) {
     );
   }
 
-  const offset = worktreePortOffset(worktreeRoot, span);
-  const derivedPort = basePort + offset;
+  const safePorts = safePortsInRange(basePort, span);
+  if (safePorts.length === 0) {
+    throw new Error(
+      `${WORKTREE_DEV_BASE_PORT_ENV}..${WORKTREE_DEV_BASE_PORT_ENV} + ${WORKTREE_DEV_PORT_SPAN_ENV} - 1 must include at least one browser-safe port.`,
+    );
+  }
+
+  const derivedPort = safePorts[worktreePortOffset(worktreeRoot, safePorts.length)];
+  const offset = derivedPort - basePort;
 
   return {
     basePort,
     offset,
     pathKey,
-    port: explicitPort ?? derivedPort,
+    port: derivedPort,
+    portIsBrowserUnsafe: false,
     span,
     usingExplicitPort: false,
   };

--- a/scripts/worktree_dev_port.mjs
+++ b/scripts/worktree_dev_port.mjs
@@ -110,7 +110,7 @@ export function resolveWorktreeDevPort({ env = process.env, worktreeRoot }) {
   const safePorts = safePortsInRange(basePort, span);
   if (safePorts.length === 0) {
     throw new Error(
-      `${WORKTREE_DEV_BASE_PORT_ENV}..${WORKTREE_DEV_BASE_PORT_ENV} + ${WORKTREE_DEV_PORT_SPAN_ENV} - 1 must include at least one browser-safe port.`,
+      `range ${WORKTREE_DEV_BASE_PORT_ENV}..(${WORKTREE_DEV_BASE_PORT_ENV} + ${WORKTREE_DEV_PORT_SPAN_ENV} - 1) (${basePort}..${basePort + span - 1}) must include at least one browser-safe port.`,
     );
   }
 

--- a/tests/frontend/worktreeDevPort.test.mjs
+++ b/tests/frontend/worktreeDevPort.test.mjs
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_WORKTREE_DEV_BASE_PORT,
   DEFAULT_WORKTREE_DEV_PORT_SPAN,
+  isBrowserUnsafePort,
   resolveWorktreeDevPort,
   worktreePathKey,
 } from "../../scripts/worktree_dev_port.mjs";
@@ -17,6 +18,7 @@ describe("worktree dev port", () => {
     expect(first.port).toBeLessThan(
       DEFAULT_WORKTREE_DEV_BASE_PORT + DEFAULT_WORKTREE_DEV_PORT_SPAN,
     );
+    expect(isBrowserUnsafePort(first.port)).toBe(false);
   });
 
   it("uses configured base port and span for the deterministic offset", () => {
@@ -33,6 +35,7 @@ describe("worktree dev port", () => {
     expect(config.port).toBe(5100 + config.offset);
     expect(config.offset).toBeGreaterThanOrEqual(0);
     expect(config.offset).toBeLessThan(50);
+    expect(isBrowserUnsafePort(config.port)).toBe(false);
   });
 
   it("lets an explicit worktree port override the derived port", () => {
@@ -67,6 +70,33 @@ describe("worktree dev port", () => {
 
     expect(config.port).toBe(6400);
     expect(config.usingExplicitPort).toBe(true);
+  });
+
+  it("skips browser-unsafe ports when deriving a worktree port", () => {
+    const config = resolveWorktreeDevPort({
+      env: {
+        WORKTREE_DEV_BASE_PORT: "5059",
+        WORKTREE_DEV_PORT_SPAN: "4",
+      },
+      worktreeRoot: "/repo/zeta",
+    });
+
+    expect(config.port).toBeGreaterThanOrEqual(5059);
+    expect(config.port).toBeLessThan(5063);
+    expect([5059, 5062]).toContain(config.port);
+    expect(isBrowserUnsafePort(config.port)).toBe(false);
+  });
+
+  it("fails when a configured derivation range only contains browser-unsafe ports", () => {
+    expect(() =>
+      resolveWorktreeDevPort({
+        env: {
+          WORKTREE_DEV_BASE_PORT: "5060",
+          WORKTREE_DEV_PORT_SPAN: "2",
+        },
+        worktreeRoot: "/repo/eta",
+      }),
+    ).toThrow(/browser-safe port/);
   });
 
   it("normalizes paths into a filesystem-root-relative key", () => {


### PR DESCRIPTION
## Description
Prevent hashed worktree dev ports from landing on browser-blocked ports such as 5060 and 5061 by deriving from the browser-safe ports in the configured range.
Expose whether an explicit port is browser-unsafe and print a warning when someone forces one manually.
Add Vitest coverage for safe-port derivation and the all-unsafe-range failure case.

## Related Issue
No verified related issue found in this repo.

## How Has This Been Tested?
- `bun x vitest run tests/frontend/worktreeDevPort.test.mjs`
- `bun run check`
- `bun run build`
