### PR TITLE
[codex] test Conductor middleware redirect alias

### DIFF
--- a/tests/frontend/middleware.test.ts
+++ b/tests/frontend/middleware.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("astro:middleware", () => ({
+  defineMiddleware: (handler: unknown) => handler,
+}));
+
+import { onRequest } from "../../src/middleware";
+
+function createContext(pathname: string) {
+  const redirect = vi.fn((location: string, status: number) => ({ location, status }));
+
+  return {
+    url: new URL(`https://example.com${pathname}`),
+    redirect,
+  };
+}
+
+describe("middleware redirects", () => {
+  it("redirects the encoded Conductor ANSI reset alias to home", async () => {
+    const context = createContext("/%1B%5B39m");
+    const next = vi.fn();
+
+    const response = await onRequest(context as never, next);
+
+    expect(context.redirect).toHaveBeenCalledWith("/", 302);
+    expect(next).not.toHaveBeenCalled();
+    expect(response).toEqual({ location: "/", status: 302 });
+  });
+
+  it("passes through normal paths", async () => {
+    const context = createContext("/guides/spokane");
+    const nextResponse = new Response("ok");
+    const next = vi.fn(async () => nextResponse);
+
+    const response = await onRequest(context as never, next);
+
+    expect(context.redirect).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledOnce();
+    expect(response).toBe(nextResponse);
+  });
+});


### PR DESCRIPTION
## Description
Add a frontend regression test that covers Conductor's weird ANSI reset open alias path, `/%1B%5B39m`, and asserts that middleware redirects it to `/`.
This locks in the existing redirect behavior so future changes do not silently break that edge case.

## Related Issue
Searched `508-dev/favorite-places` issues for related Conductor redirect or middleware alias work and did not find a relevant issue to link.

## How Has This Been Tested?
- `bun run check`
- `bun run test:frontend -- tests/frontend/middleware.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive middleware behavior validation tests to ensure proper request routing and redirect handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->