### PR TITLE
Retry limited-view place pages missing review counts

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7087,6 +7087,12 @@ def fetch_place_page_enrichment(
     llm_repairer = None if llm_mode == "off" else build_place_llm_repairer()
     collect_reviews = google_maps_place_collect_reviews()
     collect_about = google_maps_place_collect_about()
+    candidate_urls = build_place_page_candidate_urls(
+        place,
+        city_name=city_name,
+        country_name=country_name,
+        google_place_id=google_place_id,
+    )
 
     def scrape_for_enrichment(scrape_url: str, *, llm_tasks: Sequence[Any]) -> Any:
         return scrape_place(
@@ -7100,68 +7106,72 @@ def fetch_place_page_enrichment(
             collect_about=collect_about,
         )
 
+    def process_scrape_url(scrape_url: str) -> tuple[EnrichmentPlace | None, bool]:
+        nonlocal browser_session, http_session, last_error, saw_non_error_result
+        try:
+            details = scrape_for_enrichment(scrape_url, llm_tasks=("dom_repair",))
+        except RECOVERABLE_REFRESH_ERRORS as exc:
+            if should_reset_scraper_session(exc):
+                clear_scraper_session_state(session_state)
+                browser_session, http_session = build_scraper_configs(session_state, proxy)
+                try:
+                    details = scrape_for_enrichment(scrape_url, llm_tasks=("dom_repair",))
+                except RECOVERABLE_REFRESH_ERRORS as retry_exc:
+                    last_error = f"scrape_error:{retry_exc}"
+                    return None, False
+            else:
+                last_error = f"scrape_error:{exc}"
+                return None, False
+
+        saw_non_error_result = True
+        record_scraper_session_use(session_state, proxy=proxy)
+        apply_reusable_place_display_fields(details, existing_entry)
+        if (
+            llm_mode == "dom_then_translation"
+            and llm_repairer is not None
+            and repair_place_display_fields is not None
+            and place_details_need_display_translation(details)
+        ):
+            try:
+                details = repair_place_display_fields(
+                    details,
+                    repairer=llm_repairer,
+                    evidence={
+                        "city": city_name,
+                        "country": country_name,
+                        "query": query,
+                    },
+                )
+            except Exception as exc:
+                last_error = f"display_repair_error:{exc}"
+        enrichment_place = normalize_place_page_enrichment(details)
+        source_url = as_string(getattr(details, "source_url", None)) or enrichment_place.google_maps_uri
+        if source_url and "/maps/search/" in source_url and not enrichment_place.formatted_address:
+            return None, False
+
+        matched = place_page_has_meaningful_enrichment(details, enrichment_place)
+        if matched and not place_page_candidate_is_confident_match(place, details, enrichment_place):
+            return None, False
+        if matched:
+            apply_semantic_enrichment(
+                enrichment_place,
+                raw_place=place,
+                city_name=city_name,
+                country_name=country_name,
+                existing_entry=existing_entry,
+                raw_note=place.note,
+                suppress_description=suppress_description,
+            )
+            return enrichment_place, False
+        return None, should_retry_limited_place_page_result(details, enrichment_place)
+
     try:
         last_error: str | None = None
         saw_non_error_result = False
-        for scrape_url in build_place_page_candidate_urls(
-            place,
-            city_name=city_name,
-            country_name=country_name,
-            google_place_id=google_place_id,
-        ):
-            try:
-                details = scrape_for_enrichment(scrape_url, llm_tasks=("dom_repair",))
-            except RECOVERABLE_REFRESH_ERRORS as exc:
-                if should_reset_scraper_session(exc):
-                    clear_scraper_session_state(session_state)
-                    browser_session, http_session = build_scraper_configs(session_state, proxy)
-                    try:
-                        details = scrape_for_enrichment(scrape_url, llm_tasks=("dom_repair",))
-                    except RECOVERABLE_REFRESH_ERRORS as retry_exc:
-                        last_error = f"scrape_error:{retry_exc}"
-                        continue
-                else:
-                    last_error = f"scrape_error:{exc}"
-                    continue
-
-            saw_non_error_result = True
-            record_scraper_session_use(session_state, proxy=proxy)
-            apply_reusable_place_display_fields(details, existing_entry)
-            if (
-                llm_mode == "dom_then_translation"
-                and llm_repairer is not None
-                and repair_place_display_fields is not None
-                and place_details_need_display_translation(details)
-            ):
-                try:
-                    details = repair_place_display_fields(
-                        details,
-                        repairer=llm_repairer,
-                        evidence={
-                            "city": city_name,
-                            "country": country_name,
-                            "query": query,
-                        },
-                    )
-                except Exception as exc:
-                    last_error = f"display_repair_error:{exc}"
-            enrichment_place = normalize_place_page_enrichment(details)
-            source_url = as_string(getattr(details, "source_url", None)) or enrichment_place.google_maps_uri
-            if source_url and "/maps/search/" in source_url and not enrichment_place.formatted_address:
-                continue
-            matched = place_page_has_meaningful_enrichment(details, enrichment_place)
-            if matched and not place_page_candidate_is_confident_match(place, details, enrichment_place):
-                continue
-            if matched:
-                apply_semantic_enrichment(
-                    enrichment_place,
-                    raw_place=place,
-                    city_name=city_name,
-                    country_name=country_name,
-                    existing_entry=existing_entry,
-                    raw_note=place.note,
-                    suppress_description=suppress_description,
-                )
+        retry_urls: list[str] = []
+        for scrape_url in candidate_urls:
+            enrichment_place, should_retry = process_scrape_url(scrape_url)
+            if enrichment_place is not None:
                 return build_cache_entry(
                     place,
                     source="google_maps_page",
@@ -7172,6 +7182,25 @@ def fetch_place_page_enrichment(
                     score=STRONG_MATCH_SCORE,
                     enrichment_place=enrichment_place,
                 )
+            if should_retry:
+                retry_urls.append(scrape_url)
+
+        if retry_urls:
+            clear_scraper_session_state(session_state)
+            browser_session, http_session = build_scraper_configs(session_state, proxy)
+            for scrape_url in dedupe_urls(retry_urls):
+                enrichment_place, _should_retry = process_scrape_url(scrape_url)
+                if enrichment_place is not None:
+                    return build_cache_entry(
+                        place,
+                        source="google_maps_page",
+                        query=query,
+                        city_name=city_name,
+                        country_name=country_name,
+                        matched=True,
+                        score=STRONG_MATCH_SCORE,
+                        enrichment_place=enrichment_place,
+                    )
         if saw_non_error_result:
             return build_cache_entry(
                 place,
@@ -7237,6 +7266,8 @@ def place_page_has_meaningful_enrichment(
         or enrichment_place.plus_code
         or enrichment_place.description
     )
+    if should_retry_limited_place_page_result(details, enrichment_place):
+        return False
     if has_identity and (has_reputation or has_contact_or_context):
         return True
     if (
@@ -7248,6 +7279,15 @@ def place_page_has_meaningful_enrichment(
     return not bool(getattr(details, "limited_view", False)) and bool(
         has_reputation and enrichment_place.formatted_address
     )
+
+
+def should_retry_limited_place_page_result(
+    details: Any,
+    enrichment_place: EnrichmentPlace,
+) -> bool:
+    if not bool(getattr(details, "limited_view", False)):
+        return False
+    return enrichment_place.user_rating_count is None
 
 
 def place_page_candidate_is_confident_match(

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7087,12 +7087,6 @@ def fetch_place_page_enrichment(
     llm_repairer = None if llm_mode == "off" else build_place_llm_repairer()
     collect_reviews = google_maps_place_collect_reviews()
     collect_about = google_maps_place_collect_about()
-    candidate_urls = build_place_page_candidate_urls(
-        place,
-        city_name=city_name,
-        country_name=country_name,
-        google_place_id=google_place_id,
-    )
 
     def scrape_for_enrichment(scrape_url: str, *, llm_tasks: Sequence[Any]) -> Any:
         return scrape_place(
@@ -7145,9 +7139,10 @@ def fetch_place_page_enrichment(
             except Exception as exc:
                 last_error = f"display_repair_error:{exc}"
         enrichment_place = normalize_place_page_enrichment(details)
+        should_retry = should_retry_limited_place_page_result(details, enrichment_place)
         source_url = as_string(getattr(details, "source_url", None)) or enrichment_place.google_maps_uri
         if source_url and "/maps/search/" in source_url and not enrichment_place.formatted_address:
-            return None, False
+            return None, should_retry
 
         matched = place_page_has_meaningful_enrichment(details, enrichment_place)
         if matched and not place_page_candidate_is_confident_match(place, details, enrichment_place):
@@ -7163,11 +7158,17 @@ def fetch_place_page_enrichment(
                 suppress_description=suppress_description,
             )
             return enrichment_place, False
-        return None, should_retry_limited_place_page_result(details, enrichment_place)
+        return None, should_retry
 
     try:
         last_error: str | None = None
         saw_non_error_result = False
+        candidate_urls = build_place_page_candidate_urls(
+            place,
+            city_name=city_name,
+            country_name=country_name,
+            google_place_id=google_place_id,
+        )
         retry_urls: list[str] = []
         for scrape_url in candidate_urls:
             enrichment_place, should_retry = process_scrape_url(scrape_url)

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -5843,7 +5843,7 @@ class BuildDataTests(unittest.TestCase):
         self.assertTrue(entry.matched)
         self.assertEqual(entry.place.display_name, "Cantina OK!")
 
-    def test_fetch_place_page_enrichment_retries_limited_view_without_reputation_after_candidate_queue(self) -> None:
+    def test_fetch_place_page_enrichment_retries_limited_view_without_review_count_after_candidate_queue(self) -> None:
         place = RawPlace(
             name="Cantina OK!",
             address="Council Pl, Sydney NSW 2000, Australia",
@@ -5900,6 +5900,65 @@ class BuildDataTests(unittest.TestCase):
             scrape_attempts,
             ["https://example.com/first", "https://example.com/second", "https://example.com/first"],
         )
+        clear_session.assert_called_once()
+        self.assertTrue(entry.matched)
+        assert entry.place is not None
+        self.assertEqual(entry.place.user_rating_count, 512)
+
+    def test_fetch_place_page_enrichment_retries_sparse_search_result_without_review_count(self) -> None:
+        place = RawPlace(
+            name="Cantina OK!",
+            maps_url="https://www.google.com/maps/search/?api=1&query=Cantina+OK!",
+        )
+        search_url = "https://www.google.com/maps/search/?api=1&query=Cantina+OK!"
+        scrape_attempts: list[str] = []
+
+        def scrape_side_effect(
+            scrape_url: str,
+            *,
+            headless: bool,
+            browser_session: object,
+            http_session: object,
+            llm_fallback: object,
+            llm_tasks: tuple[str, ...],
+            collect_reviews: bool,
+            collect_about: bool,
+        ) -> SimpleNamespace:
+            scrape_attempts.append(scrape_url)
+            if len(scrape_attempts) == 1:
+                return SimpleNamespace(
+                    source_url=scrape_url,
+                    resolved_url=scrape_url,
+                    name="Cantina OK!",
+                    category="Cocktail bar",
+                    rating=4.4,
+                    address=None,
+                    limited_view=True,
+                )
+            return SimpleNamespace(
+                source_url=scrape_url,
+                resolved_url="https://www.google.com/maps/place/Cantina+OK!/@-33.87,151.20,17z",
+                name="Cantina OK!",
+                category="Cocktail bar",
+                rating=4.8,
+                review_count=512,
+                address="Council Pl, Sydney NSW 2000, Australia",
+                limited_view=False,
+            )
+
+        with (
+            patch.object(build_data, "current_scraper_proxy", return_value=None),
+            patch.object(build_data, "build_place_page_candidate_urls", return_value=[search_url]),
+            patch.object(build_data, "build_scraper_sessions", return_value=(SimpleNamespace(), None, None)),
+            patch.object(build_data, "build_scraper_configs", return_value=(None, None)),
+            patch.object(build_data, "record_scraper_session_use"),
+            patch.object(build_data, "clear_scraper_session_state") as clear_session,
+            patch.object(build_data, "release_scraper_session_lock"),
+            patch.object(build_data, "scrape_place", side_effect=scrape_side_effect),
+        ):
+            entry = build_data.fetch_place_page_enrichment(place)
+
+        self.assertEqual(scrape_attempts, [search_url, search_url])
         clear_session.assert_called_once()
         self.assertTrue(entry.matched)
         assert entry.place is not None

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2426,6 +2426,18 @@ class BuildDataTests(unittest.TestCase):
             )
         )
 
+    def test_place_page_has_meaningful_enrichment_rejects_limited_view_without_review_count(self) -> None:
+        details = SimpleNamespace(limited_view=True)
+        enrichment_place = EnrichmentPlace(
+            display_name="Bianchetto",
+            formatted_address="26-28 Cotham Rd, Kew VIC 3101, Australia",
+            primary_type_display_name="Bar",
+            rating=4.4,
+        )
+
+        self.assertTrue(build_data.should_retry_limited_place_page_result(details, enrichment_place))
+        self.assertFalse(build_data.place_page_has_meaningful_enrichment(details, enrichment_place))
+
     def test_should_fallback_to_places_api_for_sparse_search_result(self) -> None:
         entry = EnrichmentCacheEntry(
             fetched_at="2026-04-20T00:00:00+00:00",
@@ -5830,6 +5842,68 @@ class BuildDataTests(unittest.TestCase):
         )
         self.assertTrue(entry.matched)
         self.assertEqual(entry.place.display_name, "Cantina OK!")
+
+    def test_fetch_place_page_enrichment_retries_limited_view_without_reputation_after_candidate_queue(self) -> None:
+        place = RawPlace(
+            name="Cantina OK!",
+            address="Council Pl, Sydney NSW 2000, Australia",
+            maps_url="https://www.google.com/maps/place/Cantina+OK!",
+        )
+        scrape_urls = ["https://example.com/first", "https://example.com/second"]
+        scrape_attempts: list[str] = []
+
+        def scrape_side_effect(
+            scrape_url: str,
+            *,
+            headless: bool,
+            browser_session: object,
+            http_session: object,
+            llm_fallback: object,
+            llm_tasks: tuple[str, ...],
+            collect_reviews: bool,
+            collect_about: bool,
+        ) -> SimpleNamespace:
+            scrape_attempts.append(scrape_url)
+            if len(scrape_attempts) <= len(scrape_urls):
+                return SimpleNamespace(
+                    source_url=scrape_url,
+                    resolved_url=scrape_url,
+                    name="Cantina OK!",
+                    category="Cocktail bar",
+                    address="Council Pl, Sydney NSW 2000, Australia",
+                    limited_view=True,
+                )
+            return SimpleNamespace(
+                source_url=scrape_url,
+                resolved_url=scrape_url,
+                name="Cantina OK!",
+                category="Cocktail bar",
+                address="Council Pl, Sydney NSW 2000, Australia",
+                rating=4.8,
+                review_count=512,
+                limited_view=False,
+            )
+
+        with (
+            patch.object(build_data, "current_scraper_proxy", return_value=None),
+            patch.object(build_data, "build_place_page_candidate_urls", return_value=scrape_urls),
+            patch.object(build_data, "build_scraper_sessions", return_value=(SimpleNamespace(), None, None)),
+            patch.object(build_data, "build_scraper_configs", return_value=(None, None)),
+            patch.object(build_data, "record_scraper_session_use"),
+            patch.object(build_data, "clear_scraper_session_state") as clear_session,
+            patch.object(build_data, "release_scraper_session_lock"),
+            patch.object(build_data, "scrape_place", side_effect=scrape_side_effect),
+        ):
+            entry = build_data.fetch_place_page_enrichment(place)
+
+        self.assertEqual(
+            scrape_attempts,
+            ["https://example.com/first", "https://example.com/second", "https://example.com/first"],
+        )
+        clear_session.assert_called_once()
+        self.assertTrue(entry.matched)
+        assert entry.place is not None
+        self.assertEqual(entry.place.user_rating_count, 512)
 
     def test_fetch_places_enrichment_uses_scrape_strategy_without_api_fallback(self) -> None:
         place = RawPlace(


### PR DESCRIPTION
## Description
Retry limited-view Google Maps place-page enrichments when the page omits the review count, even if a star rating is present. This defers those transient results until the candidate URL queue finishes and then retries them once with a fresh scraper session so downstream consumers do not cache partial matches too early.

## Related Issue
None found.

## How Has This Been Tested?
`uv run python -m unittest tests.python.test_build_data`
