### PR TITLE
Add site mapping rules for place enrichment

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -2392,18 +2392,26 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
             country_name=country_name,
         )
         primary_category = manual_primary_category or mapped_primary_category
+        machine_primary_category_tag = (
+            normalize_tag_slug(machine_primary_category) if machine_primary_category else None
+        )
+        mapped_primary_category_tag = (
+            normalize_tag_slug(mapped_primary_category) if mapped_primary_category else None
+        )
+        category_mapping_replaces_tag = bool(
+            not manual_primary_category
+            and machine_primary_category_tag
+            and mapped_primary_category_tag
+            and mapped_primary_category_tag != machine_primary_category_tag
+        )
         mapped_primary_category_source_tag = (
-            normalize_tag_slug(machine_primary_category)
-            if (
-                not manual_primary_category
-                and machine_primary_category
-                and mapped_primary_category != machine_primary_category
-            )
+            machine_primary_category_tag
+            if category_mapping_replaces_tag
             else None
         )
         primary_category_localized = (
             None
-            if manual_primary_category or mapped_primary_category != machine_primary_category
+            if manual_primary_category or category_mapping_replaces_tag
             else enrichment.primary_type_display_name_localized
         )
         use_semantic_enrichment = google_maps_place_semantic_llm_enabled()
@@ -8466,14 +8474,12 @@ def semantic_enrichment_evidence(
         "raw_address": enrichment_place.formatted_address or raw_place.address,
         "category": enrichment_place.primary_type_display_name,
         "category_localized": enrichment_place.primary_type_display_name_localized,
-        "google_description": enrichment_place.description,
+        "google_maps_description": enrichment_place.description,
         "search_result_description": enrichment_place.search_result_description,
         "types": enrichment_place.types[:8],
         "price_range": enrichment_place.price_range,
         "admission_price": enrichment_place.admission_price,
         "room_price": enrichment_place.room_price,
-        "google_maps_description": enrichment_place.description,
-        "search_result_description": enrichment_place.search_result_description,
         "review_topics": enrichment_place.review_topics[:12],
         "about_sections": compact_about_sections(enrichment_place.about_sections),
     }
@@ -8501,14 +8507,12 @@ def semantic_description_signature(
             enrichment_place.address_display_en or enrichment_place.formatted_address or raw_place.address
         ),
         "category": semantic_signature_text(enrichment_place.primary_type_display_name),
-        "google_description": semantic_signature_text(enrichment_place.description),
+        "google_maps_description": semantic_signature_text(enrichment_place.description),
         "search_result_description": semantic_signature_text(enrichment_place.search_result_description),
         "types": [value for value in (semantic_signature_text(item) for item in enrichment_place.types[:8]) if value],
         "price_range": semantic_signature_text(enrichment_place.price_range),
         "admission_price": semantic_signature_text(enrichment_place.admission_price),
         "room_price": semantic_signature_text(enrichment_place.room_price),
-        "google_maps_description": semantic_signature_text(enrichment_place.description),
-        "search_result_description": semantic_signature_text(enrichment_place.search_result_description),
         "rating_bucket": rating_bucket(enrichment_place.rating),
         "review_count_bucket": review_count_bucket(enrichment_place.user_rating_count),
         "review_topics": compact_review_topics_for_signature(enrichment_place.review_topics),

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -2424,15 +2424,21 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
             ]
             if semantic_tag_slug_is_usable(tag) and tag != mapped_primary_category_source_tag
         ]
+        override_tags = coerce_string_list(override.get("tags"))
         tags = sorted(
             {
-                *coerce_string_list(override.get("tags")),
+                *override_tags,
                 *semantic_tags,
                 *derive_place_tags(place, city_name, enrichment=enrichment, category=primary_category),
             }
         )
         if mapped_primary_category_source_tag:
-            tags = [tag for tag in tags if tag != mapped_primary_category_source_tag]
+            tags = sorted(
+                {
+                    *override_tags,
+                    *(tag for tag in tags if tag != mapped_primary_category_source_tag),
+                }
+            )
         raw_locality_candidates = infer_address_localities(
             place.address,
             city_name=city_name,

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -2385,12 +2385,27 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
         enrichment_cache_entry = enrichment_cache.get(place_id)
         enrichment = coerce_enrichment_place(enrichment_cache_entry)
         manual_primary_category = as_string(override.get("primary_category"))
-        primary_category = (
-            manual_primary_category
-            or enrichment.primary_type_display_name
-            or humanize_type_id(enrichment.primary_type)
+        machine_primary_category = enrichment.primary_type_display_name or humanize_type_id(enrichment.primary_type)
+        mapped_primary_category = apply_site_category_mappings(
+            machine_primary_category,
+            city_name=city_name,
+            country_name=country_name,
         )
-        primary_category_localized = None if manual_primary_category else enrichment.primary_type_display_name_localized
+        primary_category = manual_primary_category or mapped_primary_category
+        mapped_primary_category_source_tag = (
+            normalize_tag_slug(machine_primary_category)
+            if (
+                not manual_primary_category
+                and machine_primary_category
+                and mapped_primary_category != machine_primary_category
+            )
+            else None
+        )
+        primary_category_localized = (
+            None
+            if manual_primary_category or mapped_primary_category != machine_primary_category
+            else enrichment.primary_type_display_name_localized
+        )
         use_semantic_enrichment = google_maps_place_semantic_llm_enabled()
         use_semantic_descriptions = google_maps_place_semantic_descriptions_enabled()
         semantic_tags = [
@@ -2399,7 +2414,7 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
                 *(enrichment.semantic_tags if use_semantic_enrichment else []),
                 *(enrichment.semantic_types if use_semantic_enrichment else []),
             ]
-            if semantic_tag_slug_is_usable(tag)
+            if semantic_tag_slug_is_usable(tag) and tag != mapped_primary_category_source_tag
         ]
         tags = sorted(
             {
@@ -2408,6 +2423,8 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
                 *derive_place_tags(place, city_name, enrichment=enrichment, category=primary_category),
             }
         )
+        if mapped_primary_category_source_tag:
+            tags = [tag for tag in tags if tag != mapped_primary_category_source_tag]
         raw_locality_candidates = infer_address_localities(
             place.address,
             city_name=city_name,
@@ -2800,7 +2817,7 @@ def build_tag_provenance(
             source_place_field(tag, primary_category_field),
             priority=30 if primary_category_field and primary_category_field.source == "manual" else 20,
         )
-    for tag in derive_enrichment_type_tags(enrichment):
+    for tag in derive_enrichment_type_tags(enrichment, category=primary_category):
         put_tag(tag, google_places_field(tag, enrichment_cache_entry), priority=20)
 
     return [ranked_fields[tag][1] for tag in tags if tag in ranked_fields]
@@ -3601,7 +3618,7 @@ def derive_place_tags(
     )
     if category:
         tags.add(normalize_tag_slug(category))
-    tags.update(derive_enrichment_type_tags(enrichment))
+    tags.update(derive_enrichment_type_tags(enrichment, category=category))
     return sorted(tag for tag in tags if tag)
 
 
@@ -3639,16 +3656,16 @@ def derive_locality_tags(
     if not locality_tags:
         return []
 
-    has_specific_enrichment = bool(category or derive_enrichment_type_tags(enrichment))
+    has_specific_enrichment = bool(category or derive_enrichment_type_tags(enrichment, category=category))
     if has_specific_enrichment:
         return locality_tags[:1]
     return locality_tags[:2]
 
 
-def derive_enrichment_type_tags(enrichment: EnrichmentPlace) -> list[str]:
+def derive_enrichment_type_tags(enrichment: EnrichmentPlace, *, category: str | None = None) -> list[str]:
     _primary_type, type_ids = normalized_enrichment_type_ids(
         enrichment.primary_type,
-        enrichment.primary_type_display_name,
+        category or enrichment.primary_type_display_name,
         enrichment.types,
     )
     return [type_id.replace("_", "-") for type_id in type_ids]
@@ -4876,6 +4893,19 @@ def google_maps_place_semantic_description_force_refresh() -> bool:
 
 def google_maps_place_neighborhood_mappings() -> list[dict[str, Any]]:
     configured = site_google_maps_place_config_value("neighborhood_mappings")
+    if isinstance(configured, dict):
+        return [
+            {"from": source, "to": target}
+            for source, target in configured.items()
+            if isinstance(source, str) and isinstance(target, str)
+        ]
+    if isinstance(configured, list):
+        return [item for item in configured if isinstance(item, dict)]
+    return []
+
+
+def google_maps_place_category_mappings() -> list[dict[str, Any]]:
+    configured = site_google_maps_place_config_value("category_mappings")
     if isinstance(configured, dict):
         return [
             {"from": source, "to": target}
@@ -8350,7 +8380,11 @@ def repair_semantic_enrichment_with_llm(
                     "local area names over the smallest administrative unit. The neighborhood must be a "
                     "human-facing display label, not a tag or slug: use normal local display casing such as "
                     "Perth CBD, Northbridge, or Margaret River; preserve acronyms like CBD; never return "
-                    "kebab-case, snake_case, or all-lowercase labels. For Taiwan, village/li labels "
+                    "kebab-case, snake_case, all-lowercase labels, or labels with stray spaces inside words. "
+                    "For English-language guides, return the common English-facing neighborhood label when "
+                    "one exists; use established English names rather than mechanically preserving local-language "
+                    "administrative labels. "
+                    "For Taiwan, village/li labels "
                     "such as Kangle Village or Tonghua Village are usually too granular; prefer the district "
                     "such as Zhongshan or Da'an unless the evidence explicitly names a more recognizable local "
                     "area as the neighborhood. Do not infer Ximen, Neihu, Longshan, or similar local areas from "
@@ -8432,6 +8466,8 @@ def semantic_enrichment_evidence(
         "raw_address": enrichment_place.formatted_address or raw_place.address,
         "category": enrichment_place.primary_type_display_name,
         "category_localized": enrichment_place.primary_type_display_name_localized,
+        "google_description": enrichment_place.description,
+        "search_result_description": enrichment_place.search_result_description,
         "types": enrichment_place.types[:8],
         "price_range": enrichment_place.price_range,
         "admission_price": enrichment_place.admission_price,
@@ -8465,6 +8501,8 @@ def semantic_description_signature(
             enrichment_place.address_display_en or enrichment_place.formatted_address or raw_place.address
         ),
         "category": semantic_signature_text(enrichment_place.primary_type_display_name),
+        "google_description": semantic_signature_text(enrichment_place.description),
+        "search_result_description": semantic_signature_text(enrichment_place.search_result_description),
         "types": [value for value in (semantic_signature_text(item) for item in enrichment_place.types[:8]) if value],
         "price_range": semantic_signature_text(enrichment_place.price_range),
         "admission_price": semantic_signature_text(enrichment_place.admission_price),
@@ -8688,18 +8726,18 @@ def apply_site_neighborhood_mapping_rule(
     target = sanitize_semantic_label(rule.get("to"), max_length=64)
     if target is None:
         return None
-    if not neighborhood_mapping_context_matches(rule.get("city"), city_name):
+    if not site_mapping_context_matches(rule.get("city"), city_name):
         return None
-    if not neighborhood_mapping_context_matches(rule.get("country"), country_name):
+    if not site_mapping_context_matches(rule.get("country"), country_name):
         return None
-    if not neighborhood_mapping_values_match(rule.get("from"), [neighborhood]):
+    if not site_mapping_values_match(rule.get("from"), [neighborhood]):
         return None
-    if "when_address_contains" in rule and not neighborhood_mapping_contains(
+    if "when_address_contains" in rule and not site_mapping_contains(
         rule.get("when_address_contains"),
         address_values,
     ):
         return None
-    if "when_candidate" in rule and not neighborhood_mapping_values_match(
+    if "when_candidate" in rule and not site_mapping_values_match(
         rule.get("when_candidate"),
         locality_candidates,
     ):
@@ -8707,7 +8745,46 @@ def apply_site_neighborhood_mapping_rule(
     return target
 
 
-def neighborhood_mapping_context_matches(configured: Any, actual: str | None) -> bool:
+def apply_site_category_mappings(
+    category: str | None,
+    *,
+    city_name: str | None,
+    country_name: str | None,
+) -> str | None:
+    if category is None:
+        return None
+    for rule in google_maps_place_category_mappings():
+        mapped = apply_site_category_mapping_rule(
+            category,
+            rule,
+            city_name=city_name,
+            country_name=country_name,
+        )
+        if mapped is not None:
+            return mapped
+    return category
+
+
+def apply_site_category_mapping_rule(
+    category: str,
+    rule: dict[str, Any],
+    *,
+    city_name: str | None,
+    country_name: str | None,
+) -> str | None:
+    target = sanitize_enrichment_primary_category(rule.get("to"))
+    if target is None:
+        return None
+    if not site_mapping_context_matches(rule.get("city"), city_name):
+        return None
+    if not site_mapping_context_matches(rule.get("country"), country_name):
+        return None
+    if not site_mapping_values_match(rule.get("from"), [category]):
+        return None
+    return target
+
+
+def site_mapping_context_matches(configured: Any, actual: str | None) -> bool:
     values = coerce_mapping_string_list(configured)
     if not values:
         return True
@@ -8715,7 +8792,7 @@ def neighborhood_mapping_context_matches(configured: Any, actual: str | None) ->
     return bool(actual_key and any(normalize_locality_key(value) == actual_key for value in values))
 
 
-def neighborhood_mapping_values_match(configured: Any, values: Sequence[str]) -> bool:
+def site_mapping_values_match(configured: Any, values: Sequence[str]) -> bool:
     configured_values = coerce_mapping_string_list(configured)
     if not configured_values:
         return False
@@ -8723,7 +8800,7 @@ def neighborhood_mapping_values_match(configured: Any, values: Sequence[str]) ->
     return any(normalize_locality_key(value) in value_keys for value in configured_values)
 
 
-def neighborhood_mapping_contains(configured: Any, values: Sequence[str | None]) -> bool:
+def site_mapping_contains(configured: Any, values: Sequence[str | None]) -> bool:
     configured_values = coerce_mapping_string_list(configured)
     if not configured_values:
         return False

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -2424,10 +2424,10 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
             ]
             if semantic_tag_slug_is_usable(tag) and tag != mapped_primary_category_source_tag
         ]
-        override_tags = coerce_string_list(override.get("tags"))
+        place_override_tags = coerce_string_list(override.get("tags"))
         tags = sorted(
             {
-                *override_tags,
+                *place_override_tags,
                 *semantic_tags,
                 *derive_place_tags(place, city_name, enrichment=enrichment, category=primary_category),
             }
@@ -2435,7 +2435,7 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
         if mapped_primary_category_source_tag:
             tags = sorted(
                 {
-                    *override_tags,
+                    *place_override_tags,
                     *(tag for tag in tags if tag != mapped_primary_category_source_tag),
                 }
             )

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -131,6 +131,7 @@ export type SiteConfigInput = Partial<
   favicon?: SiteConfig["favicon"];
   logo?: SiteConfig["logo"];
   navLinks?: SiteConfig["navLinks"];
+  guideCard?: Partial<GuideCardConfig>;
   home?: Partial<Omit<HomeConfig, "guideCard">> & {
     guideCard?: Partial<GuideCardConfig>;
   };
@@ -256,6 +257,7 @@ function mergeSiteConfig(config: SiteConfigInput): SiteConfig {
       ...config.home,
       guideCard: {
         ...defaultSiteConfig.home.guideCard,
+        ...config.guideCard,
         ...config.home?.guideCard,
       },
     },

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -246,9 +246,11 @@ const defaultSiteConfig: SiteConfig = {
 };
 
 function mergeSiteConfig(config: SiteConfigInput): SiteConfig {
+  const { guideCard: legacyGuideCard, ...rootConfig } = config;
+
   return {
     ...defaultSiteConfig,
-    ...config,
+    ...rootConfig,
     favicon: config.favicon === undefined ? defaultSiteConfig.favicon : config.favicon,
     logo: config.logo === undefined ? defaultSiteConfig.logo : config.logo,
     navLinks: config.navLinks ?? defaultSiteConfig.navLinks,
@@ -257,7 +259,7 @@ function mergeSiteConfig(config: SiteConfigInput): SiteConfig {
       ...config.home,
       guideCard: {
         ...defaultSiteConfig.home.guideCard,
-        ...config.guideCard,
+        ...legacyGuideCard,
         ...config.home?.guideCard,
       },
     },

--- a/tests/frontend/siteConfig.test.ts
+++ b/tests/frontend/siteConfig.test.ts
@@ -18,6 +18,7 @@ describe("site config merging", () => {
     expect(siteConfig.home.guideCard.showDescription).toBe(false);
     expect(siteConfig.home.guideCard.maxTags).toBe(2);
     expect(siteConfig.home.guideCard.trimCountryFromTitle).toBe(false);
+    expect("guideCard" in siteConfig).toBe(false);
   });
 
   it("lets nested home guideCard config override legacy config", async () => {

--- a/tests/frontend/siteConfig.test.ts
+++ b/tests/frontend/siteConfig.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("site config merging", () => {
+  it("preserves legacy top-level guideCard config", async () => {
+    vi.resetModules();
+    vi.doMock("favorite-places:site-config", () => ({
+      siteConfig: {
+        guideCard: {
+          showDescription: false,
+          maxTags: 2,
+          trimCountryFromTitle: false,
+        },
+      },
+    }));
+    const { siteConfig } = await import("../../src/data/site");
+    vi.doUnmock("favorite-places:site-config");
+
+    expect(siteConfig.home.guideCard.showDescription).toBe(false);
+    expect(siteConfig.home.guideCard.maxTags).toBe(2);
+    expect(siteConfig.home.guideCard.trimCountryFromTitle).toBe(false);
+  });
+
+  it("lets nested home guideCard config override legacy config", async () => {
+    vi.resetModules();
+    vi.doMock("favorite-places:site-config", () => ({
+      siteConfig: {
+        guideCard: {
+          showDescription: false,
+          maxTags: 2,
+        },
+        home: {
+          guideCard: {
+            showDescription: true,
+            maxTags: 6,
+          },
+        },
+      },
+    }));
+    const { siteConfig } = await import("../../src/data/site");
+    vi.doUnmock("favorite-places:site-config");
+
+    expect(siteConfig.home.guideCard.showDescription).toBe(true);
+    expect(siteConfig.home.guideCard.maxTags).toBe(6);
+  });
+});

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -4176,6 +4176,63 @@ class BuildDataTests(unittest.TestCase):
         self.assertIn("japanese-restaurant", guide.places[0].tags)
         self.assertNotIn("authentic-japanese-restaurant", guide.places[0].tags)
 
+    def test_normalize_guide_keeps_category_tag_when_mapping_preserves_slug(self) -> None:
+        raw = RawSavedList(
+            title="Montreal, Canada",
+            places=[
+                RawPlace(
+                    name="Cafe",
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                ),
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0])
+        enrichment_cache = {
+            place_id: EnrichmentCacheEntry(
+                fetched_at="2026-05-01T00:00:00+00:00",
+                query="Cafe, Montreal, Canada",
+                matched=True,
+                source="google_maps_page",
+                place=EnrichmentPlace(
+                    display_name="Cafe",
+                    primary_type_display_name="coffee shop",
+                ),
+            ),
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+
+            with (
+                patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+                patch.object(
+                    build_data,
+                    "google_maps_place_category_mappings",
+                    return_value=[
+                        {
+                            "city": "Montreal",
+                            "country": "Canada",
+                            "from": "coffee shop",
+                            "to": "Coffee Shop",
+                        }
+                    ],
+                ),
+            ):
+                guide = build_data.normalize_guide(
+                    "montreal-canada",
+                    raw,
+                    enrichment_cache=enrichment_cache,
+                )
+
+        self.assertEqual(guide.places[0].primary_category, "Coffee Shop")
+        self.assertIn("coffee-shop", guide.places[0].tags)
+
     def test_normalize_guide_excludes_permanently_closed_places_from_ui_counts(self) -> None:
         raw = RawSavedList(
             title="Tokyo, Japan",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -3462,6 +3462,138 @@ class BuildDataTests(unittest.TestCase):
         )
         self.assertTrue(hidden_place.hidden)
 
+    def test_normalize_guide_combines_google_description_and_note_without_semantic_copy(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo, Japan",
+            places=[
+                RawPlace(
+                    name="Coffee House",
+                    note="Saved-list note from the curator.",
+                    maps_url="https://maps.google.com/?cid=1",
+                    cid="111",
+                ),
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0])
+        enrichment_cache = {
+            place_id: EnrichmentCacheEntry(
+                fetched_at="2026-04-01T00:00:00+00:00",
+                query="Coffee House, Tokyo",
+                place=EnrichmentPlace(
+                    description="Google place description.",
+                    primary_type_display_name="Coffee shop",
+                ),
+            )
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+
+            with (
+                patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+                patch.object(build_data, "google_maps_place_semantic_llm_enabled", return_value=False),
+                patch.object(build_data, "google_maps_place_semantic_descriptions_enabled", return_value=True),
+            ):
+                guide = build_data.normalize_guide("tokyo-japan", raw, enrichment_cache=enrichment_cache)
+
+        self.assertEqual(
+            guide.places[0].why_recommended,
+            "Google place description.\n\nSaved-list note from the curator.",
+        )
+        self.assertEqual(guide.places[0].note, "Saved-list note from the curator.")
+
+    def test_normalize_guide_uses_search_result_description_as_description_backup(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo, Japan",
+            places=[
+                RawPlace(
+                    name="Coffee House",
+                    note="Saved-list note from the curator.",
+                    maps_url="https://maps.google.com/?cid=1",
+                    cid="111",
+                ),
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0])
+        enrichment_cache = {
+            place_id: EnrichmentCacheEntry(
+                fetched_at="2026-04-01T00:00:00+00:00",
+                query="Coffee House, Tokyo",
+                place=EnrichmentPlace(
+                    search_result_description="Search-result place description.",
+                    primary_type_display_name="Coffee shop",
+                ),
+            )
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+
+            with (
+                patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+                patch.object(build_data, "google_maps_place_semantic_llm_enabled", return_value=False),
+                patch.object(build_data, "google_maps_place_semantic_descriptions_enabled", return_value=True),
+            ):
+                guide = build_data.normalize_guide("tokyo-japan", raw, enrichment_cache=enrichment_cache)
+
+        self.assertEqual(
+            guide.places[0].why_recommended,
+            "Search-result place description.\n\nSaved-list note from the curator.",
+        )
+
+    def test_normalize_guide_prefers_semantic_description_over_deterministic_description_fallback(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo, Japan",
+            places=[
+                RawPlace(
+                    name="Coffee House",
+                    note="Saved-list note from the curator.",
+                    maps_url="https://maps.google.com/?cid=1",
+                    cid="111",
+                ),
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0])
+        enrichment_cache = {
+            place_id: EnrichmentCacheEntry(
+                fetched_at="2026-04-01T00:00:00+00:00",
+                query="Coffee House, Tokyo",
+                place=EnrichmentPlace(
+                    description="Google place description.",
+                    search_result_description="Search-result place description.",
+                    semantic_description="LLM semantic description.",
+                    primary_type_display_name="Coffee shop",
+                ),
+            )
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+
+            with (
+                patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+                patch.object(build_data, "google_maps_place_semantic_llm_enabled", return_value=False),
+                patch.object(build_data, "google_maps_place_semantic_descriptions_enabled", return_value=True),
+            ):
+                guide = build_data.normalize_guide("tokyo-japan", raw, enrichment_cache=enrichment_cache)
+
+        self.assertEqual(guide.places[0].why_recommended, "LLM semantic description.")
+
     def test_normalize_guide_rejects_manual_why_recommended_override(self) -> None:
         raw = RawSavedList(
             title="Tokyo, Japan",
@@ -3926,6 +4058,123 @@ class BuildDataTests(unittest.TestCase):
                 )
 
         self.assertEqual(guide.places[0].neighborhood, "Wanhua")
+
+    def test_normalize_guide_applies_site_neighborhood_mapping_alias_lists(self) -> None:
+        raw = RawSavedList(
+            title="Montreal, Canada",
+            places=[
+                RawPlace(
+                    name="Plateau Cafe",
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                ),
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0])
+        enrichment_cache = {
+            place_id: EnrichmentCacheEntry(
+                fetched_at="2026-05-01T00:00:00+00:00",
+                query="Plateau Cafe, Montreal, Canada",
+                matched=True,
+                source="google_maps_page",
+                place=EnrichmentPlace(
+                    display_name="Plateau Cafe",
+                    formatted_address="100 Mont-Royal Ave E, Montréal, QC, Canada",
+                    primary_type_display_name="Cafe",
+                    semantic_neighborhood="Le Plateau",
+                ),
+            ),
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+
+            with (
+                patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+                patch.object(build_data, "google_maps_place_semantic_llm_enabled", return_value=True),
+                patch.object(
+                    build_data,
+                    "google_maps_place_neighborhood_mappings",
+                    return_value=[
+                        {
+                            "city": "Montreal",
+                            "country": "Canada",
+                            "from": ["The Plateau", "Le Plateau"],
+                            "to": "Plateau",
+                        }
+                    ],
+                ),
+            ):
+                guide = build_data.normalize_guide(
+                    "montreal-canada",
+                    raw,
+                    enrichment_cache=enrichment_cache,
+                )
+
+        self.assertEqual(guide.places[0].neighborhood, "Plateau")
+
+    def test_normalize_guide_applies_site_category_mapping_rules(self) -> None:
+        raw = RawSavedList(
+            title="Montreal, Canada",
+            places=[
+                RawPlace(
+                    name="Kitano Shokudo",
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                ),
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0])
+        enrichment_cache = {
+            place_id: EnrichmentCacheEntry(
+                fetched_at="2026-05-01T00:00:00+00:00",
+                query="Kitano Shokudo, Montreal, Canada",
+                matched=True,
+                source="google_maps_page",
+                place=EnrichmentPlace(
+                    display_name="Kitano Shokudo",
+                    primary_type_display_name="Authentic Japanese restaurant",
+                ),
+            ),
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+
+            with (
+                patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+                patch.object(
+                    build_data,
+                    "google_maps_place_category_mappings",
+                    return_value=[
+                        {
+                            "city": "Montreal",
+                            "country": "Canada",
+                            "from": "Authentic Japanese restaurant",
+                            "to": "Japanese restaurant",
+                        }
+                    ],
+                ),
+            ):
+                guide = build_data.normalize_guide(
+                    "montreal-canada",
+                    raw,
+                    enrichment_cache=enrichment_cache,
+                )
+
+        self.assertEqual(guide.places[0].primary_category, "Japanese restaurant")
+        self.assertIn("japanese-restaurant", guide.places[0].tags)
+        self.assertNotIn("authentic-japanese-restaurant", guide.places[0].tags)
 
     def test_normalize_guide_excludes_permanently_closed_places_from_ui_counts(self) -> None:
         raw = RawSavedList(
@@ -6763,6 +7012,8 @@ class BuildDataTests(unittest.TestCase):
             patch.object(build_data, "build_scraper_sessions", return_value=(SimpleNamespace(), None, None)),
             patch.object(build_data, "record_scraper_session_use"),
             patch.object(build_data, "release_scraper_session_lock"),
+            patch.object(build_data, "google_maps_place_collect_reviews", return_value=True),
+            patch.object(build_data, "google_maps_place_collect_about", return_value=True),
             patch.object(build_data, "scrape_place", return_value=details) as scrape,
         ):
             entry = build_data.fetch_place_page_enrichment(place)

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -4233,6 +4233,75 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(guide.places[0].primary_category, "Coffee Shop")
         self.assertIn("coffee-shop", guide.places[0].tags)
 
+    def test_normalize_guide_preserves_manual_tags_when_category_mapping_prunes_source_tag(self) -> None:
+        raw = RawSavedList(
+            title="Montreal, Canada",
+            places=[
+                RawPlace(
+                    name="Kitano Shokudo",
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                ),
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0])
+        enrichment_cache = {
+            place_id: EnrichmentCacheEntry(
+                fetched_at="2026-05-01T00:00:00+00:00",
+                query="Kitano Shokudo, Montreal, Canada",
+                matched=True,
+                source="google_maps_page",
+                place=EnrichmentPlace(
+                    display_name="Kitano Shokudo",
+                    primary_type_display_name="Authentic Japanese restaurant",
+                ),
+            ),
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+            (place_overrides_dir / "montreal-canada.json").write_text(
+                json.dumps(
+                    {
+                        place_id: {
+                            "tags": ["authentic-japanese-restaurant", "izakaya"],
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+                patch.object(
+                    build_data,
+                    "google_maps_place_category_mappings",
+                    return_value=[
+                        {
+                            "city": "Montreal",
+                            "country": "Canada",
+                            "from": "Authentic Japanese restaurant",
+                            "to": "Japanese restaurant",
+                        }
+                    ],
+                ),
+            ):
+                guide = build_data.normalize_guide(
+                    "montreal-canada",
+                    raw,
+                    enrichment_cache=enrichment_cache,
+                )
+
+        self.assertEqual(guide.places[0].primary_category, "Japanese restaurant")
+        self.assertIn("japanese-restaurant", guide.places[0].tags)
+        self.assertIn("authentic-japanese-restaurant", guide.places[0].tags)
+        self.assertIn("izakaya", guide.places[0].tags)
+
     def test_normalize_guide_excludes_permanently_closed_places_from_ui_counts(self) -> None:
         raw = RawSavedList(
             title="Tokyo, Japan",


### PR DESCRIPTION
## Description
Adds site-configurable category mappings for Google Maps place enrichment and reuses generalized mapping helpers for neighborhood aliases.
Mapped categories now replace the machine category in the primary category and derived tags, which avoids duplicate facets after site-level consolidations.
The semantic enrichment prompt now asks for English-facing neighborhood labels, and semantic description signatures include Google/search-result descriptions so generated copy refreshes when those inputs change.
Adds regression coverage for description fallbacks, alias-list neighborhood mappings, category mappings, and explicit review/about scraping flags.

## Related Issue
None found after searching issues for semantic enrichment neighborhood/category alias mapping.

## How Has This Been Tested?
`bun run test:python`
`git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Refactor**
* Improved category mapping logic and semantic tag filtering for enhanced data consistency
* Refined neighborhood mapping support with better rule handling
* Optimized field naming for description sources

**Tests**
* Added comprehensive tests for category-aware mapping features
* Expanded neighborhood mapping rule coverage with additional scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->