### PR TITLE
Harden enrichment and scraper safeguards

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -5855,8 +5855,13 @@ def preserve_existing_enrichment(
         if not refreshed_place.about_sections and previous_place.about_sections:
             refreshed_place.about_sections = previous_place.about_sections[:]
             append_unique_reason(preserved_fields, "about")
-        if not refreshed_place.semantic_description and previous_place.semantic_description:
-            refreshed_place.semantic_description = previous_place.semantic_description
+        preserved_semantic_description = semantic_description_for_preservation(
+            previous_place,
+            refreshed_place,
+            raw_place=raw_place,
+        )
+        if not refreshed_place.semantic_description and preserved_semantic_description:
+            refreshed_place.semantic_description = preserved_semantic_description
             refreshed_place.semantic_description_signature = previous_place.semantic_description_signature
             refreshed_place.semantic_source = previous_place.semantic_source
             append_unique_reason(preserved_fields, "semantic_description")
@@ -5868,6 +5873,25 @@ def preserve_existing_enrichment(
         refreshed_entry,
         f"WARNING: Preserving previous enrichment fields for {slug}:{place_id} [{place_name}]: "
         f"{', '.join(preserved_fields)}.",
+    )
+
+
+def semantic_description_for_preservation(
+    previous_place: EnrichmentPlace,
+    refreshed_place: EnrichmentPlace,
+    *,
+    raw_place: RawPlace | None,
+) -> str | None:
+    if not previous_place.semantic_description:
+        return None
+    if raw_place is None:
+        return sanitize_semantic_description(previous_place.semantic_description)
+    return usable_semantic_description(
+        previous_place.semantic_description,
+        enrichment_place=refreshed_place,
+        raw_place=raw_place,
+        city_name=None,
+        country_name=None,
     )
 
 
@@ -9735,21 +9759,34 @@ def sanitize_semantic_description(value: Any) -> str | None:
 
 
 SEMANTIC_DESCRIPTION_MALFORMED_RE = re.compile(
-    r"(?:"
-    r"^\s*(?:great|good|nice|amazing|awesome)\s+spot\b|"
-    r"\b(?:top\s+notch|kinda|at\s+this\s+price\s+point|doesn[’']?t\s+feel|"
-    r"feels?\s+(?:kinda\s+)?cheap|clueless)\b"
-    r")",
+    r"\b(?:"
+    r"top\s+notch|kinda|at\s+this\s+price\s+point|doesn[’']?t\s+feel|"
+    r"feels?\s+(?:kinda\s+)?cheap|clueless)\b",
     re.IGNORECASE,
 )
 
 
 def looks_like_malformed_semantic_description(value: str) -> bool:
-    if value.count("/") >= 2:
+    if looks_like_slash_delimited_phrase_leak(value):
         return True
     malformed_markers = SEMANTIC_DESCRIPTION_MALFORMED_RE.findall(value)
     has_chatty_structure = any(marker in value for marker in ("$", ";", "(", ")"))
     return has_chatty_structure and len(malformed_markers) >= 2
+
+
+SEMANTIC_DESCRIPTION_SLASH_SEPARATOR_RE = re.compile(r"(?:(?<=\s)/|/(?=\s))")
+
+
+def looks_like_slash_delimited_phrase_leak(value: str) -> bool:
+    if len(SEMANTIC_DESCRIPTION_SLASH_SEPARATOR_RE.findall(value)) < 2:
+        return False
+    segments = [segment.strip() for segment in re.split(r"\s*/\s*", value) if segment.strip()]
+    phrase_like_segments = 0
+    for segment in segments:
+        words = SEMANTIC_DESCRIPTION_TOKEN_RE.findall(segment)
+        if len(words) >= 3 or len(segment) >= 35:
+            phrase_like_segments += 1
+    return phrase_like_segments >= 2
 
 
 SEMANTIC_DESCRIPTION_REVIEW_SOURCE_LEAK_RE = re.compile(

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -18,7 +18,7 @@ import time
 import unicodedata
 import uuid
 from collections import Counter
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime, timedelta
 from dataclasses import dataclass
@@ -6054,6 +6054,26 @@ def save_places_cache_to_sqlite(
         connection.close()
 
 
+def existing_places_cache_sqlite_row_counts(slugs: Iterable[str]) -> dict[str, int]:
+    if not PLACES_SQLITE_PATH.exists():
+        return {}
+    connection = sqlite3.connect(PLACES_SQLITE_PATH)
+    try:
+        if not sqlite_table_exists(connection, "guide_enrichment_cache"):
+            return {}
+        return {
+            slug: connection.execute(
+                "SELECT COUNT(*) FROM guide_enrichment_cache WHERE guide_slug = ?",
+                (slug,),
+            ).fetchone()[0]
+            for slug in slugs
+        }
+    except sqlite3.Error:
+        return {}
+    finally:
+        connection.close()
+
+
 def export_all_places_cache_json() -> int:
     PLACES_CACHE_DIR.mkdir(parents=True, exist_ok=True)
     exported = 0
@@ -6366,6 +6386,20 @@ def rebuild_places_sqlite(
     guides: list[Guide],
     enrichment_caches: dict[str, dict[str, EnrichmentCacheEntry]],
 ) -> None:
+    existing_row_counts = existing_places_cache_sqlite_row_counts(raw_lists.keys())
+    empty_replacements = [
+        slug
+        for slug, raw in raw_lists.items()
+        if raw.places
+        and not enrichment_caches.get(slug)
+        and existing_row_counts.get(slug, 0) > 0
+    ]
+    if empty_replacements:
+        joined_slugs = ", ".join(sorted(empty_replacements))
+        raise RuntimeError(
+            "Refusing to rebuild enrichment cache with empty payloads for "
+            f"non-empty guide(s): {joined_slugs}."
+        )
     pruned_any = False
     for slug, raw in raw_lists.items():
         cache_payload = enrichment_caches.get(slug)
@@ -9688,9 +9722,7 @@ SEMANTIC_DESCRIPTION_MALFORMED_RE = re.compile(
     r"(?:"
     r"^\s*(?:great|good|nice|amazing|awesome)\s+spot\b|"
     r"\b(?:top\s+notch|kinda|at\s+this\s+price\s+point|doesn[’']?t\s+feel|"
-    r"feels?\s+(?:kinda\s+)?cheap|clueless)\b|"
-    r"\b(?:vous|propose|sélection|raffinés|méticuleusement|choisis|convivial|"
-    r"chaleureux|feutré|partage)\b"
+    r"feels?\s+(?:kinda\s+)?cheap|clueless)\b"
     r")",
     re.IGNORECASE,
 )

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -3283,7 +3283,7 @@ def enrich_raw_sources(
         if not normalized_place_selectors:
             cache_payload, pruned_count = prune_places_cache_to_raw_places(cache_payload, raw)
             if pruned_count:
-                save_places_cache(slug, cache_payload)
+                save_places_cache(slug, cache_payload, allow_empty_overwrite=True)
         cache_payloads[slug] = cache_payload
         for place in raw.places:
             place_id = stable_place_id(place, source_type=raw.configured_source_type)
@@ -3450,7 +3450,7 @@ def refresh_cached_semantic_enrichment(
         if not normalized_place_selectors:
             cache_payload, pruned_count = prune_places_cache_to_raw_places(cache_payload, raw)
             if pruned_count:
-                save_places_cache(slug, cache_payload)
+                save_places_cache(slug, cache_payload, allow_empty_overwrite=True)
         cache_payloads[slug] = cache_payload
 
         for place in raw.places:
@@ -5870,8 +5870,13 @@ def load_places_cache(slug: str) -> dict[str, EnrichmentCacheEntry]:
     return load_places_cache_from_sqlite(slug) or {}
 
 
-def save_places_cache(slug: str, payload: dict[str, EnrichmentCacheEntry]) -> None:
-    save_places_cache_to_sqlite(slug, payload)
+def save_places_cache(
+    slug: str,
+    payload: dict[str, EnrichmentCacheEntry],
+    *,
+    allow_empty_overwrite: bool = False,
+) -> None:
+    save_places_cache_to_sqlite(slug, payload, allow_empty_overwrite=allow_empty_overwrite)
 
 
 def prune_places_cache_to_raw_places(
@@ -5991,13 +5996,18 @@ def load_places_cache_from_sqlite(slug: str) -> dict[str, EnrichmentCacheEntry] 
     return result
 
 
-def save_places_cache_to_sqlite(slug: str, payload: dict[str, EnrichmentCacheEntry]) -> None:
+def save_places_cache_to_sqlite(
+    slug: str,
+    payload: dict[str, EnrichmentCacheEntry],
+    *,
+    allow_empty_overwrite: bool = False,
+) -> None:
     PLACES_SQLITE_PATH.parent.mkdir(parents=True, exist_ok=True)
     connection = sqlite3.connect(PLACES_SQLITE_PATH)
     try:
         with connection:
             ensure_guide_enrichment_cache_table(connection)
-            if not payload:
+            if not payload and not allow_empty_overwrite:
                 existing_count = connection.execute(
                     "SELECT COUNT(*) FROM guide_enrichment_cache WHERE guide_slug = ?",
                     (slug,),

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -5845,6 +5845,22 @@ def preserve_existing_enrichment(
         refreshed_place.photo_url = previous_place.photo_url
         append_unique_reason(preserved_fields, "photo_url")
 
+    if can_preserve_previous_identity:
+        if not refreshed_place.review_topics and previous_place.review_topics:
+            refreshed_place.review_topics = previous_place.review_topics[:]
+            append_unique_reason(preserved_fields, "review_topics")
+        if not refreshed_place.reviews and previous_place.reviews:
+            refreshed_place.reviews = previous_place.reviews[:]
+            append_unique_reason(preserved_fields, "reviews")
+        if not refreshed_place.about_sections and previous_place.about_sections:
+            refreshed_place.about_sections = previous_place.about_sections[:]
+            append_unique_reason(preserved_fields, "about")
+        if not refreshed_place.semantic_description and previous_place.semantic_description:
+            refreshed_place.semantic_description = previous_place.semantic_description
+            refreshed_place.semantic_description_signature = previous_place.semantic_description_signature
+            refreshed_place.semantic_source = previous_place.semantic_source
+            append_unique_reason(preserved_fields, "semantic_description")
+
     if not preserved_fields:
         return refreshed_entry, None
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -368,6 +368,7 @@ COUNTRY_LOCALITY_ALIASES = (
     "China",
     "中国",
     "South Korea",
+    "Korea",
     "韓国",
     "Vatican City",
     "Ivory Coast",
@@ -417,7 +418,6 @@ SEMANTIC_NEIGHBORHOOD_UPPERCASE_TOKENS = {
 }
 COUNTRY_LOCALITY_KEYS: set[str] | None = None
 SUBNATIONAL_LOCALITY_KEYS: set[str] | None = None
-SUBNATIONAL_LOCALITY_CODE_KEYS: set[str] | None = None
 SUBNATIONAL_LOCALITY_ABBREVIATIONS = frozenset(
     {
         "AL",
@@ -473,14 +473,22 @@ SUBNATIONAL_LOCALITY_ABBREVIATIONS = frozenset(
         "DC",
     }
 )
+SUBNATIONAL_LOCALITY_CODE_KEYS: set[str] | None = None
 LOCATION_TAG_ALIASES: dict[str, tuple[str, ...]] = {
     "geneve": ("geneva",),
     "geneva": ("geneve",),
 }
 LOCALITY_EQUIVALENCE_ALIASES: dict[str, str] = {
+    "brussel": "brussels",
+    "bruxelles": "brussels",
     "donostia": "san sebastian",
     "donostia san sebastián": "san sebastian",
     "donostia san sebastian": "san sebastian",
+    "genève": "geneva",
+    "geneve": "geneva",
+    "københavn": "copenhagen",
+    "münchen": "munich",
+    "nürnberg": "nuremberg",
     "san sebastián": "san sebastian",
 }
 BROKEN_TAG_NORMALIZATION_MAP: dict[str, str] = {
@@ -2487,9 +2495,14 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
         top_pick = top_pick_override if top_pick_override is not None else place.is_favorite
         manual_note = as_string(override.get("note"))
         note = manual_note or place.note
-        added_by = place_added_by_for_ui(place, override=override)
+        enrichment_identity_compatible = enrichment_identity_is_compatible_with_raw(place, enrichment)
+        enrichment_recommendation_copy = (
+            enrichment.description or enrichment.search_result_description
+            if enrichment_identity_compatible
+            else None
+        )
         base_recommendation = combine_recommendation_copy(
-            enrichment.description or enrichment.search_result_description,
+            enrichment_recommendation_copy,
             place.note,
         )
         semantic_description = (
@@ -2584,7 +2597,6 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
             neighborhood=neighborhood,
             note=note,
             why_recommended=why_recommended,
-            added_by=added_by,
             main_photo_path=None,
             top_pick=top_pick,
             hidden=hidden,
@@ -2776,12 +2788,6 @@ def build_place_provenance(
             manual_place_field(normalized.why_recommended)
             if manual_note
             else None
-        )
-    if normalized.added_by:
-        provenance.added_by = (
-            manual_place_field(normalized.added_by)
-            if "added_by" in override
-            else google_list_field(normalized.added_by, raw)
         )
     provenance.top_pick = (
         manual_place_field(normalized.top_pick)
@@ -3869,7 +3875,14 @@ def sanitize_place_photo_url(value: str | None) -> str | None:
     url_parts = urlsplit(normalized)
     host = (url_parts.hostname or "").lower()
     path = url_parts.path.lower()
+    query = url_parts.query.lower()
     if "staticmap" in path:
+        return None
+    if host.endswith("gstatic.com") and (
+        host.startswith("encrypted-tbn")
+        or path.startswith(("/faviconv2", "/ads-travel/"))
+        or "tbn:" in query
+    ):
         return None
     if (
         (host.endswith("googleusercontent.com") or host.endswith("ggpht.com"))
@@ -4426,7 +4439,7 @@ def infer_address_parts_localities(
         if (
             not candidate_key
             or candidate_key == city_key
-            or candidate_equivalence_key in city_equivalence_keys
+            or (candidate_equivalence_key in city_equivalence_keys)
             or is_subnational_locality(normalized_candidate)
         ):
             continue
@@ -4912,12 +4925,6 @@ def guide_author_for_ui(raw: RawSavedList, *, list_override: dict[str, Any]) -> 
     return raw.owner
 
 
-def place_added_by_for_ui(place: RawPlace, *, override: dict[str, Any]) -> ListAuthor | None:
-    if "added_by" in override:
-        return coerce_list_author(override.get("added_by"))
-    return place.added_by
-
-
 def load_raw_saved_list(path: Path) -> RawSavedList | None:
     if not path.exists():
         return None
@@ -5256,9 +5263,6 @@ def preserve_existing_raw_place(
     if names_compatible and not refreshed_place.is_favorite and existing_place.is_favorite:
         updates["is_favorite"] = True
         preserved_fields.append("is_favorite")
-    if names_compatible and refreshed_place.added_by is None and existing_place.added_by is not None:
-        updates["added_by"] = existing_place.added_by
-        preserved_fields.append("added_by")
 
     if not updates:
         return refreshed_place, preserved_fields
@@ -7884,6 +7888,7 @@ PLACE_PAGE_DISPLAY_NAME_REJECT_VALUES = {
     "save",
     "saved",
     "share",
+    "sponsored",
     "website",
 }
 
@@ -7892,7 +7897,10 @@ def sanitize_place_page_display_name(value: Any) -> str | None:
     normalized = as_string(value)
     if normalized is None:
         return None
-    if normalize_text(normalized) in PLACE_PAGE_DISPLAY_NAME_REJECT_VALUES:
+    normalized_lookup = normalize_text(normalized)
+    if normalized_lookup in PLACE_PAGE_DISPLAY_NAME_REJECT_VALUES:
+        return None
+    if normalized_lookup.startswith("sponsored "):
         return None
     return normalized
 
@@ -7923,8 +7931,33 @@ PLACE_PAGE_FIRST_PERSON_DESCRIPTION_MARKERS = (
     "went",
 )
 PLACE_PAGE_REVIEW_DESCRIPTION_MARKERS = (
+    "best place to stay",
+    "boy was it worth",
+    "definitely recommend this place",
+    "great experience overall",
+    "had a great time",
+    "hidden gem-literally",
     "highly recommended",
+    "i forgot his name",
+    "i'd just finished",
+    "i've tasted",
+    "i’d just finished",
+    "i’ve tasted",
+    "it was my first attempt",
+    "my stay in",
+    "once step in",
+    "offered great recommendation",
+    "omfg",
     "overrated",
+    "so yummy",
+    "the katsu burger",
+    "the rooms were huge",
+    "we have ever had",
+    "we've ever had",
+    "what a great hotel",
+    "would recommend to everyone",
+    "about this data",
+    "get the most out of google maps",
     "your children",
     "your kids",
     "you should",
@@ -7949,17 +7982,33 @@ PLACE_PAGE_FIRST_PERSON_DESCRIPTION_MARKER_RE = re.compile(
     ),
     re.IGNORECASE,
 )
+PLACE_PAGE_UI_ACTION_CLUSTER_LABEL_PATTERN = (
+    r"(?:call|directions|save|saved|nearby|send to phone|share|website|sign in)"
+)
+PLACE_PAGE_UI_ACTION_CLUSTER_RE = re.compile(
+    rf"^{PLACE_PAGE_UI_ACTION_CLUSTER_LABEL_PATTERN}"
+    rf"(?:\s+{PLACE_PAGE_UI_ACTION_CLUSTER_LABEL_PATTERN}){{2,}}$",
+    re.IGNORECASE,
+)
 
 
 def sanitize_place_page_description(value: Any) -> str | None:
     normalized = as_string(value)
     if normalized is None:
         return None
+    if looks_like_place_page_ui_action_cluster(normalized):
+        return None
     if looks_like_place_page_review_description(normalized):
         return None
     if looks_like_place_page_first_person_description(normalized):
         return None
     return normalized
+
+
+def looks_like_place_page_ui_action_cluster(value: str) -> bool:
+    normalized = re.sub(r"[\ue000-\uf8ff]", " ", value)
+    normalized = re.sub(r"\s+", " ", normalized).strip(" .")
+    return PLACE_PAGE_UI_ACTION_CLUSTER_RE.fullmatch(normalized) is not None
 
 
 def looks_like_place_page_review_description(value: str) -> bool:
@@ -9606,9 +9655,29 @@ def sanitize_semantic_description(value: Any) -> str | None:
     description = re.sub(r"\s+", " ", description).strip()
     if not description or len(description) > SEMANTIC_DESCRIPTION_MAX_CHARS:
         return None
+    if looks_like_malformed_semantic_description(description):
+        return None
     if looks_like_semantic_description_review_source_leak(description):
         return None
     return description
+
+
+SEMANTIC_DESCRIPTION_MALFORMED_RE = re.compile(
+    r"(?:"
+    r"^\s*(?:great|good|nice|amazing|awesome)\s+spot\b|"
+    r"\b(?:top\s+notch|kinda|at\s+this\s+price\s+point|doesn[’']?t\s+feel|"
+    r"feels?\s+(?:kinda\s+)?cheap|clueless)\b|"
+    r"\b(?:vous|propose|sélection|raffinés|méticuleusement|choisis|convivial|"
+    r"chaleureux|feutré|partage)\b"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def looks_like_malformed_semantic_description(value: str) -> bool:
+    if value.count("/") >= 2:
+        return True
+    return SEMANTIC_DESCRIPTION_MALFORMED_RE.search(value) is not None
 
 
 SEMANTIC_DESCRIPTION_REVIEW_SOURCE_LEAK_RE = re.compile(
@@ -9641,6 +9710,8 @@ def usable_semantic_description(
 ) -> str | None:
     description = sanitize_semantic_description(value)
     if description is None:
+        return None
+    if not enrichment_identity_is_compatible_with_raw(raw_place, enrichment_place):
         return None
     if semantic_description_has_conflicting_location(
         description,

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -3280,9 +3280,10 @@ def enrich_raw_sources(
         city_name, country_name = guide_location_context(slug, raw)
         place_override_map = read_json(PLACE_OVERRIDES_DIR / f"{slug}.json")
         cache_payload = load_places_cache(slug)
-        cache_payload, pruned_count = prune_places_cache_to_raw_places(cache_payload, raw)
-        if pruned_count:
-            save_places_cache(slug, cache_payload)
+        if not normalized_place_selectors:
+            cache_payload, pruned_count = prune_places_cache_to_raw_places(cache_payload, raw)
+            if pruned_count:
+                save_places_cache(slug, cache_payload)
         cache_payloads[slug] = cache_payload
         for place in raw.places:
             place_id = stable_place_id(place, source_type=raw.configured_source_type)
@@ -3446,9 +3447,10 @@ def refresh_cached_semantic_enrichment(
         city_name, country_name = guide_location_context(slug, raw)
         place_override_map = read_json(PLACE_OVERRIDES_DIR / f"{slug}.json")
         cache_payload = load_places_cache(slug)
-        cache_payload, pruned_count = prune_places_cache_to_raw_places(cache_payload, raw)
-        if pruned_count:
-            save_places_cache(slug, cache_payload)
+        if not normalized_place_selectors:
+            cache_payload, pruned_count = prune_places_cache_to_raw_places(cache_payload, raw)
+            if pruned_count:
+                save_places_cache(slug, cache_payload)
         cache_payloads[slug] = cache_payload
 
         for place in raw.places:
@@ -5995,6 +5997,16 @@ def save_places_cache_to_sqlite(slug: str, payload: dict[str, EnrichmentCacheEnt
     try:
         with connection:
             ensure_guide_enrichment_cache_table(connection)
+            if not payload:
+                existing_count = connection.execute(
+                    "SELECT COUNT(*) FROM guide_enrichment_cache WHERE guide_slug = ?",
+                    (slug,),
+                ).fetchone()[0]
+                if existing_count:
+                    raise RuntimeError(
+                        f"Refusing to replace non-empty enrichment cache for {slug} "
+                        "with an empty payload."
+                    )
             connection.execute(
                 "DELETE FROM guide_enrichment_cache WHERE guide_slug = ?",
                 (slug,),

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6403,6 +6403,15 @@ def rebuild_places_sqlite(
     enrichment_caches: dict[str, dict[str, EnrichmentCacheEntry]],
 ) -> None:
     existing_row_counts = existing_places_cache_sqlite_row_counts(raw_lists.keys())
+    pruned_any = False
+    for slug, raw in raw_lists.items():
+        cache_payload = enrichment_caches.get(slug)
+        if cache_payload is None:
+            continue
+        pruned_payload, pruned_count = prune_places_cache_to_raw_places(cache_payload, raw)
+        if pruned_count:
+            enrichment_caches[slug] = pruned_payload
+            pruned_any = True
     empty_replacements = [
         slug
         for slug, raw in raw_lists.items()
@@ -6416,15 +6425,6 @@ def rebuild_places_sqlite(
             "Refusing to rebuild enrichment cache with empty payloads for "
             f"non-empty guide(s): {joined_slugs}."
         )
-    pruned_any = False
-    for slug, raw in raw_lists.items():
-        cache_payload = enrichment_caches.get(slug)
-        if cache_payload is None:
-            continue
-        pruned_payload, pruned_count = prune_places_cache_to_raw_places(cache_payload, raw)
-        if pruned_count:
-            enrichment_caches[slug] = pruned_payload
-            pruned_any = True
     hydrated_count = hydrate_shared_enrichment_photo_urls(enrichment_caches)
     build_signature = build_places_sqlite_signature(
         raw_lists=raw_lists,
@@ -9747,7 +9747,9 @@ SEMANTIC_DESCRIPTION_MALFORMED_RE = re.compile(
 def looks_like_malformed_semantic_description(value: str) -> bool:
     if value.count("/") >= 2:
         return True
-    return SEMANTIC_DESCRIPTION_MALFORMED_RE.search(value) is not None
+    malformed_markers = SEMANTIC_DESCRIPTION_MALFORMED_RE.findall(value)
+    has_chatty_structure = any(marker in value for marker in ("$", ";", "(", ")"))
+    return has_chatty_structure and len(malformed_markers) >= 2
 
 
 SEMANTIC_DESCRIPTION_REVIEW_SOURCE_LEAK_RE = re.compile(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -11332,6 +11332,25 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(list(loaded_payload), ["cid:111"])
         self.assertEqual(loaded_payload["cid:111"].query, "Open Kitchen")
 
+    def test_save_places_cache_to_sqlite_allows_explicit_empty_prune(self) -> None:
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="Open Kitchen",
+            matched=True,
+            place=EnrichmentPlace(display_name="Open Kitchen"),
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            db_path = tmpdir_path / "places.sqlite"
+
+            with patch.object(build_data, "PLACES_SQLITE_PATH", db_path):
+                build_data.save_places_cache_to_sqlite("tokyo-japan", {"cid:111": cache_entry})
+                build_data.save_places_cache_to_sqlite("tokyo-japan", {}, allow_empty_overwrite=True)
+                loaded_payload = build_data.load_places_cache("tokyo-japan")
+
+        self.assertEqual(loaded_payload, {})
+
     def test_prune_places_cache_to_raw_places_drops_stale_place_ids(self) -> None:
         raw = RawSavedList(
             title="Aguas Calientes",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2763,6 +2763,57 @@ class BuildDataTests(unittest.TestCase):
         self.assertIn("about", warning or "")
         self.assertIn("semantic_description", warning or "")
 
+    def test_preserve_existing_enrichment_skips_invalid_cached_semantic_description(self) -> None:
+        existing_entry = EnrichmentCacheEntry(
+            fetched_at="2026-05-01T00:00:00+00:00",
+            source="google_maps_page",
+            query="Sushi Okeya Kyujiro, Montreal",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="Sushi Okeya Kyujiro",
+                formatted_address="1227 Rue de la Montagne, Montréal, QC H3G 1Z2, Canada",
+                semantic_description=(
+                    "$180 lunch omakase; food is top notch, though it doesn’t feel that "
+                    "elevated at this price point (dishware feels kinda cheap and "
+                    "servers are a bit clueless about alcohol options)"
+                ),
+                semantic_description_signature="old-signature",
+                semantic_source="llm",
+            ),
+        )
+        refreshed_entry = EnrichmentCacheEntry(
+            fetched_at="2026-05-02T00:00:00+00:00",
+            source="google_maps_page",
+            query="Sushi Okeya Kyujiro, Montreal",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="Sushi Okeya Kyujiro",
+                formatted_address="1227 Rue de la Montagne, Montréal, QC H3G 1Z2, Canada",
+                rating=4.6,
+            ),
+        )
+        raw_place = RawPlace(
+            name="Sushi Okeya Kyujiro",
+            address="1227 Rue de la Montagne, Montréal, QC H3G 1Z2, Canada",
+            maps_url="https://maps.google.com/?cid=123",
+            cid="123",
+        )
+
+        merged, warning = build_data.preserve_existing_enrichment(
+            slug="montreal-canada",
+            place_id="cid:123",
+            place_name="Sushi Okeya Kyujiro",
+            existing_entry=existing_entry,
+            refreshed_entry=refreshed_entry,
+            raw_place=raw_place,
+        )
+
+        self.assertIsNone(warning)
+        assert merged.place is not None
+        self.assertIsNone(merged.place.semantic_description)
+        self.assertIsNone(merged.place.semantic_description_signature)
+        self.assertIsNone(merged.place.semantic_source)
+
     def test_uncertain_place_page_identity_suppresses_publishable_identity_fields(self) -> None:
         raw_place = RawPlace(
             name="Lola Underground",
@@ -6454,6 +6505,20 @@ class BuildDataTests(unittest.TestCase):
         ):
             with self.subTest(description=description):
                 self.assertEqual(build_data.sanitize_semantic_description(description), description)
+
+    def test_semantic_description_accepts_common_recommendation_openers(self) -> None:
+        for description in (
+            "Great spot for handmade soba with a quiet counter and seasonal sides.",
+            "Amazing spot for seasonal gelato and espresso near the old market.",
+            "Nice spot for small plates, natural wine, and a low-key patio dinner.",
+        ):
+            with self.subTest(description=description):
+                self.assertEqual(build_data.sanitize_semantic_description(description), description)
+
+    def test_semantic_description_accepts_slash_abbreviations(self) -> None:
+        description = "Counter-service breakfast/lunch cafe with vegetarian/vegan bowls and house coffee."
+
+        self.assertEqual(build_data.sanitize_semantic_description(description), description)
 
     def test_semantic_description_rejects_paragraph_length_text(self) -> None:
         self.assertIsNone(build_data.sanitize_semantic_description("x" * 321))

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -6372,6 +6372,16 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertEqual(build_data.sanitize_semantic_description(description), description)
 
+    def test_semantic_description_accepts_valid_english_words_that_overlap_french_leak_terms(
+        self,
+    ) -> None:
+        for description in (
+            "A convivial neighborhood wine bar with a compact list and relaxed counter seating.",
+            "Contemporary bistro menus propose a focused set of seasonal plates for sharing.",
+        ):
+            with self.subTest(description=description):
+                self.assertEqual(build_data.sanitize_semantic_description(description), description)
+
     def test_semantic_description_rejects_paragraph_length_text(self) -> None:
         self.assertIsNone(build_data.sanitize_semantic_description("x" * 321))
 
@@ -10842,6 +10852,58 @@ class BuildDataTests(unittest.TestCase):
             finally:
                 connection.close()
 
+    def test_rebuild_places_sqlite_rejects_empty_payload_over_existing_nonempty_guide(self) -> None:
+        raw = RawSavedList(
+            configured_source_type="google_list_url",
+            title="Tokyo",
+            places=[
+                RawPlace(
+                    name="Coffee House",
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                )
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0], source_type=raw.configured_source_type)
+        guide = Guide(
+            slug="tokyo-japan",
+            title="Tokyo",
+            country_name="Japan",
+            city_name="Tokyo",
+            generated_at="2026-04-20T00:00:00+00:00",
+            place_count=1,
+            places=[
+                NormalizedPlace(
+                    id=place_id,
+                    name="Coffee House",
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Coffee+House",
+                    status="active",
+                )
+            ],
+        )
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="Coffee House",
+            matched=True,
+            place=EnrichmentPlace(display_name="Coffee House"),
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            db_path = tmpdir_path / "cache" / "places.sqlite"
+
+            with patch.object(build_data, "PLACES_SQLITE_PATH", db_path):
+                build_data.save_places_cache("tokyo-japan", {place_id: cache_entry})
+                with self.assertRaisesRegex(RuntimeError, "tokyo-japan"):
+                    build_data.rebuild_places_sqlite(
+                        raw_lists={"tokyo-japan": raw},
+                        guides=[guide],
+                        enrichment_caches={"tokyo-japan": {}},
+                    )
+                loaded_payload = build_data.load_places_cache("tokyo-japan")
+
+        self.assertEqual(list(loaded_payload), [place_id])
+
     def test_rebuild_places_sqlite_hydrates_matching_guide_cache_photo_urls(self) -> None:
         shared_place_id = "cid:111"
         photo_url = "https://images.example/shared-photo.webp"
@@ -11447,6 +11509,7 @@ class BuildDataTests(unittest.TestCase):
             tmpdir_path = Path(tmpdir)
             raw_dir = tmpdir_path / "raw"
             cache_dir = tmpdir_path / "cache"
+            db_path = tmpdir_path / "places.sqlite"
             raw_dir.mkdir()
             cache_dir.mkdir()
             (raw_dir / "tokyo-japan.json").write_text(
@@ -11480,6 +11543,7 @@ class BuildDataTests(unittest.TestCase):
             with (
                 patch.object(build_data, "RAW_DIR", raw_dir),
                 patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
+                patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
                 patch.object(build_data, "google_places_api_key", return_value=None),
                 patch.object(build_data, "ThreadPoolExecutor", FakeExecutor),
                 patch.object(build_data, "as_completed", return_value=[future]),

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2699,6 +2699,70 @@ class BuildDataTests(unittest.TestCase):
         assert merged.place is not None
         self.assertEqual(merged.place.google_maps_uri, "https://maps.google.com/?cid=963849929162476527")
 
+    def test_preserve_existing_enrichment_keeps_thinner_successful_refresh_fields(self) -> None:
+        existing_entry = EnrichmentCacheEntry(
+            fetched_at="2026-05-01T00:00:00+00:00",
+            source="google_maps_page",
+            query="The Bob Hawke Beer and Leisure Centre, Sydney",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="The Bob Hawke Beer and Leisure Centre",
+                formatted_address="8-12 Sydney St, Marrickville NSW 2204, Australia",
+                review_topics=[{"label": "beer", "count": 10}],
+                reviews=[{"text": "Great pub"}],
+                about_sections=[
+                    {
+                        "title": "Offerings",
+                        "items": [{"label": "Beer", "aria_label": "Serves beer"}],
+                    }
+                ],
+                semantic_description="A brewery-backed leisure centre with pub food and a retro Australian beer-hall feel.",
+                semantic_description_signature="old-signature",
+                semantic_source="llm",
+            ),
+        )
+        refreshed_entry = EnrichmentCacheEntry(
+            fetched_at="2026-05-02T00:00:00+00:00",
+            source="google_maps_page",
+            query="The Bob Hawke Beer and Leisure Centre, Sydney",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="The Bob Hawke Beer and Leisure Centre",
+                formatted_address="8-12 Sydney St, Marrickville NSW 2204, Australia",
+                rating=4.5,
+            ),
+        )
+
+        merged, warning = build_data.preserve_existing_enrichment(
+            slug="sydney-australia",
+            place_id="cid:4697974207037271879",
+            place_name="The Bob Hawke Beer and Leisure Centre",
+            existing_entry=existing_entry,
+            refreshed_entry=refreshed_entry,
+        )
+
+        self.assertIsNotNone(warning)
+        assert merged.place is not None
+        self.assertEqual(merged.place.review_topics, [{"label": "beer", "count": 10}])
+        self.assertEqual(merged.place.reviews, [{"text": "Great pub"}])
+        self.assertEqual(
+            merged.place.about_sections,
+            [
+                {
+                    "title": "Offerings",
+                    "items": [{"label": "Beer", "aria_label": "Serves beer"}],
+                }
+            ],
+        )
+        self.assertEqual(
+            merged.place.semantic_description,
+            "A brewery-backed leisure centre with pub food and a retro Australian beer-hall feel.",
+        )
+        self.assertEqual(merged.place.semantic_description_signature, "old-signature")
+        self.assertEqual(merged.place.semantic_source, "llm")
+        self.assertIn("about", warning or "")
+        self.assertIn("semantic_description", warning or "")
+
     def test_uncertain_place_page_identity_suppresses_publishable_identity_fields(self) -> None:
         raw_place = RawPlace(
             name="Lola Underground",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -63,23 +63,6 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(saved_list.collaborators[0].name, "Second Curator")
         self.assertEqual(saved_list.collaborators[0].photo_url, "https://example.com/second.jpg")
 
-    def test_raw_place_keeps_added_by_metadata_from_json(self) -> None:
-        place = RawPlace.model_validate(
-            {
-                "name": "Coffee Spot",
-                "maps_url": "https://maps.example/coffee",
-                "added_by": {
-                    "name": "Second Curator",
-                    "profile_id": "second-curator-id",
-                },
-            }
-        )
-
-        self.assertIsNotNone(place.added_by)
-        assert place.added_by is not None
-        self.assertEqual(place.added_by.name, "Second Curator")
-        self.assertEqual(place.added_by.profile_id, "second-curator-id")
-
     def test_normalize_guide_uses_raw_owner_as_author(self) -> None:
         raw = RawSavedList(
             title="Tokyo, Japan",
@@ -178,77 +161,6 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(guide.author.avatar_mode, "initials")
         self.assertIsNone(guide.author.photo_url)
         self.assertIsNone(guide.author.photo_path)
-
-    def test_normalize_guide_preserves_place_added_by(self) -> None:
-        raw = RawSavedList(
-            title="Tokyo, Japan",
-            owner=ListAuthor(name="Guide Owner", profile_id="owner-id"),
-            places=[
-                RawPlace(
-                    name="Coffee Spot",
-                    maps_url="https://maps.example/coffee",
-                    added_by=ListAuthor(name="Second Curator", profile_id="second-id"),
-                )
-            ],
-        )
-
-        def read_json_side_effect(path: Path) -> dict[str, object]:
-            if path == build_data.LIST_OVERRIDES_DIR / "tokyo-japan.json":
-                return {}
-            if path == build_data.PLACE_OVERRIDES_DIR / "tokyo-japan.json":
-                return {}
-            return {}
-
-        with patch.object(build_data, "read_json", side_effect=read_json_side_effect):
-            guide = build_data.normalize_guide("tokyo-japan", raw, enrichment_cache={})
-
-        self.assertEqual(guide.places[0].added_by, ListAuthor(name="Second Curator", profile_id="second-id"))
-        self.assertIsNotNone(guide.places[0].provenance.added_by)
-        assert guide.places[0].provenance.added_by is not None
-        self.assertEqual(guide.places[0].provenance.added_by.source, "google_list")
-
-    def test_normalize_guide_allows_place_added_by_override_and_suppression(self) -> None:
-        raw = RawSavedList(
-            title="Tokyo, Japan",
-            places=[
-                RawPlace(
-                    name="Coffee Spot",
-                    maps_url="https://maps.example/coffee",
-                    cid="1",
-                    added_by=ListAuthor(name="Raw Curator"),
-                ),
-                RawPlace(
-                    name="Tea Spot",
-                    maps_url="https://maps.example/tea",
-                    cid="2",
-                    added_by=ListAuthor(name="Raw Curator"),
-                ),
-            ],
-        )
-
-        def read_json_side_effect(path: Path) -> dict[str, object]:
-            if path == build_data.LIST_OVERRIDES_DIR / "tokyo-japan.json":
-                return {}
-            if path == build_data.PLACE_OVERRIDES_DIR / "tokyo-japan.json":
-                return {
-                    "cid:1": {"added_by": {"name": "Manual Curator", "avatar_mode": "initials"}},
-                    "cid:2": {"added_by": None},
-                }
-            return {}
-
-        with patch.object(build_data, "read_json", side_effect=read_json_side_effect):
-            guide = build_data.normalize_guide("tokyo-japan", raw, enrichment_cache={})
-
-        places_by_id = {place.id: place for place in guide.places}
-        self.assertEqual(
-            places_by_id["cid:1"].added_by,
-            ListAuthor(name="Manual Curator", avatar_mode="initials"),
-        )
-        self.assertIsNotNone(places_by_id["cid:1"].provenance.added_by)
-        assert places_by_id["cid:1"].provenance.added_by is not None
-        self.assertEqual(places_by_id["cid:1"].provenance.added_by.source, "manual")
-        self.assertIsNone(places_by_id["cid:2"].added_by)
-        self.assertIsNone(places_by_id["cid:2"].provenance.added_by)
 
     def test_sync_list_author_photo_downloads_local_photo_path(self) -> None:
         author = ListAuthor(
@@ -850,7 +762,6 @@ class BuildDataTests(unittest.TestCase):
                     cid="8935267511126082507",
                     google_id="/g/1tdwf48w",
                     maps_place_token="0xdeadbeef:0x1",
-                    added_by=ListAuthor(name="Second Curator", profile_id="second-id"),
                 )
             ],
         )
@@ -867,7 +778,6 @@ class BuildDataTests(unittest.TestCase):
                     cid="8935267511126082507",
                     google_id=None,
                     maps_place_token=None,
-                    added_by=None,
                 )
             ],
         )
@@ -884,7 +794,6 @@ class BuildDataTests(unittest.TestCase):
         )
         self.assertEqual(merged.places[0].google_id, "/g/1tdwf48w")
         self.assertEqual(merged.places[0].maps_place_token, "0xdeadbeef:0x1")
-        self.assertEqual(merged.places[0].added_by, ListAuthor(name="Second Curator", profile_id="second-id"))
         self.assertTrue(merged.places[0].is_favorite)
 
     def test_preserve_existing_raw_saved_list_does_not_apply_to_non_matching_place(self) -> None:
@@ -2190,6 +2099,45 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertIsNone(enrichment.description)
 
+        details.description = (
+            "Best ramen we've ever had. It helps that you get to make it yourself "
+            "(the noodles at least). Everything tastes better when you do it yourself! "
+            "Date day for a Saturday morning class. Great experience overall."
+        )
+
+        enrichment = build_data.normalize_place_page_enrichment(details)
+
+        self.assertIsNone(enrichment.description)
+
+        details.description = (
+            "That’s gotta be one of the best hot chocolate drink I’ve tasted in my life! "
+            "The long wait was definitely worth it. There was quite a line before we got "
+            "a seat, but boy was it worth every minute. Definitely recommend this place."
+        )
+
+        enrichment = build_data.normalize_place_page_enrichment(details)
+
+        self.assertIsNone(enrichment.description)
+
+        for review_description in (
+            "It was my first attempt to eat mukhata. The food was so delicious and the clerks were very kind.",
+            "Best place to stay in Hanoi. I’d just finished Ha Giang loop and needed a place to rest.",
+            "The katsu burger!!! Omfg!!! So yummy and the young man with blonde curly hair from England.",
+            "What a great hotel! The rooms were huge and have balconies with a seating area.",
+            "Had a great time here with my friends! The barkeeper made us feel welcomed and we had a lot of fun.",
+            "The lady was just so so lovely. My feet are just gorgeous. Would recommend to everyone.",
+            "My stay in Alila was wonderful. Special shout out to the staff for making it memorable.",
+            "The hotel have a sense of peace and tranquility once step in. The personal service was delicate.",
+            "The staffs also offered great recommendation for drinks based on your preference.",
+            "Directions Save Nearby Send to phone Share About this data Get the most out of Google Maps Sign in",
+            "\ue52e Directions \ue866 Save \uf05f Nearby \ue702 Send to phone \ue80d Share",
+        ):
+            details.description = review_description
+
+            enrichment = build_data.normalize_place_page_enrichment(details)
+
+            self.assertIsNone(enrichment.description)
+
         details.source_url = "https://www.google.com/maps/place/Modern+Restaurant"
         details.resolved_url = "https://www.google.com/maps/place/Modern+Restaurant"
         details.description = (
@@ -3252,6 +3200,13 @@ class BuildDataTests(unittest.TestCase):
                 "https://lh5.ggpht.com:443/a/example-avatar=w680-h680-p-rp-mo-br100"
             )
         )
+        for photo_url in (
+            "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcExample&s=3",
+            "https://www.gstatic.com/faviconV2?url=https://example.com",
+            "https://www.gstatic.com/ads-travel/example.png",
+        ):
+            with self.subTest(photo_url=photo_url):
+                self.assertIsNone(build_data.sanitize_place_photo_url(photo_url))
 
     def test_sanitize_place_photo_url_uses_hostname_suffix_for_avatar_hosts(self) -> None:
         self.assertEqual(
@@ -4486,6 +4441,45 @@ class BuildDataTests(unittest.TestCase):
             "A concise LLM description grounded in the zoo summary and panda note.",
         )
 
+    def test_normalize_guide_rejects_recommendation_copy_from_mismatched_enrichment_identity(self) -> None:
+        raw = RawSavedList(
+            title="Las Vegas, Nevada",
+            places=[
+                RawPlace(
+                    name="Niu-Gu Noodle House",
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                ),
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0])
+        enrichment_cache = {
+            place_id: EnrichmentCacheEntry(
+                fetched_at="2026-05-01T00:00:00+00:00",
+                source="google_maps_page",
+                query="Niu-Gu Noodle House, Las Vegas, Nevada",
+                matched=True,
+                place=EnrichmentPlace(
+                    display_name="Michael's",
+                    description="Long-running steakhouse with fine dining and a polished bar.",
+                    search_result_description="Classic steakhouse in Las Vegas.",
+                    semantic_description="An enduring Henderson steakhouse offering fine dining with classic cuts.",
+                ),
+            )
+        }
+
+        with (
+            patch.object(build_data, "google_maps_place_semantic_descriptions_enabled", return_value=True),
+            patch.object(build_data, "google_maps_place_semantic_llm_enabled", return_value=True),
+        ):
+            guide = build_data.normalize_guide(
+                "las-vegas-nevada-usa",
+                raw,
+                enrichment_cache=enrichment_cache,
+            )
+
+        self.assertIsNone(guide.places[0].why_recommended)
+
     def test_normalize_guide_uses_search_result_description_when_full_description_missing(self) -> None:
         raw = RawSavedList(
             title="Taipei, Taiwan",
@@ -4892,6 +4886,217 @@ class BuildDataTests(unittest.TestCase):
                 )
 
         self.assertEqual(guide.places[0].neighborhood, "Plateau")
+
+    def test_normalize_guide_applies_country_level_site_neighborhood_mapping_rules(self) -> None:
+        raw = RawSavedList(
+            title="Busan, Korea",
+            places=[
+                RawPlace(
+                    name="Seomyeon Cafe",
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                ),
+            ],
+        )
+        place_id = build_data.stable_place_id(raw.places[0])
+        enrichment_cache = {
+            place_id: EnrichmentCacheEntry(
+                fetched_at="2026-05-01T00:00:00+00:00",
+                query="Seomyeon Cafe, Busan, Korea",
+                matched=True,
+                source="google_maps_page",
+                place=EnrichmentPlace(
+                    display_name="Seomyeon Cafe",
+                    formatted_address="22-9 Seojeon-ro 10beon-gil, Busanjin District, Busan, South Korea",
+                    primary_type_display_name="Cafe",
+                    semantic_neighborhood="Busanjin District",
+                ),
+            ),
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+
+            with (
+                patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+                patch.object(
+                    build_data,
+                    "google_maps_place_neighborhood_mappings",
+                    return_value=[
+                        {
+                            "country": "Korea",
+                            "from": "Busanjin District",
+                            "to": "Busanjin",
+                        }
+                    ],
+                ),
+            ):
+                guide = build_data.normalize_guide(
+                    "busan-korea",
+                    raw,
+                    enrichment_cache=enrichment_cache,
+                )
+
+        self.assertEqual(guide.places[0].neighborhood, "Busanjin")
+
+    def test_apply_site_neighborhood_mappings_expands_exact_observed_labels(self) -> None:
+        rules = [
+            {
+                "city": "Mexico City",
+                "country": "Mexico",
+                "from": "Roma Nte",
+                "to": "Roma Norte",
+            },
+            {
+                "city": "Mexico City",
+                "country": "Mexico",
+                "from": "Col del Valle Nte",
+                "to": "Del Valle Norte",
+            },
+            {
+                "city": "Mexico City",
+                "country": "Mexico",
+                "from": "Balderas S/N",
+                "to": "Balderas",
+            },
+            {
+                "city": "Guadalajara",
+                "country": "Mexico",
+                "from": "Vallarta Nte",
+                "to": "Vallarta Norte",
+            },
+            {
+                "city": "Montreal",
+                "country": "Canada",
+                "from": "Vieux-Montréal",
+                "to": "Old Montreal",
+            },
+            {
+                "city": "Luxembourg",
+                "country": "Luxembourg",
+                "from": ["Ville Haute Luxembourg", "Ville-Haute Luxembourg"],
+                "to": "Ville Haute",
+            },
+            {
+                "city": "Luxembourg",
+                "country": "Luxembourg",
+                "from": ["Pafendall", "Pafendall Luxembourg"],
+                "to": "Pfaffenthal",
+            },
+            {
+                "city": "Luxembourg",
+                "country": "Luxembourg",
+                "from": "Cote d'Eich",
+                "to": "Côte d'Eich",
+            },
+            {
+                "city": "Paris",
+                "country": "France",
+                "from": "Bd Saint-Germain",
+                "to": "Boulevard Saint-Germain",
+            },
+            {
+                "city": "Paris",
+                "country": "France",
+                "from": "Gal de Valois",
+                "to": "Galerie de Valois",
+            },
+            {
+                "city": "Cannes",
+                "country": "France",
+                "from": "Bd de la République",
+                "to": "Boulevard de la République",
+            },
+            {
+                "city": "Cannes",
+                "country": "France",
+                "from": "Jetée Albert Edouard",
+                "to": "Jetée Albert Édouard",
+            },
+            {
+                "city": "Cannes",
+                "country": "France",
+                "from": "Musée de La Castre",
+                "to": "Musée de la Castre",
+            },
+            {
+                "city": "Lyon",
+                "country": "France",
+                "from": "Cr Lafayette F",
+                "to": "Cours Lafayette",
+            },
+            {
+                "city": "Metz",
+                "country": "France",
+                "from": "Parv. des Droits de l'Homme CS",
+                "to": "Parvis des Droits de l'Homme",
+            },
+            {
+                "city": "Sydney",
+                "country": "Australia",
+                "from": "The Rocks NSW オーストラリア",
+                "to": "The Rocks",
+            },
+            {
+                "city": "Bologna",
+                "country": "Italy",
+                "from": "Bologna Centro Storico",
+                "to": "Centro Storico",
+            },
+            {
+                "city": "Milan",
+                "country": "Italy",
+                "from": "P.za del Duomo",
+                "to": "Piazza del Duomo",
+            },
+            {
+                "city": "Madrid",
+                "country": "Spain",
+                "from": "P.º del Prado",
+                "to": "Paseo del Prado",
+            },
+        ]
+
+        cases = [
+            ("Roma Nte", "Mexico City", "Mexico", "Roma Norte"),
+            ("Col del Valle Nte", "Mexico City", "Mexico", "Del Valle Norte"),
+            ("Balderas S/N", "Mexico City", "Mexico", "Balderas"),
+            ("Vallarta Nte", "Guadalajara", "Mexico", "Vallarta Norte"),
+            ("Vieux-Montréal", "Montreal", "Canada", "Old Montreal"),
+            ("Ville-Haute Luxembourg", "Luxembourg", "Luxembourg", "Ville Haute"),
+            ("Pafendall Luxembourg", "Luxembourg", "Luxembourg", "Pfaffenthal"),
+            ("Cote d'Eich", "Luxembourg", "Luxembourg", "Côte d'Eich"),
+            ("Bd Saint-Germain", "Paris", "France", "Boulevard Saint-Germain"),
+            ("Gal de Valois", "Paris", "France", "Galerie de Valois"),
+            ("Bd de la République", "Cannes", "France", "Boulevard de la République"),
+            ("Jetée Albert Edouard", "Cannes", "France", "Jetée Albert Édouard"),
+            ("Musée de La Castre", "Cannes", "France", "Musée de la Castre"),
+            ("Cr Lafayette F", "Lyon", "France", "Cours Lafayette"),
+            ("Parv. des Droits de l'Homme CS", "Metz", "France", "Parvis des Droits de l'Homme"),
+            ("The Rocks NSW オーストラリア", "Sydney", "Australia", "The Rocks"),
+            ("Bologna Centro Storico", "Bologna", "Italy", "Centro Storico"),
+            ("P.za del Duomo", "Milan", "Italy", "Piazza del Duomo"),
+            ("P.º del Prado", "Madrid", "Spain", "Paseo del Prado"),
+        ]
+
+        with patch.object(build_data, "google_maps_place_neighborhood_mappings", return_value=rules):
+            for neighborhood, city_name, country_name, expected in cases:
+                with self.subTest(neighborhood=neighborhood):
+                    self.assertEqual(
+                        build_data.apply_site_neighborhood_mappings(
+                            neighborhood,
+                            city_name=city_name,
+                            country_name=country_name,
+                            address_values=[],
+                            locality_candidates=[neighborhood],
+                        ),
+                        expected,
+                    )
 
     def test_normalize_guide_applies_site_category_mapping_rules(self) -> None:
         raw = RawSavedList(
@@ -6217,6 +6422,24 @@ class BuildDataTests(unittest.TestCase):
             )
         )
 
+    def test_semantic_description_rejects_chat_history_leaky_examples(self) -> None:
+        for description in (
+            (
+                "$180 lunch omakase; food is top notch, though it doesn’t feel that "
+                "elevated at this price point (dishware feels kinda cheap and "
+                "servers are a bit clueless about alcohol options)"
+            ),
+            (
+                "Annette partage / Annette est festive / prendre un verre dans un "
+                "esprit convivial et chaleureux/ Annette vous propose des petits "
+                "plats à partager, des cocktails raffinés et une sélection de vins "
+                "méticuleusement choisis / Annette reçoit dans un décor tendance et feutré"
+            ),
+            "Great spot for a banh mi and don’t miss the whelk papaya salad",
+        ):
+            with self.subTest(description=description):
+                self.assertIsNone(build_data.sanitize_semantic_description(description))
+
     def test_apply_semantic_enrichment_preserves_semantic_source_when_semantics_remain_populated(self) -> None:
         raw_place = RawPlace(
             name="Tea House",
@@ -6681,6 +6904,23 @@ class BuildDataTests(unittest.TestCase):
         self.assertIsNone(place.display_name)
         self.assertEqual(place.primary_type_display_name, "Zoo")
         self.assertEqual(place.formatted_address, "No. 30號, Section 2, Xinguang Rd")
+
+    def test_normalize_place_page_enrichment_drops_sponsored_display_name(self) -> None:
+        place = build_data.normalize_place_page_enrichment(
+            SimpleNamespace(
+                source_url="https://www.google.com/maps/search/?api=1&query=Restaurant",
+                resolved_url="https://www.google.com/maps/search/?api=1&query=Restaurant",
+                name="Sponsored \ue5d4",
+                category="Restaurant",
+                rating=3.7,
+                review_count=186,
+                address=None,
+                limited_view=False,
+            )
+        )
+
+        self.assertIsNone(place.display_name)
+        self.assertEqual(place.primary_type_display_name, "Restaurant")
 
     def test_normalize_guide_display_address_formats_taiwan_postal_prefix(self) -> None:
         self.assertEqual(
@@ -8194,6 +8434,13 @@ class BuildDataTests(unittest.TestCase):
                 "Hobart",
             ),
             (
+                "Galerie de la Reine 5, 1000 Brussel, Belgium",
+                "Brussels",
+                {"brussels"},
+                {"brussel", "belgium"},
+                None,
+            ),
+            (
                 "26-28 Cotham Rd, Kew VIC 3101, Australia",
                 "Melbourne",
                 {"kew", "melbourne"},
@@ -8233,6 +8480,27 @@ class BuildDataTests(unittest.TestCase):
                 "Toledo",
                 {"toledo"},
                 {"paseo-del-transito"},
+                None,
+            ),
+            (
+                "Rathauspl. 1, 90403 Nürnberg, Germany",
+                "Nuremberg",
+                {"nuremberg"},
+                {"nurnberg", "nürnberg", "germany"},
+                None,
+            ),
+            (
+                "Pilestræde 39, 1112 København, Denmark",
+                "Copenhagen",
+                {"copenhagen"},
+                {"kobenhavn", "københavn", "denmark"},
+                None,
+            ),
+            (
+                "Barer Str. 27, 80333 München, Germany",
+                "Munich",
+                {"munich"},
+                {"munchen", "münchen", "germany"},
                 None,
             ),
         ]
@@ -8866,8 +9134,6 @@ class BuildDataTests(unittest.TestCase):
             patch.object(build_data, "build_scraper_sessions", return_value=(SimpleNamespace(), None, None)),
             patch.object(build_data, "record_scraper_session_use"),
             patch.object(build_data, "release_scraper_session_lock"),
-            patch.object(build_data, "google_maps_place_collect_reviews", return_value=True),
-            patch.object(build_data, "google_maps_place_collect_about", return_value=True),
             patch.object(build_data, "scrape_place", return_value=details) as scrape,
         ):
             entry = build_data.fetch_place_page_enrichment(place)
@@ -10582,6 +10848,111 @@ class BuildDataTests(unittest.TestCase):
                 self.assertEqual(place_payload["photo_url"], photo_url)
             finally:
                 connection.close()
+
+    def test_build_places_sqlite_rows_only_contains_enrichment_cache_rows(self) -> None:
+        shared_place_id = "cid:222"
+        oita_raw = RawSavedList(
+            configured_source_type="google_list_url",
+            title="Oita",
+            places=[
+                RawPlace(
+                    name="Milch",
+                    address="1 Oita, Japan",
+                    maps_url="https://maps.google.com/?cid=222",
+                    cid="222",
+                )
+            ],
+        )
+        yufuin_raw = RawSavedList(
+            configured_source_type="google_list_url",
+            title="Yufuin",
+            places=[
+                RawPlace(
+                    name="Share",
+                    address="1 Yufuin, Japan",
+                    maps_url="https://maps.google.com/?cid=222",
+                    cid="222",
+                )
+            ],
+        )
+        oita_guide = Guide(
+            slug="oita-japan",
+            title="Oita",
+            country_name="Japan",
+            city_name="Oita",
+            generated_at="2026-04-20T00:00:00+00:00",
+            place_count=1,
+            places=[
+                NormalizedPlace(
+                    id=shared_place_id,
+                    name="Milch",
+                    maps_url="https://maps.google.com/?cid=222",
+                    cid="222",
+                    google_place_id="place-milch",
+                    google_place_resource_name="places/place-milch",
+                    status="active",
+                )
+            ],
+        )
+        yufuin_guide = Guide(
+            slug="yufuin-japan",
+            title="Yufuin",
+            country_name="Japan",
+            city_name="Yufuin",
+            generated_at="2026-04-20T00:00:00+00:00",
+            place_count=1,
+            places=[
+                NormalizedPlace(
+                    id=shared_place_id,
+                    name="Share",
+                    maps_url="https://maps.google.com/?cid=222",
+                    cid="222",
+                    main_photo_path="/place-photos/share.webp",
+                    user_rating_count=100,
+                    status="active",
+                )
+            ],
+        )
+        oita_cache_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="Milch, Oita",
+            matched=True,
+            place=EnrichmentPlace(
+                google_place_id="place-milch",
+                google_place_resource_name="places/place-milch",
+                display_name="Milch",
+            ),
+        )
+        yufuin_cache_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-21T00:00:00+00:00",
+            query="Share, Yufuin",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="Share",
+                photo_url="https://images.example/share.webp",
+            ),
+        )
+
+        rows = build_data.build_places_sqlite_rows(
+            raw_lists={
+                "oita-japan": oita_raw,
+                "yufuin-japan": yufuin_raw,
+            },
+            guides=[oita_guide, yufuin_guide],
+            enrichment_caches={
+                "oita-japan": {shared_place_id: oita_cache_entry},
+                "yufuin-japan": {shared_place_id: yufuin_cache_entry},
+            },
+        )
+
+        self.assertEqual(len(rows.guide_cache_rows), 2)
+        cache_rows_by_guide = {row[0]: row for row in rows.guide_cache_rows}
+        self.assertEqual(cache_rows_by_guide["oita-japan"][1], shared_place_id)
+        self.assertEqual(cache_rows_by_guide["yufuin-japan"][1], shared_place_id)
+        self.assertEqual(
+            json.loads(cache_rows_by_guide["oita-japan"][12])["place"]["google_place_id"],
+            "place-milch",
+        )
 
     def test_rebuild_places_sqlite_skips_rewrite_when_signature_matches(self) -> None:
         raw = RawSavedList(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -9882,6 +9882,62 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(refreshed_cache["cid:111"].place.semantic_neighborhood, "Zhongshan")
         self.assertEqual(refreshed_cache["cid:111"].place.semantic_tags, ["fine-dining"])
 
+    def test_refresh_cached_semantic_enrichment_with_place_selector_preserves_unselected_guide_cache(self) -> None:
+        tokyo_raw = RawSavedList(
+            title="Tokyo",
+            places=[RawPlace(name="Current Tokyo Place", maps_url="https://maps.google.com/?cid=111", cid="111")],
+        )
+        taipei_raw = RawSavedList(
+            title="Taipei",
+            places=[RawPlace(name="Selected Taipei Place", maps_url="https://maps.google.com/?cid=222", cid="222")],
+        )
+        stale_tokyo_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="Deleted Tokyo Place",
+            matched=True,
+            place=EnrichmentPlace(display_name="Deleted Tokyo Place"),
+        )
+        taipei_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="Selected Taipei Place",
+            matched=True,
+            place=EnrichmentPlace(display_name="Selected Taipei Place"),
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            raw_dir = tmpdir_path / "raw"
+            cache_dir = tmpdir_path / "cache"
+            db_path = tmpdir_path / "places.sqlite"
+            raw_dir.mkdir()
+            cache_dir.mkdir()
+            (raw_dir / "tokyo-japan.json").write_text(
+                json.dumps(tokyo_raw.model_dump(mode="json"), ensure_ascii=False),
+                encoding="utf-8",
+            )
+            (raw_dir / "taipei-taiwan.json").write_text(
+                json.dumps(taipei_raw.model_dump(mode="json"), ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(build_data, "RAW_DIR", raw_dir),
+                patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
+                patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
+            ):
+                build_data.save_places_cache("tokyo-japan", {"cid:999": stale_tokyo_entry})
+                build_data.save_places_cache("taipei-taiwan", {"cid:222": taipei_entry})
+                updated_count, reused_count, skipped_count = build_data.refresh_cached_semantic_enrichment(
+                    enable_semantics=False,
+                    enable_description=False,
+                    place_selectors=["taipei-taiwan:cid:222"],
+                )
+                tokyo_cache = build_data.load_places_cache("tokyo-japan")
+
+        self.assertEqual((updated_count, reused_count, skipped_count), (0, 1, 0))
+        self.assertEqual(list(tokyo_cache), ["cid:999"])
+        self.assertEqual(tokyo_cache["cid:999"].query, "Deleted Tokyo Place")
+
     def test_enrich_raw_sources_prioritizes_missing_entries_before_expired_refreshes(self) -> None:
         raw = RawSavedList(
             title="Tokyo",
@@ -10067,6 +10123,69 @@ class BuildDataTests(unittest.TestCase):
                 )
 
             self.assertEqual(seen_places, ["Second Place"])
+
+    def test_enrich_raw_sources_with_place_selector_preserves_unselected_guide_cache(self) -> None:
+        tokyo_raw = RawSavedList(
+            title="Tokyo",
+            places=[RawPlace(name="Current Tokyo Place", maps_url="https://maps.google.com/?cid=111", cid="111")],
+        )
+        taipei_raw = RawSavedList(
+            title="Taipei",
+            places=[RawPlace(name="Selected Taipei Place", maps_url="https://maps.google.com/?cid=222", cid="222")],
+        )
+        stale_tokyo_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="Deleted Tokyo Place",
+            matched=True,
+            place=EnrichmentPlace(display_name="Deleted Tokyo Place"),
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            raw_dir = tmpdir_path / "raw"
+            cache_dir = tmpdir_path / "cache"
+            db_path = tmpdir_path / "places.sqlite"
+            raw_dir.mkdir()
+            cache_dir.mkdir()
+            (raw_dir / "tokyo-japan.json").write_text(
+                json.dumps(tokyo_raw.model_dump(mode="json"), ensure_ascii=False),
+                encoding="utf-8",
+            )
+            (raw_dir / "taipei-taiwan.json").write_text(
+                json.dumps(taipei_raw.model_dump(mode="json"), ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            seen_places: list[str] = []
+
+            def fake_enrich_place_job(_slug, _place_id, place_name, _refresh_reason, _place_payload, **_kwargs):
+                seen_places.append(place_name)
+                return EnrichmentCacheEntry(
+                    fetched_at="2026-04-20T00:00:00+00:00",
+                    query=place_name,
+                    matched=True,
+                    place=EnrichmentPlace(display_name=place_name),
+                )
+
+            with (
+                patch.object(build_data, "RAW_DIR", raw_dir),
+                patch.object(build_data, "PLACES_CACHE_DIR", cache_dir),
+                patch.object(build_data, "PLACES_SQLITE_PATH", db_path),
+                patch.object(build_data, "google_places_api_key", return_value=None),
+                patch.object(build_data, "enrich_place_job", side_effect=fake_enrich_place_job),
+            ):
+                build_data.save_places_cache("tokyo-japan", {"cid:999": stale_tokyo_entry})
+                build_data.enrich_raw_sources(
+                    force_refresh=True,
+                    place_selectors=["taipei-taiwan:cid:222"],
+                    refresh_workers=1,
+                    refresh_startup_jitter_seconds=0,
+                )
+                tokyo_cache = build_data.load_places_cache("tokyo-japan")
+
+        self.assertEqual(seen_places, ["Selected Taipei Place"])
+        self.assertEqual(list(tokyo_cache), ["cid:999"])
+        self.assertEqual(tokyo_cache["cid:999"].query, "Deleted Tokyo Place")
 
     def test_enrich_raw_sources_matches_cid_derived_from_maps_url(self) -> None:
         raw = RawSavedList(
@@ -11191,6 +11310,27 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(loaded_payload["cid:111"].place.primary_type_display_name, "Restaurant")
         self.assertEqual(loaded_payload["cid:111"].place.primary_type_display_name_localized, "レストラン")
         self.assertIsNone(loaded_payload["cid:111"].place.photo_url)
+
+    def test_save_places_cache_to_sqlite_rejects_empty_overwrite_of_existing_cache(self) -> None:
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="Open Kitchen",
+            matched=True,
+            place=EnrichmentPlace(display_name="Open Kitchen"),
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            db_path = tmpdir_path / "places.sqlite"
+
+            with patch.object(build_data, "PLACES_SQLITE_PATH", db_path):
+                build_data.save_places_cache_to_sqlite("tokyo-japan", {"cid:111": cache_entry})
+                with self.assertRaisesRegex(RuntimeError, "Refusing to replace non-empty enrichment cache"):
+                    build_data.save_places_cache_to_sqlite("tokyo-japan", {})
+                loaded_payload = build_data.load_places_cache("tokyo-japan")
+
+        self.assertEqual(list(loaded_payload), ["cid:111"])
+        self.assertEqual(loaded_payload["cid:111"].query, "Open Kitchen")
 
     def test_prune_places_cache_to_raw_places_drops_stale_place_ids(self) -> None:
         raw = RawSavedList(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -6446,6 +6446,15 @@ class BuildDataTests(unittest.TestCase):
             with self.subTest(description=description):
                 self.assertEqual(build_data.sanitize_semantic_description(description), description)
 
+    def test_semantic_description_accepts_common_phrases_that_overlap_chat_leaks(self) -> None:
+        for description in (
+            "A top notch omakase counter with seasonal nigiri and polished service.",
+            "Kinda hidden cocktail bar with a compact menu and relaxed late-night energy.",
+            "Great spot for a banh mi and don’t miss the whelk papaya salad.",
+        ):
+            with self.subTest(description=description):
+                self.assertEqual(build_data.sanitize_semantic_description(description), description)
+
     def test_semantic_description_rejects_paragraph_length_text(self) -> None:
         self.assertIsNone(build_data.sanitize_semantic_description("x" * 321))
 
@@ -6509,7 +6518,6 @@ class BuildDataTests(unittest.TestCase):
                 "plats à partager, des cocktails raffinés et une sélection de vins "
                 "méticuleusement choisis / Annette reçoit dans un décor tendance et feutré"
             ),
-            "Great spot for a banh mi and don’t miss the whelk papaya salad",
         ):
             with self.subTest(description=description):
                 self.assertIsNone(build_data.sanitize_semantic_description(description))
@@ -10967,6 +10975,69 @@ class BuildDataTests(unittest.TestCase):
                 loaded_payload = build_data.load_places_cache("tokyo-japan")
 
         self.assertEqual(list(loaded_payload), [place_id])
+
+    def test_rebuild_places_sqlite_rejects_empty_payload_after_pruning_stale_ids(self) -> None:
+        stale_raw = RawPlace(
+            name="Old Coffee House",
+            maps_url="https://maps.google.com/?cid=111",
+            cid="111",
+        )
+        current_raw = RawPlace(
+            name="Coffee House",
+            maps_url="https://maps.google.com/?cid=222",
+            cid="222",
+        )
+        raw = RawSavedList(
+            configured_source_type="google_list_url",
+            title="Tokyo",
+            places=[current_raw],
+        )
+        stale_place_id = build_data.stable_place_id(
+            stale_raw,
+            source_type=raw.configured_source_type,
+        )
+        current_place_id = build_data.stable_place_id(
+            current_raw,
+            source_type=raw.configured_source_type,
+        )
+        guide = Guide(
+            slug="tokyo-japan",
+            title="Tokyo",
+            country_name="Japan",
+            city_name="Tokyo",
+            generated_at="2026-04-20T00:00:00+00:00",
+            place_count=1,
+            places=[
+                NormalizedPlace(
+                    id=current_place_id,
+                    name="Coffee House",
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Coffee+House",
+                    status="active",
+                )
+            ],
+        )
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="Old Coffee House",
+            matched=True,
+            place=EnrichmentPlace(display_name="Old Coffee House"),
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            db_path = tmpdir_path / "cache" / "places.sqlite"
+
+            with patch.object(build_data, "PLACES_SQLITE_PATH", db_path):
+                build_data.save_places_cache("tokyo-japan", {stale_place_id: cache_entry})
+                with self.assertRaisesRegex(RuntimeError, "tokyo-japan"):
+                    build_data.rebuild_places_sqlite(
+                        raw_lists={"tokyo-japan": raw},
+                        guides=[guide],
+                        enrichment_caches={"tokyo-japan": {stale_place_id: cache_entry}},
+                    )
+                loaded_payload = build_data.load_places_cache("tokyo-japan")
+
+        self.assertEqual(list(loaded_payload), [stale_place_id])
 
     def test_rebuild_places_sqlite_hydrates_matching_guide_cache_photo_urls(self) -> None:
         shared_place_id = "cid:111"

--- a/vendor/gmaps-scraper/src/gmaps_scraper/parser.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/parser.py
@@ -644,6 +644,9 @@ def _find_cid_in_value(value: JSONValue | None) -> str | None:
         return _normalize_cid_token(value)
     if not isinstance(value, list):
         return None
+    owner = _parse_list_owner(value)
+    if owner is not None and (owner.photo_url is not None or owner.profile_id is not None):
+        return None
 
     numeric_texts = [
         text

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -99,6 +99,13 @@ _UI_ACTION_LABELS = {
     "share",
     "website",
 }
+_UI_ACTION_CLUSTER_LABEL_PATTERN = (
+    r"(?:call|directions|save|saved|nearby|send to phone|share|website|sign in)"
+)
+_UI_ACTION_CLUSTER_RE = re.compile(
+    rf"^{_UI_ACTION_CLUSTER_LABEL_PATTERN}(?:\s+{_UI_ACTION_CLUSTER_LABEL_PATTERN}){{2,}}$",
+    re.IGNORECASE,
+)
 _DESCRIPTION_STOP_MARKERS = {
     "photos",
     "about this data",
@@ -136,8 +143,33 @@ _DESCRIPTION_REVIEW_RESPONSE_MARKERS = (
     "i'm sorry to inform",
 )
 _DESCRIPTION_REVIEW_PROSE_MARKERS = (
+    "best place to stay",
+    "boy was it worth",
+    "definitely recommend this place",
+    "great experience overall",
+    "had a great time",
+    "hidden gem-literally",
     "highly recommended",
+    "i forgot his name",
+    "i'd just finished",
+    "i've tasted",
+    "i’d just finished",
+    "i’ve tasted",
+    "it was my first attempt",
+    "my stay in",
+    "once step in",
+    "offered great recommendation",
+    "omfg",
     "overrated",
+    "so yummy",
+    "the katsu burger",
+    "the rooms were huge",
+    "we have ever had",
+    "we've ever had",
+    "what a great hotel",
+    "would recommend to everyone",
+    "about this data",
+    "get the most out of google maps",
     "your children",
     "your kids",
     "you should",
@@ -573,6 +605,67 @@ _PLACE_JS_EXTRACTOR = r"""
     }
     return null;
   };
+  const elementTop = (element) => {
+    const rect = element?.getBoundingClientRect?.();
+    return rect && rect.height > 0 ? rect.top : null;
+  };
+  const elementBottom = (element) => {
+    const rect = element?.getBoundingClientRect?.();
+    return rect && rect.height > 0 ? rect.bottom : null;
+  };
+  const descriptionBoundaryTop = () => {
+    const rows = Array.from(panel.querySelectorAll("[data-item-id]"))
+      .map(elementTop)
+      .filter((value) => value !== null);
+    if (rows.length > 0) {
+      return Math.min(...rows);
+    }
+    const addressRow = addressRowElement();
+    const addressTop = elementTop(addressRow);
+    return addressTop === null ? Infinity : addressTop;
+  };
+  const descriptionValue = () => {
+    const direct = firstText([".WeS02d", ".PYvSYb"]);
+    if (direct) {
+      return direct;
+    }
+    const titleBottom = Math.max(
+      ...[
+        elementBottom(titleElement),
+        ...Array.from(panel.querySelectorAll("div.F7nice")).map(elementBottom),
+      ].filter((value) => value !== null),
+      0,
+    );
+    const boundaryTop = descriptionBoundaryTop();
+    const candidates = [];
+    for (const element of panel.querySelectorAll("div, span")) {
+      const text = cleanLine(element.innerText || element.textContent || "");
+      if (!text || text.includes("·")) {
+        continue;
+      }
+      if (
+        element.closest(
+          "button, a, [role='button'], [data-item-id], [data-review-id], div.F7nice",
+        )
+      ) {
+        continue;
+      }
+      if (
+        Array.from(element.children).some(
+          (child) => cleanLine(child.innerText || child.textContent || "") === text,
+        )
+      ) {
+        continue;
+      }
+      const top = elementTop(element);
+      if (top === null || top <= titleBottom || top >= boundaryTop) {
+        continue;
+      }
+      candidates.push({top, text});
+    }
+    candidates.sort((left, right) => left.top - right.top);
+    return candidates[0]?.text || null;
+  };
 
   const normalizeCount = (value) => {
     if (!value) {
@@ -683,22 +776,19 @@ _PLACE_JS_EXTRACTOR = r"""
   }
 
   const mainPhotoUrl = firstImageUrl([
+    "div.RZ66Rb button[jsaction*='heroHeaderImage'] img",
     "button[jsaction*='heroHeaderImage'] img",
-    "button[aria-label^='Photo of'] img",
-    "button[aria-label^='写真'] img",
-    "button[jsaction*='image'] img",
-    "button[jsaction*='photo'] img",
+    "div.ZKCDEc [data-photo-index='0'] img",
+    "[data-photo-index='0'] img",
     "[data-photo-index] img",
-  ], document)
+  ])
     || firstBackgroundImageUrl([
-      "button[jsaction*='image']",
-      "button[jsaction*='photo']",
+      "div.RZ66Rb button[jsaction*='heroHeaderImage']",
+      "button[jsaction*='heroHeaderImage']",
+      "div.ZKCDEc [data-photo-index='0']",
+      "[data-photo-index='0']",
       "[data-photo-index]",
-      "[aria-label*='Photo']",
-      "[aria-label*='photo']",
-      "[aria-label*='写真']",
-      "[aria-label*='画像']",
-    ], document);
+    ]);
   const photoUrl = mainPhotoUrl
     || firstAttr(["meta[property='og:image']", "meta[itemprop='image']"], "content", document);
 
@@ -1033,7 +1123,7 @@ _PLACE_JS_EXTRACTOR = r"""
       "button[data-item-id^='phone:']",
     ]),
     plus_code: itemValue("oloc"),
-    description: firstText([".WeS02d", ".PYvSYb"]),
+    description: descriptionValue(),
     review_topics: collectReviewTopics(),
     admission_prices: collectLeafPrices(sectionRootByHeading([
       "Admission",
@@ -1324,24 +1414,33 @@ _PLACE_SEARCH_RESULT_CLICK_JS = r"""
     }
     return {category: null, address: null};
   };
-  const findDescriptionLine = (lines, excludedValues) => {
+  const cardDescription = (article, excludedValues) => {
     const excluded = new Set(excludedValues.map(cleanLine).filter(Boolean));
-    return lines.find((line) => {
-      const text = cleanLine(line);
+    const rows = Array.from(article.querySelectorAll("div.W4Efsd"));
+    for (const row of rows) {
+      const text = cleanLine(row.innerText || row.textContent || "");
       if (!text || excluded.has(text)) {
-        return false;
+        continue;
       }
       if (text.includes("·") || parseCardRating(text) || parseCardReviewCount(text)) {
-        return false;
+        continue;
+      }
+      if (
+        row.querySelector(
+          ".AJB7ye, .UsdlK, [role='img'][aria-label*='star' i], a[href^='tel:']",
+        )
+      ) {
+        continue;
       }
       if (/^(open|closed|temporarily closed|website|directions|saved in)\b/i.test(text)) {
-        return false;
+        continue;
       }
       if (/^[+()\d\s.-]{7,}$/.test(text)) {
-        return false;
+        continue;
       }
-      return text.length >= 12;
-    }) || null;
+      return text;
+    }
+    return null;
   };
   const safeDecodeURIComponent = (value) => {
     try {
@@ -1373,10 +1472,11 @@ _PLACE_SEARCH_RESULT_CLICK_JS = r"""
       review_count: reviewCount,
       category: categoryAddress.category,
       address: categoryAddress.address,
-      search_result_description: findDescriptionLine(
-        lines,
+      search_result_description: cardDescription(
+        article,
         [name, categoryAddress.category, categoryAddress.address],
       ),
+      panel_text: lines.join("\n"),
       body_text: lines.join("\n"),
     };
   };
@@ -2390,9 +2490,8 @@ def _build_place_details(
     snapshot: Mapping[str, object],
 ) -> PlaceDetails:
     panel_lines = _body_lines(snapshot.get("panel_text"))
-    body_lines = _body_lines(snapshot.get("body_text"))
-    search_lines = panel_lines or body_lines
-    combined_lines = _dedupe_lines([*panel_lines, *body_lines])
+    search_lines = panel_lines
+    combined_lines = _dedupe_lines(panel_lines)
     category = _clean_category_text(snapshot.get("category")) or _extract_category_from_lines(
         search_lines
     )
@@ -2484,7 +2583,7 @@ def _build_place_details(
         plus_code=_clean_plus_code_text(snapshot.get("plus_code"))
         or _extract_plus_code_from_lines(combined_lines),
         address_parts=_extract_address_parts(snapshot.get("address_parts")),
-        description=_extract_description(snapshot, combined_lines),
+        description=_extract_description(snapshot),
         search_result_description=_clean_description_text(
             snapshot.get("search_result_description")
         ),
@@ -3624,18 +3723,8 @@ def _extract_plus_code_from_lines(lines: list[str]) -> str | None:
     return None
 
 
-def _extract_description(snapshot: Mapping[str, object], lines: list[str]) -> str | None:
-    direct = _clean_description_text(snapshot.get("description"))
-    if direct is not None:
-        return direct
-    for index, line in enumerate(lines):
-        if line.startswith("Seasonal ") or line.startswith("Modern setting "):
-            return line
-        if line == "Share" and index + 1 < len(lines):
-            candidate = _clean_description_text(lines[index + 1])
-            if candidate is not None and candidate.lower() not in _DESCRIPTION_STOP_MARKERS:
-                return candidate
-    return None
+def _extract_description(snapshot: Mapping[str, object]) -> str | None:
+    return _clean_description_text(snapshot.get("description"))
 
 
 def _clean_description_text(value: object) -> str | None:
@@ -3652,7 +3741,11 @@ def _clean_description_text(value: object) -> str | None:
         return None
     if _looks_like_status_text(normalized):
         return None
-    if _looks_like_search_results_label(normalized) or _looks_like_ui_action_label(normalized):
+    if (
+        _looks_like_search_results_label(normalized)
+        or _looks_like_ui_action_label(normalized)
+        or _looks_like_ui_action_cluster(normalized)
+    ):
         return None
     if (
         _looks_like_description_review_prose(normalized)
@@ -3672,6 +3765,12 @@ def _clean_description_text(value: object) -> str | None:
     ):
         return None
     return normalized
+
+
+def _looks_like_ui_action_cluster(value: str) -> bool:
+    text = re.sub(r"[\ue000-\uf8ff]", " ", value)
+    text = re.sub(r"\s+", " ", text).strip(" .")
+    return _UI_ACTION_CLUSTER_RE.fullmatch(text) is not None
 
 
 def _strip_description_service_options(value: str) -> str | None:
@@ -3795,6 +3894,10 @@ def _normalize_photo_url(value: object) -> str | None:
     if (
         "googleusercontent.com" in host or host.endswith("ggpht.com")
     ) and path.startswith(("/a-", "/a/")):
+        return None
+    if re.fullmatch(r"lh[0-9]+\.(?:googleusercontent\.com|ggpht\.com)", host) is None:
+        return None
+    if re.search(r"(?:=|-)w[0-9]+-h[0-9]+(?:-|$)", normalized) is None:
         return None
     return normalized
 
@@ -4241,7 +4344,10 @@ def _looks_like_search_results_label(value: str) -> bool:
     normalized = _clean_text(value)
     if normalized is None:
         return False
-    return normalized.casefold() in _SEARCH_RESULTS_LABELS
+    normalized_lookup = normalized.casefold()
+    return normalized_lookup in _SEARCH_RESULTS_LABELS or normalized_lookup.startswith(
+        "sponsored "
+    )
 
 
 def _looks_like_ui_action_label(value: str) -> bool:

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -2421,6 +2421,7 @@ def _search_result_snapshot(candidate: str | Mapping[str, object]) -> dict[str, 
         "category",
         "address",
         "search_result_description",
+        "panel_text",
         "body_text",
     ):
         value = candidate.get(key)

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -113,6 +113,7 @@ _DESCRIPTION_STOP_MARKERS = {
     "write a review",
     "claim this business",
     "suggest an edit",
+    "overview reviews about",
     "limited view of google maps",
     "get the most out of google maps",
     "our policies do not permit contributions to this type of place.",
@@ -645,7 +646,8 @@ _PLACE_JS_EXTRACTOR = r"""
       }
       if (
         element.closest(
-          "button, a, [role='button'], [data-item-id], [data-review-id], div.F7nice",
+          "button, a, [role='button'], [role='tab'], [role='tablist'], "
+            + "[data-item-id], [data-review-id], div.F7nice",
         )
       ) {
         continue;

--- a/vendor/gmaps-scraper/tests/test_parser.py
+++ b/vendor/gmaps-scraper/tests/test_parser.py
@@ -350,6 +350,26 @@ class ParserTests(unittest.TestCase):
             "https://www.google.com/maps/search/?api=1&query=Northwind+Cafe%2C+Example+District",
         )
 
+    def test_does_not_use_owner_payload_inside_metadata_as_place_cid(self) -> None:
+        runtime_state = copy.deepcopy(["noise", _LIST_NODE])
+        first_place = runtime_state[1][8][0]
+        assert isinstance(first_place, list)
+        first_metadata = first_place[1]
+        assert isinstance(first_metadata, list)
+
+        first_metadata[6] = [
+            "Fixture Owner",
+            "https://lh3.googleusercontent.com/a-/fixture-owner",
+            "104356373423434804635",
+        ]
+
+        parsed = parse_saved_list_artifacts(_LIST_URL, runtime_state=runtime_state)
+
+        self.assertEqual(len(parsed.places), 2)
+        self.assertEqual(parsed.places[0].cid, None)
+        self.assertEqual(parsed.places[0].google_id, "/g/11northwind")
+        self.assertNotEqual(parsed.places[0].cid, "104356373423434804635")
+
     def test_extracts_favorite_and_note_from_user_payload_shape(self) -> None:
         runtime_state = [
             "noise",

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -2014,7 +2014,10 @@ class PlaceScraperTests(unittest.TestCase):
             snapshot=snapshot,
         )
 
-        self.assertEqual(snapshot["panel_text"], "Open Kitchen\nRestaurant · MPF7+73 Shibuya, Tokyo, Japan")
+        self.assertEqual(
+            snapshot["panel_text"],
+            "Open Kitchen\nRestaurant · MPF7+73 Shibuya, Tokyo, Japan",
+        )
         self.assertEqual(details.category, "Restaurant")
         self.assertEqual(details.plus_code, "MPF7+73 Shibuya, Tokyo, Japan")
 

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -83,6 +83,7 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertIn("const descriptionValue = () => {", _PLACE_JS_EXTRACTOR)
         self.assertIn('firstText([".WeS02d", ".PYvSYb"])', _PLACE_JS_EXTRACTOR)
         self.assertIn("const descriptionBoundaryTop = () => {", _PLACE_JS_EXTRACTOR)
+        self.assertIn("[role='button'], [role='tab'], [role='tablist']", _PLACE_JS_EXTRACTOR)
 
     def test_place_js_extractor_uses_structural_panel_photo_selectors(self) -> None:
         self.assertIn("div.RZ66Rb button[jsaction*='heroHeaderImage'] img", _PLACE_JS_EXTRACTOR)
@@ -1449,6 +1450,9 @@ class PlaceScraperTests(unittest.TestCase):
 
     def test_clean_description_text_rejects_sponsored_label(self) -> None:
         self.assertIsNone(_clean_description_text("Sponsored"))
+
+    def test_clean_description_text_rejects_place_tab_strip(self) -> None:
+        self.assertIsNone(_clean_description_text("Overview Reviews About"))
 
     def test_clean_description_text_keeps_structured_marketing_summary(self) -> None:
         self.assertEqual(

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -79,6 +79,18 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertIn('element.closest("[data-review-id]")', _PLACE_JS_EXTRACTOR)
         self.assertIn("root.querySelectorAll(selector)", _PLACE_JS_EXTRACTOR)
         self.assertIn(r"return /(^|\W)reviews?(\W|$)/i.test(label);", _PLACE_JS_EXTRACTOR)
+        self.assertIn("const descriptionValue = () => {", _PLACE_JS_EXTRACTOR)
+        self.assertIn('firstText([".WeS02d", ".PYvSYb"])', _PLACE_JS_EXTRACTOR)
+        self.assertIn("const descriptionBoundaryTop = () => {", _PLACE_JS_EXTRACTOR)
+
+    def test_place_js_extractor_uses_structural_panel_photo_selectors(self) -> None:
+        self.assertIn("div.RZ66Rb button[jsaction*='heroHeaderImage'] img", _PLACE_JS_EXTRACTOR)
+        self.assertIn("div.ZKCDEc [data-photo-index='0'] img", _PLACE_JS_EXTRACTOR)
+        self.assertIn("[data-photo-index='0'] img", _PLACE_JS_EXTRACTOR)
+        self.assertNotIn("button[jsaction*='image'] img", _PLACE_JS_EXTRACTOR)
+        self.assertNotIn("button[jsaction*='photo'] img", _PLACE_JS_EXTRACTOR)
+        self.assertNotIn("button[aria-label^='Photo of'] img", _PLACE_JS_EXTRACTOR)
+        self.assertNotIn("], document)\n    || firstBackgroundImageUrl", _PLACE_JS_EXTRACTOR)
 
     def test_collect_place_snapshot_can_skip_reviews_and_about_tabs(self) -> None:
         class _FakePage:
@@ -451,6 +463,7 @@ class PlaceScraperTests(unittest.TestCase):
                 "rating": "4.5",
                 "review_count": "40,001",
                 "price_range": "NT$320",
+                "admission_prices": ["NT$320"],
                 "address": "4 Chome-2-8 Shibakoen, Minato City, Tokyo 105-0011, Japan",
                 "body_text": "\n".join(
                     [
@@ -624,6 +637,12 @@ class PlaceScraperTests(unittest.TestCase):
         )
         self.assertIn("searchResultTitleLabels", _PLACE_SEARCH_RESULT_CLICK_JS)
         self.assertIn("parseCardReviewCount", _PLACE_SEARCH_RESULT_CLICK_JS)
+        self.assertIn(
+            "const cardDescription = (article, excludedValues) => {",
+            _PLACE_SEARCH_RESULT_CLICK_JS,
+        )
+        self.assertIn('article.querySelectorAll("div.W4Efsd")', _PLACE_SEARCH_RESULT_CLICK_JS)
+        self.assertNotIn("findDescriptionLine", _PLACE_SEARCH_RESULT_CLICK_JS)
         self.assertIn("getBoundingClientRect()", _PLACE_SEARCH_RESULT_OPEN_JS)
         self.assertIn("const placePanelRoot = () => {", _PLACE_JS_EXTRACTOR)
         self.assertIn("visibleArea", _PLACE_JS_EXTRACTOR)
@@ -950,7 +969,11 @@ class PlaceScraperTests(unittest.TestCase):
         assert details.diagnostics is not None
         self.assertEqual(details.diagnostics.field_sources.get("name"), "search_result")
 
-    def test_build_place_details_uses_dom_fields_and_body_fallbacks(self) -> None:
+    def test_build_place_details_uses_structured_dom_fields(self) -> None:
+        description = (
+            "Seasonal menus of strikingly presented contemporary dishes, with wine "
+            "pairings, in a stylish space."
+        )
         details = _build_place_details(
             "https://www.google.com/maps/place/Den",
             resolved_url="https://www.google.com/maps/place/Den/@35.6731762,139.7127216,17z",
@@ -969,6 +992,7 @@ class PlaceScraperTests(unittest.TestCase):
                 "website": "http://www.jimbochoden.com/",
                 "phone": "+81 3-6455-5433",
                 "plus_code": "MPF7+73 Shibuya, Tokyo, Japan",
+                "description": description,
                 "limited_view": True,
                 "body_text": "\n".join(
                     [
@@ -976,10 +1000,7 @@ class PlaceScraperTests(unittest.TestCase):
                         "傳",
                         "4.4",
                         "Japanese restaurant·",
-                        (
-                            "Seasonal menus of strikingly presented contemporary dishes, "
-                            "with wine pairings, in a stylish space."
-                        ),
+                        description,
                     ]
                 ),
             },
@@ -990,16 +1011,52 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertEqual(details.category, "Japanese restaurant")
         self.assertEqual(details.rating, 4.4)
         self.assertEqual(details.review_count, 324)
-        self.assertEqual(
-            details.description,
-            (
-                "Seasonal menus of strikingly presented contemporary dishes, with wine "
-                "pairings, in a stylish space."
-            ),
-        )
+        self.assertEqual(details.description, description)
         self.assertEqual(details.lat, 35.6731762)
         self.assertEqual(details.lng, 139.7127216)
         self.assertTrue(details.limited_view)
+
+    def test_build_place_details_does_not_promote_body_text_to_description(self) -> None:
+        details = _build_place_details(
+            "https://www.google.com/maps/place/Den",
+            resolved_url="https://www.google.com/maps/place/Den",
+            snapshot={
+                "name": "Den",
+                "category": "Japanese restaurant",
+                "body_text": "\n".join(
+                    [
+                        "Share",
+                        (
+                            "Seasonal menus of strikingly presented contemporary dishes, "
+                            "with wine pairings, in a stylish space."
+                        ),
+                    ]
+                ),
+            },
+        )
+
+        self.assertIsNone(details.description)
+
+    def test_build_place_details_does_not_promote_share_adjacent_panel_text(self) -> None:
+        details = _build_place_details(
+            "https://www.google.com/maps/place/CANNES+sign",
+            resolved_url="https://www.google.com/maps/place/CANNES+sign",
+            snapshot={
+                "name": "CANNES sign",
+                "category": "Tourist attraction",
+                "panel_text": "\n".join(
+                    [
+                        "Share",
+                        (
+                            "We took a very long cruise last summer from Venice to Portugal. "
+                            "One stop was Cannes, and this sign was on the walking tour."
+                        ),
+                    ]
+                ),
+            },
+        )
+
+        self.assertIsNone(details.description)
 
     def test_build_place_details_preserves_zero_coordinates(self) -> None:
         details = _build_place_details(
@@ -1493,6 +1550,42 @@ class PlaceScraperTests(unittest.TestCase):
                 "feel like it is a must visit spot."
             )
         )
+        self.assertIsNone(
+            _clean_description_text(
+                "Best ramen we've ever had. It helps that you get to make it yourself "
+                "(the noodles at least). Everything tastes better when you do it yourself! "
+                "Date day for a Saturday morning class. Great experience overall."
+            )
+        )
+        self.assertIsNone(
+            _clean_description_text(
+                "That’s gotta be one of the best hot chocolate drink I’ve tasted in my life! "
+                "The long wait was definitely worth it. There was quite a line before we got "
+                "a seat, but boy was it worth every minute. Definitely recommend this place."
+            )
+        )
+        for review_description in (
+            "It was my first attempt to eat mukhata. The food was so delicious and "
+            "the clerks were very kind.",
+            "Best place to stay in Hanoi. I’d just finished Ha Giang loop and "
+            "needed a place to rest.",
+            "The katsu burger!!! Omfg!!! So yummy and the young man with blonde "
+            "curly hair from England.",
+            "What a great hotel! The rooms were huge and have balconies with a seating area.",
+            "Had a great time here with my friends! The barkeeper made us feel "
+            "welcomed and we had a lot of fun.",
+            "The lady was just so so lovely. My feet are just gorgeous. "
+            "Would recommend to everyone.",
+            "My stay in Alila was wonderful. Special shout out to the staff for "
+            "making it memorable.",
+            "The hotel have a sense of peace and tranquility once step in. "
+            "The personal service was delicate.",
+            "The staffs also offered great recommendation for drinks based on your preference.",
+            "Directions Save Nearby Send to phone Share About this data "
+            "Get the most out of Google Maps Sign in",
+            "\ue52e Directions \ue866 Save \uf05f Nearby \ue702 Send to phone \ue80d Share",
+        ):
+            self.assertIsNone(_clean_description_text(review_description))
 
     def test_clean_description_text_keeps_first_person_business_summary(self) -> None:
         self.assertEqual(
@@ -1885,6 +1978,21 @@ class PlaceScraperTests(unittest.TestCase):
 
         self.assertIsNone(details.name)
 
+    def test_build_place_details_rejects_sponsored_name_label(self) -> None:
+        details = _build_place_details(
+            "https://www.google.com/maps/search/?api=1&query=Nakameguro+Iguchi",
+            resolved_url="https://www.google.com/maps/search/?api=1&query=Nakameguro+Iguchi",
+            snapshot={
+                "name": "Sponsored \ue5d4",
+                "category": "Restaurant",
+                "rating": "3.7",
+                "review_count": "186",
+                "body_text": "\n".join(["Sponsored \ue5d4", "Restaurant", "3.7"]),
+            },
+        )
+
+        self.assertIsNone(details.name)
+
     def test_build_place_details_rejects_ui_action_fallback_name_and_marks_diagnostics(
         self,
     ) -> None:
@@ -1921,7 +2029,7 @@ class PlaceScraperTests(unittest.TestCase):
             snapshot={
                 "name": "Share",
                 "category": "Event venue",
-                "body_text": "\n".join(
+                "panel_text": "\n".join(
                     ["Share", "Saved", "Directions", "Pooles Temple", "Event venue"]
                 ),
             },
@@ -2091,14 +2199,16 @@ class PlaceScraperTests(unittest.TestCase):
 
         self.assertIsNone(details.address_parts)
 
-    def test_build_place_details_rejects_page_chrome_address_and_falls_back_to_body(self) -> None:
+    def test_build_place_details_rejects_page_chrome_address_and_falls_back_to_panel_text(
+        self,
+    ) -> None:
         details = _build_place_details(
             "https://www.google.com/maps/place/Bianchetto",
             resolved_url="https://www.google.com/maps/place/Bianchetto",
             snapshot={
                 "name": "Bianchetto",
                 "address": "Imagery © 2026 Google TermsPrivacySend Product Feedback",
-                "body_text": "\n".join(
+                "panel_text": "\n".join(
                     [
                         "Bianchetto",
                         "Restaurant",
@@ -2142,7 +2252,7 @@ class PlaceScraperTests(unittest.TestCase):
             snapshot={
                 "name": "Den",
                 "plus_code": "https://www.google.com/maps/place/Den",
-                "body_text": "\n".join(
+                "panel_text": "\n".join(
                     [
                         "Den",
                         "Japanese restaurant",
@@ -2352,7 +2462,8 @@ class PlaceScraperTests(unittest.TestCase):
         )
 
     def test_place_js_extractor_keeps_place_page_description_selectors(self) -> None:
-        self.assertIn('description: firstText([".WeS02d", ".PYvSYb"])', _PLACE_JS_EXTRACTOR)
+        self.assertIn('const direct = firstText([".WeS02d", ".PYvSYb"])', _PLACE_JS_EXTRACTOR)
+        self.assertIn("description: descriptionValue()", _PLACE_JS_EXTRACTOR)
 
     def test_looks_like_google_maps_place_url_accepts_google_tlds_only(self) -> None:
         self.assertTrue(
@@ -2435,6 +2546,23 @@ class PlaceScraperTests(unittest.TestCase):
             _normalize_photo_url("https://lh3.googleusercontent.com/p/example=s680-w680-h510"),
             "https://lh3.googleusercontent.com/p/example=s680-w680-h510",
         )
+        self.assertEqual(
+            _normalize_photo_url(
+                "https://lh3.googleusercontent.com/gps-cs-s/example=w408-h306-k-no"
+            ),
+            "https://lh3.googleusercontent.com/gps-cs-s/example=w408-h306-k-no",
+        )
+
+    def test_normalize_photo_url_rejects_ad_thumbnails_and_unshaped_hosts(self) -> None:
+        for photo_url in (
+            "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcExample&s=3",
+            "https://www.gstatic.com/faviconV2?url=https://example.com",
+            "https://www.gstatic.com/ads-travel/example.png",
+            "https://lh3.googleusercontent.com/p/example",
+            "https://lh3.googleusercontent.com.example/p/example=w680-h510-k-no",
+        ):
+            with self.subTest(photo_url=photo_url):
+                self.assertIsNone(_normalize_photo_url(photo_url))
 
     def test_normalize_photo_url_rejects_google_static_map_urls(self) -> None:
         self.assertIsNone(

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -51,6 +51,7 @@ from gmaps_scraper.place_scraper import (
     _parse_price_amount,
     _parse_review_count,
     _search_result_candidate_url,
+    _search_result_snapshot,
     _seed_google_consent_cookies,
     _should_use_llm_repair,
     collect_place_snapshot,
@@ -1992,6 +1993,30 @@ class PlaceScraperTests(unittest.TestCase):
         )
 
         self.assertIsNone(details.name)
+
+    def test_search_result_snapshot_preserves_panel_text_for_fallback_parsing(self) -> None:
+        snapshot = _search_result_snapshot(
+            {
+                "href": "https://www.google.com/maps/place/Open+Kitchen",
+                "name": "Open Kitchen",
+                "panel_text": "\n".join(
+                    [
+                        "Open Kitchen",
+                        "Restaurant · MPF7+73 Shibuya, Tokyo, Japan",
+                    ]
+                ),
+            }
+        )
+
+        details = _build_place_details(
+            "https://www.google.com/maps/place/Open+Kitchen",
+            resolved_url="https://www.google.com/maps/place/Open+Kitchen",
+            snapshot=snapshot,
+        )
+
+        self.assertEqual(snapshot["panel_text"], "Open Kitchen\nRestaurant · MPF7+73 Shibuya, Tokyo, Japan")
+        self.assertEqual(details.category, "Restaurant")
+        self.assertEqual(details.plus_code, "MPF7+73 Shibuya, Tokyo, Japan")
 
     def test_build_place_details_rejects_ui_action_fallback_name_and_marks_diagnostics(
         self,


### PR DESCRIPTION
## Summary
- reject first-person/review-style Google Maps descriptions including the ramen/Angelina cases, UI shell text, and later retry findings
- keep the downstream semantic sanitizer from dropping valid English copy like “convivial”, “top notch”, or “kinda” unless it matches the malformed chat/slash leak shape
- preserve selected enrichment cache fields during targeted retries so thinner scrape results do not wipe useful description/about/review data
- run the empty-cache overwrite guard after stale place IDs are pruned so ID drift cannot wipe a still-populated guide cache
- suppress generated recommendation copy when an enrichment row resolves to an incompatible place identity, including owner/user CID payload edge cases
- vendor the gmaps-scraper fixes for panel-text fallback parsing and tab-strip exclusion from description fallback selection
- expand build-data and vendored scraper regression coverage for cache safety, sanitizer, CID parsing, and fallback extraction paths

## Validation
- uv sync --reinstall-package gmaps-scraper
- uv run python3 -m unittest tests.python.test_build_data.BuildDataTests.test_normalize_place_page_enrichment_rejects_ui_display_name_and_review_description tests.python.test_build_data.BuildDataTests.test_normalize_guide_rejects_recommendation_copy_from_mismatched_enrichment_identity
- uv run python3 -m unittest discover -s vendor/gmaps-scraper/tests -p 'test_place_scraper.py'
- uv run python3 -m unittest tests.python.test_build_data.BuildDataTests.test_semantic_description_accepts_common_phrases_that_overlap_chat_leaks tests.python.test_build_data.BuildDataTests.test_semantic_description_rejects_chat_history_leaky_examples tests.python.test_build_data.BuildDataTests.test_rebuild_places_sqlite_rejects_empty_payload_over_existing_nonempty_guide tests.python.test_build_data.BuildDataTests.test_rebuild_places_sqlite_rejects_empty_payload_after_pruning_stale_ids