### PR TITLE
[codex] Add place-level attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ Supported sources:
 
 Google My Maps URLs are not supported yet.
 
-For Google Maps URL sources, raw snapshots preserve the list `owner` object, including `name`, `photo_url`, `photo_path`, `avatar_mode`, and `profile_id`, plus any `collaborators` the scraper can recover. When the scraped owner is the effective published author, source refresh downloads a square local author image into `site/public/author-photos/` and stores its `photo_path`. Guide list overrides can optionally set, replace, or suppress the generated guide `author`; use `photo_path` to point at a site-owned image under `site/public/`, or set `avatar_mode` to `photo`, `initials`, or `icon`.
+For Google Maps URL sources, raw snapshots preserve the list `owner` object, including `name`, `photo_url`, `photo_path`, `avatar_mode`, and `profile_id`, plus any `collaborators` the scraper can recover. Individual places can also carry an `added_by` author with `name` and `profile_id`. When the scraped owner is the effective published author, source refresh downloads a square local author image into `site/public/author-photos/` and stores its `photo_path`. Guide list overrides can optionally set, replace, or suppress the generated guide `author`; use `photo_path` to point at a site-owned image under `site/public/`, or set `avatar_mode` to `photo`, `initials`, or `icon`.
+
+Place-level `added_by` metadata is preserved in generated place data. Cards show it by default only when it differs from the guide author, so collaborator additions are visible without repeating the guide owner on every card. Override a place with `"added_by": {"name": "Name", "avatar_mode": "initials"}` to set it manually, or `"added_by": null` to suppress it for that place. Set `placeCard.showAttribution: false` in `site/config.ts` to hide all individual place attributions, or `placeCard.showGuideAuthorAttribution: true` to also show places added by the guide author.
 
 ## Build Your Data
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -263,7 +263,7 @@ The project keeps these layers separate:
 1. `site/data/raw/`: raw scraper or CSV import snapshots
 2. `site/data/cache/places.sqlite`: cached Google Places lookups keyed by guide slug and stable place id
 3. `site/data/cache/google-places/`: optional debug export directory, gitignored
-4. `site/overrides/`: handwritten metadata, tags, notes, visibility, and ranking
+4. `site/overrides/`: handwritten metadata, tags, notes, visibility, attribution, and ranking
 5. `src/data/generated/`: static JSON that Astro reads at build time, gitignored
 6. `public/data/search-index.json`: browser search index, gitignored
 
@@ -274,6 +274,8 @@ Merge precedence:
 3. Raw scraped list data
 
 Manual overrides always win over machine-enriched fields.
+
+Google Maps list imports may attach `added_by` to individual raw places. The build preserves that attribution into generated place JSON, and place overrides can replace it with an author object or suppress it with `null`. The frontend default is to show individual place attribution only when it is not the effective guide author; `site/config.ts` can disable all card attributions with `placeCard.showAttribution: false`.
 
 ## Google Places Enrichment
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -2487,6 +2487,7 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
         top_pick = top_pick_override if top_pick_override is not None else place.is_favorite
         manual_note = as_string(override.get("note"))
         note = manual_note or place.note
+        added_by = place_added_by_for_ui(place, override=override)
         base_recommendation = combine_recommendation_copy(
             enrichment.description or enrichment.search_result_description,
             place.note,
@@ -2583,6 +2584,7 @@ def normalize_guide(slug: str, raw: RawSavedList, *, enrichment_cache: dict[str,
             neighborhood=neighborhood,
             note=note,
             why_recommended=why_recommended,
+            added_by=added_by,
             main_photo_path=None,
             top_pick=top_pick,
             hidden=hidden,
@@ -2774,6 +2776,12 @@ def build_place_provenance(
             manual_place_field(normalized.why_recommended)
             if manual_note
             else None
+        )
+    if normalized.added_by:
+        provenance.added_by = (
+            manual_place_field(normalized.added_by)
+            if "added_by" in override
+            else google_list_field(normalized.added_by, raw)
         )
     provenance.top_pick = (
         manual_place_field(normalized.top_pick)
@@ -4904,6 +4912,12 @@ def guide_author_for_ui(raw: RawSavedList, *, list_override: dict[str, Any]) -> 
     return raw.owner
 
 
+def place_added_by_for_ui(place: RawPlace, *, override: dict[str, Any]) -> ListAuthor | None:
+    if "added_by" in override:
+        return coerce_list_author(override.get("added_by"))
+    return place.added_by
+
+
 def load_raw_saved_list(path: Path) -> RawSavedList | None:
     if not path.exists():
         return None
@@ -5242,6 +5256,9 @@ def preserve_existing_raw_place(
     if names_compatible and not refreshed_place.is_favorite and existing_place.is_favorite:
         updates["is_favorite"] = True
         preserved_fields.append("is_favorite")
+    if names_compatible and refreshed_place.added_by is None and existing_place.added_by is not None:
+        updates["added_by"] = existing_place.added_by
+        preserved_fields.append("added_by")
 
     if not updates:
         return refreshed_place, preserved_fields

--- a/scripts/pipeline_models.py
+++ b/scripts/pipeline_models.py
@@ -145,6 +145,7 @@ class RawPlace(PipelineModel):
     address: str | None = None
     note: str | None = None
     is_favorite: bool = False
+    added_by: ListAuthor | None = None
     lat: float | None = None
     lng: float | None = None
     maps_url: str
@@ -286,6 +287,7 @@ class PlaceProvenance(PipelineModel):
     neighborhood: PlaceField | None = None
     note: PlaceField | None = None
     why_recommended: PlaceField | None = None
+    added_by: PlaceField | None = None
     top_pick: PlaceField | None = None
     hidden: PlaceField | None = None
     manual_rank: PlaceField | None = None
@@ -315,6 +317,7 @@ class NormalizedPlace(PipelineModel):
     neighborhood: str | None = None
     note: str | None = None
     why_recommended: str | None = None
+    added_by: ListAuthor | None = None
     main_photo_path: str | None = None
     top_pick: bool = False
     hidden: bool = False

--- a/site.example/overrides/places/taipei-taiwan.json
+++ b/site.example/overrides/places/taipei-taiwan.json
@@ -4,6 +4,10 @@
     "neighborhood": "Xinyi",
     "google_place_id": "ChIJraeA2rarQjQRPBBjyR3RxKw",
     "note": "Still the easiest big-view landmark in Taipei, with shopping, food, and transit wrapped around the tower.",
+    "added_by": {
+      "name": "Sample Collaborator",
+      "avatar_mode": "initials"
+    },
     "top_pick": true,
     "manual_rank": 20,
     "tags": ["skyline", "viewpoint"],

--- a/src/components/PlaceCard.astro
+++ b/src/components/PlaceCard.astro
@@ -4,11 +4,13 @@ import { siteConfig } from "../data/site";
 import { buildMapMarkerSvg, getMapMarkerColors } from "../lib/mapMarkerIcons";
 import { getDisplayGuideTags, getDisplayPlaceTags, getTagComparisonValue } from "../lib/placeTags";
 import { renderRichText } from "../lib/renderRichText";
-import type { Place } from "../lib/types";
+import type { ListAuthor, Place } from "../lib/types";
+import AuthorByline from "./AuthorByline.astro";
 
 interface Props {
   bestHit?: boolean;
   featured?: boolean;
+  guideAuthor?: ListAuthor | null;
   guideContext?: {
     cityName?: string | null;
     countryCode?: string | null;
@@ -17,7 +19,21 @@ interface Props {
   place: Place;
 }
 
-const { bestHit = false, featured = false, guideContext = {}, place } = Astro.props;
+function authorsReferToSamePerson(left: ListAuthor | null | undefined, right: ListAuthor | null | undefined): boolean {
+  if (!left || !right) {
+    return false;
+  }
+
+  const leftProfileId = left.profile_id?.trim();
+  const rightProfileId = right.profile_id?.trim();
+  if (leftProfileId && rightProfileId) {
+    return leftProfileId === rightProfileId;
+  }
+
+  return left.name.trim().toLocaleLowerCase() === right.name.trim().toLocaleLowerCase();
+}
+
+const { bestHit = false, featured = false, guideAuthor = null, guideContext = {}, place } = Astro.props;
 const placeTags = place.tags ?? [];
 const configuredVisibleTags = place.visible_tags ?? [];
 const placeVibeTags = place.vibe_tags ?? [];
@@ -87,6 +103,14 @@ const badges = [
   ...(bestHit ? [{ className: "badge badge--best-hit", label: siteConfig.placeCard.bestHitLabel }] : []),
 ];
 const isTemporarilyClosed = siteConfig.placeCard.showStatus && place.status === "temporarily-closed";
+const placeAttribution =
+  place.added_by && place.added_by.name.trim().length > 0
+    ? place.added_by
+    : null;
+const showPlaceAttribution =
+  siteConfig.placeCard.showAttribution &&
+  placeAttribution &&
+  (siteConfig.placeCard.showGuideAuthorAttribution || !authorsReferToSamePerson(placeAttribution, guideAuthor));
 ---
 
 <article
@@ -209,6 +233,11 @@ const isTemporarilyClosed = siteConfig.placeCard.showStatus && place.status === 
     )}
   </div>
 
+  {showPlaceAttribution && (
+    <div class="place-card-attribution">
+      <AuthorByline author={placeAttribution} label={siteConfig.placeCard.attributionLabel} variant="card" />
+    </div>
+  )}
   {siteConfig.placeCard.showWhyRecommended && whyRecommendedHtml && (
     <p class="rich-copy ui-copy place-card-description" set:html={whyRecommendedHtml} />
   )}

--- a/src/components/PlaceCard.astro
+++ b/src/components/PlaceCard.astro
@@ -30,7 +30,13 @@ function authorsReferToSamePerson(left: ListAuthor | null | undefined, right: Li
     return leftProfileId === rightProfileId;
   }
 
-  return left.name.trim().toLocaleLowerCase() === right.name.trim().toLocaleLowerCase();
+  const leftName = left.name?.trim();
+  const rightName = right.name?.trim();
+  if (!leftName || !rightName) {
+    return false;
+  }
+
+  return leftName.toLowerCase() === rightName.toLowerCase();
 }
 
 const { bestHit = false, featured = false, guideAuthor = null, guideContext = {}, place } = Astro.props;
@@ -107,10 +113,12 @@ const placeAttribution =
   place.added_by && place.added_by.name.trim().length > 0
     ? place.added_by
     : null;
-const showPlaceAttribution =
+const showPlaceAttribution = Boolean(
   siteConfig.placeCard.showAttribution &&
   placeAttribution &&
-  (siteConfig.placeCard.showGuideAuthorAttribution || !authorsReferToSamePerson(placeAttribution, guideAuthor));
+  (siteConfig.placeCard.showGuideAuthorAttribution || !authorsReferToSamePerson(placeAttribution, guideAuthor)),
+);
+const displayedPlaceAttribution = showPlaceAttribution ? placeAttribution : null;
 ---
 
 <article
@@ -233,9 +241,9 @@ const showPlaceAttribution =
     )}
   </div>
 
-  {showPlaceAttribution && (
+  {displayedPlaceAttribution && (
     <div class="place-card-attribution">
-      <AuthorByline author={placeAttribution} label={siteConfig.placeCard.attributionLabel} variant="card" />
+      <AuthorByline author={displayedPlaceAttribution} label={siteConfig.placeCard.attributionLabel} variant="card" />
     </div>
   )}
   {siteConfig.placeCard.showWhyRecommended && whyRecommendedHtml && (

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -82,6 +82,8 @@ interface GuideConfig {
 interface PlaceCardConfig {
   showPhoto: boolean;
   showMapLink: boolean;
+  showAttribution: boolean;
+  showGuideAuthorAttribution: boolean;
   showCategory: boolean;
   showNeighborhood: boolean;
   showRating: boolean;
@@ -95,6 +97,7 @@ interface PlaceCardConfig {
   showStatus: boolean;
   bestHitLabel: string;
   topPickLabel: string;
+  attributionLabel: string;
   mapsLabel: string;
   savedPlaceLabel: string;
   photoPlaceholderFallback: string;
@@ -226,6 +229,8 @@ const defaultSiteConfig: SiteConfig = {
   placeCard: {
     showPhoto: true,
     showMapLink: true,
+    showAttribution: true,
+    showGuideAuthorAttribution: false,
     showCategory: true,
     showNeighborhood: true,
     showRating: true,
@@ -239,6 +244,7 @@ const defaultSiteConfig: SiteConfig = {
     showStatus: true,
     bestHitLabel: "Popular",
     topPickLabel: "Top pick",
+    attributionLabel: "Added by",
     mapsLabel: "Maps",
     savedPlaceLabel: "Saved place",
     photoPlaceholderFallback: "Saved favorite",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -46,6 +46,7 @@ export interface PlaceProvenance {
   neighborhood?: PlaceField<string> | null;
   note?: PlaceField<string> | null;
   why_recommended?: PlaceField<string> | null;
+  added_by?: PlaceField<ListAuthor> | null;
   top_pick?: PlaceField<boolean> | null;
   hidden?: PlaceField<boolean> | null;
   manual_rank?: PlaceField<number> | null;
@@ -76,6 +77,7 @@ export interface Place {
   neighborhood: string | null;
   note: string | null;
   why_recommended: string | null;
+  added_by?: ListAuthor | null;
   main_photo_path: string | null;
   top_pick: boolean;
   hidden: boolean;

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -446,6 +446,7 @@ const guideJsonLd = [
           {visiblePlaces.map((place) => (
             <PlaceCard
               place={place}
+              guideAuthor={guide.author}
               guideContext={placeTagGuideContext}
               featured={featuredPlaceIds.has(place.id)}
               bestHit={bestHitPlaceIds.has(place.id)}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1425,6 +1425,29 @@
     line-height: 1.48;
   }
 
+  .place-card-attribution {
+    width: 100%;
+    padding-top: 0.1rem;
+  }
+
+  .place-card-attribution .guide-author {
+    font-size: 0.78rem;
+  }
+
+  .place-card-attribution .guide-author-mark {
+    width: 1.45rem;
+    height: 1.45rem;
+  }
+
+  .place-card-attribution .guide-author-icon {
+    width: 0.88rem;
+    height: 0.88rem;
+  }
+
+  .place-card-attribution .guide-author-initials {
+    font-size: 0.62rem;
+  }
+
   .place-card-tags {
     width: 100%;
     gap: 0.38rem;

--- a/tests/frontend/siteConfig.test.ts
+++ b/tests/frontend/siteConfig.test.ts
@@ -43,4 +43,21 @@ describe("site config merging", () => {
     expect(siteConfig.home.guideCard.showDescription).toBe(true);
     expect(siteConfig.home.guideCard.maxTags).toBe(6);
   });
+
+  it("merges place attribution config with defaults", async () => {
+    vi.resetModules();
+    vi.doMock("favorite-places:site-config", () => ({
+      siteConfig: {
+        placeCard: {
+          showAttribution: false,
+        },
+      },
+    }));
+    const { siteConfig } = await import("../../src/data/site");
+    vi.doUnmock("favorite-places:site-config");
+
+    expect(siteConfig.placeCard.showAttribution).toBe(false);
+    expect(siteConfig.placeCard.showGuideAuthorAttribution).toBe(false);
+    expect(siteConfig.placeCard.attributionLabel).toBe("Added by");
+  });
 });

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -63,6 +63,23 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(saved_list.collaborators[0].name, "Second Curator")
         self.assertEqual(saved_list.collaborators[0].photo_url, "https://example.com/second.jpg")
 
+    def test_raw_place_keeps_added_by_metadata_from_json(self) -> None:
+        place = RawPlace.model_validate(
+            {
+                "name": "Coffee Spot",
+                "maps_url": "https://maps.example/coffee",
+                "added_by": {
+                    "name": "Second Curator",
+                    "profile_id": "second-curator-id",
+                },
+            }
+        )
+
+        self.assertIsNotNone(place.added_by)
+        assert place.added_by is not None
+        self.assertEqual(place.added_by.name, "Second Curator")
+        self.assertEqual(place.added_by.profile_id, "second-curator-id")
+
     def test_normalize_guide_uses_raw_owner_as_author(self) -> None:
         raw = RawSavedList(
             title="Tokyo, Japan",
@@ -161,6 +178,76 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(guide.author.avatar_mode, "initials")
         self.assertIsNone(guide.author.photo_url)
         self.assertIsNone(guide.author.photo_path)
+
+    def test_normalize_guide_preserves_place_added_by(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo, Japan",
+            owner=ListAuthor(name="Guide Owner", profile_id="owner-id"),
+            places=[
+                RawPlace(
+                    name="Coffee Spot",
+                    maps_url="https://maps.example/coffee",
+                    added_by=ListAuthor(name="Second Curator", profile_id="second-id"),
+                )
+            ],
+        )
+
+        def read_json_side_effect(path: Path) -> dict[str, object]:
+            if path == build_data.LIST_OVERRIDES_DIR / "tokyo-japan.json":
+                return {}
+            if path == build_data.PLACE_OVERRIDES_DIR / "tokyo-japan.json":
+                return {}
+            return {}
+
+        with patch.object(build_data, "read_json", side_effect=read_json_side_effect):
+            guide = build_data.normalize_guide("tokyo-japan", raw, enrichment_cache={})
+
+        self.assertEqual(guide.places[0].added_by, ListAuthor(name="Second Curator", profile_id="second-id"))
+        self.assertIsNotNone(guide.places[0].provenance.added_by)
+        assert guide.places[0].provenance.added_by is not None
+        self.assertEqual(guide.places[0].provenance.added_by.source, "google_list")
+
+    def test_normalize_guide_allows_place_added_by_override_and_suppression(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo, Japan",
+            places=[
+                RawPlace(
+                    name="Coffee Spot",
+                    maps_url="https://maps.example/coffee",
+                    cid="1",
+                    added_by=ListAuthor(name="Raw Curator"),
+                ),
+                RawPlace(
+                    name="Tea Spot",
+                    maps_url="https://maps.example/tea",
+                    cid="2",
+                    added_by=ListAuthor(name="Raw Curator"),
+                ),
+            ],
+        )
+
+        def read_json_side_effect(path: Path) -> dict[str, object]:
+            if path == build_data.LIST_OVERRIDES_DIR / "tokyo-japan.json":
+                return {}
+            if path == build_data.PLACE_OVERRIDES_DIR / "tokyo-japan.json":
+                return {
+                    "cid:1": {"added_by": {"name": "Manual Curator", "avatar_mode": "initials"}},
+                    "cid:2": {"added_by": None},
+                }
+            return {}
+
+        with patch.object(build_data, "read_json", side_effect=read_json_side_effect):
+            guide = build_data.normalize_guide("tokyo-japan", raw, enrichment_cache={})
+
+        places_by_id = {place.id: place for place in guide.places}
+        self.assertEqual(
+            places_by_id["cid:1"].added_by,
+            ListAuthor(name="Manual Curator", avatar_mode="initials"),
+        )
+        self.assertIsNotNone(places_by_id["cid:1"].provenance.added_by)
+        assert places_by_id["cid:1"].provenance.added_by is not None
+        self.assertEqual(places_by_id["cid:1"].provenance.added_by.source, "manual")
+        self.assertIsNone(places_by_id["cid:2"].added_by)
 
     def test_sync_list_author_photo_downloads_local_photo_path(self) -> None:
         author = ListAuthor(
@@ -762,6 +849,7 @@ class BuildDataTests(unittest.TestCase):
                     cid="8935267511126082507",
                     google_id="/g/1tdwf48w",
                     maps_place_token="0xdeadbeef:0x1",
+                    added_by=ListAuthor(name="Second Curator", profile_id="second-id"),
                 )
             ],
         )
@@ -778,6 +866,7 @@ class BuildDataTests(unittest.TestCase):
                     cid="8935267511126082507",
                     google_id=None,
                     maps_place_token=None,
+                    added_by=None,
                 )
             ],
         )
@@ -794,6 +883,7 @@ class BuildDataTests(unittest.TestCase):
         )
         self.assertEqual(merged.places[0].google_id, "/g/1tdwf48w")
         self.assertEqual(merged.places[0].maps_place_token, "0xdeadbeef:0x1")
+        self.assertEqual(merged.places[0].added_by, ListAuthor(name="Second Curator", profile_id="second-id"))
         self.assertTrue(merged.places[0].is_favorite)
 
     def test_preserve_existing_raw_saved_list_does_not_apply_to_non_matching_place(self) -> None:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -248,6 +248,7 @@ class BuildDataTests(unittest.TestCase):
         assert places_by_id["cid:1"].provenance.added_by is not None
         self.assertEqual(places_by_id["cid:1"].provenance.added_by.source, "manual")
         self.assertIsNone(places_by_id["cid:2"].added_by)
+        self.assertIsNone(places_by_id["cid:2"].provenance.added_by)
 
     def test_sync_list_author_photo_downloads_local_photo_path(self) -> None:
         author = ListAuthor(


### PR DESCRIPTION
## Summary
- preserve Google Maps per-place `added_by` metadata through raw validation, normalized guide data, and provenance
- render place-card attribution only when the contributor differs from the guide author by default
- add config controls to hide all place attributions or also show guide-owner attributions
- add a small `site.example` override so the behavior is visible in the demo data

## Validation
- `bun run test:frontend`
- `bun run check`
- `bun run test:python`
- `bun run build`

## Notes
This branch was created directly from `508dev/main` so it does not include the larger in-progress branch from the current workspace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Places now show who added them and avoid duplicate attribution when the guide author is the same person
  * Config options to toggle place attributions and whether guide-author attribution is shown

* **Documentation**
  * Clarified how place-level added-by attribution is preserved, overridden, or suppressed and how config flags affect UI attribution

* **Tests**
  * Added tests covering preservation, override/suppression, and config merging for place attribution

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/508-dev/favorite-places/pull/97)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->