### PR TITLE
[codex] Refresh missing place photos

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -3870,6 +3870,15 @@ def canonicalized_enrichment_cache_entry_copy(entry: EnrichmentCacheEntry | None
     )
 
 
+def enrichment_cache_entry_payload(entry: EnrichmentCacheEntry) -> dict[str, Any]:
+    canonicalized_entry = canonicalized_enrichment_cache_entry_copy(entry)
+    assert canonicalized_entry is not None
+    payload = canonicalized_entry.model_dump(mode="json", exclude_none=True)
+    if not payload.get("merged_sources"):
+        payload.pop("merged_sources", None)
+    return payload
+
+
 def sanitize_place_photo_url(value: str | None) -> str | None:
     normalized = as_string(value)
     if normalized is None:
@@ -5691,11 +5700,36 @@ def cache_entry_needs_photo_url_retry(entry: EnrichmentCacheEntry) -> bool:
     return bool(
         entry.error is None
         and entry.matched is True
-        and entry.source != "google_places_api"
+        and cache_entry_has_page_scrape_enrichment(entry)
         and place is not None
         and not place.main_photo_url
         and not place.photo_url
         and enrichment_place_has_real_place_identity(place)
+    )
+
+
+def cache_entry_has_page_scrape_enrichment(entry: EnrichmentCacheEntry) -> bool:
+    if entry.source == "google_maps_page":
+        return True
+    if "google_maps_page" in entry.merged_sources:
+        return True
+    place = entry.place
+    return bool(
+        entry.source == "google_places_api"
+        and place is not None
+        and (
+            place.address_display_en
+            or place.address_display_en_source
+            or place.category_display_en
+            or place.category_display_en_source
+            or place.plus_code
+            or place.description
+            or place.search_result_description
+            or place.search_result_url
+            or place.review_topics
+            or place.reviews
+            or place.about_sections
+        )
     )
 
 
@@ -5773,7 +5807,16 @@ def merge_page_place_into_api_entry(
     if google_maps_uri_strength(page_place.google_maps_uri) > google_maps_uri_strength(api_place.google_maps_uri):
         api_place.google_maps_uri = page_place.google_maps_uri
 
+    api_entry.merged_sources = merged_enrichment_sources(api_entry, page_entry)
     return api_entry
+
+
+def merged_enrichment_sources(*entries: EnrichmentCacheEntry) -> list[Literal["google_maps_page", "google_places_api"]]:
+    sources: list[Literal["google_maps_page", "google_places_api"]] = []
+    for source in ("google_maps_page", "google_places_api"):
+        if any(entry.source == source or source in entry.merged_sources for entry in entries):
+            sources.append(source)
+    return sources
 
 
 def preserve_existing_enrichment(
@@ -5989,10 +6032,8 @@ def sqlite_bool_or_none(value: bool | None) -> int | None:
 
 
 def serialized_enrichment_cache_entry(entry: EnrichmentCacheEntry) -> str:
-    canonicalized_entry = canonicalized_enrichment_cache_entry_copy(entry)
-    assert canonicalized_entry is not None
     return json.dumps(
-        canonicalized_entry.model_dump(mode="json", exclude_none=True),
+        enrichment_cache_entry_payload(entry),
         ensure_ascii=False,
         separators=(",", ":"),
     )
@@ -6262,10 +6303,7 @@ def build_places_sqlite_signature(
         "schema_sha256": hashlib.sha256(PLACES_SQLITE_SCHEMA_SQL.encode("utf-8")).hexdigest(),
         "enrichment_caches": {
             slug: {
-                place_id: canonicalized_enrichment_cache_entry_copy(entry).model_dump(
-                    mode="json",
-                    exclude_none=True,
-                )
+                place_id: enrichment_cache_entry_payload(entry)
                 for place_id, entry in sorted(cache_payload.items())
             }
             for slug, cache_payload in sorted(enrichment_caches.items())

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -137,6 +137,7 @@ LOW_CONFIDENCE_CACHE_TTL = timedelta(days=3)
 RATINGS_CACHE_TTL = timedelta(days=7)
 NON_OPERATIONAL_CACHE_TTL = timedelta(days=3)
 OPERATIONAL_CACHE_TTL = timedelta(days=14)
+PHOTOLESS_REAL_PLACE_CACHE_TTL = timedelta(days=1)
 RAW_SOURCE_CACHE_TTL = timedelta(days=14)
 RAW_SOURCE_REFRESH_JITTER = timedelta(days=3)
 STRONG_MATCH_SCORE = 45
@@ -5490,9 +5491,17 @@ def cache_refresh_reason(
     if cache_entry.input_signature != expected_signature:
         return "raw-place-changed"
 
+    if cache_entry_needs_photo_url_retry(cache_entry):
+        try:
+            fetched_at_dt = parse_metadata_datetime(cache_entry.fetched_at)
+        except ValueError:
+            return "invalid-fetched-at"
+        if datetime.now(UTC) - fetched_at_dt >= PHOTOLESS_REAL_PLACE_CACHE_TTL:
+            return "missing-photo-url"
+
     if cache_entry.refresh_after:
         try:
-            refresh_after_dt = datetime.fromisoformat(cache_entry.refresh_after)
+            refresh_after_dt = parse_metadata_datetime(cache_entry.refresh_after)
         except ValueError:
             return "invalid-refresh-after"
         if datetime.now(UTC) >= refresh_after_dt:
@@ -5500,7 +5509,7 @@ def cache_refresh_reason(
         return None
 
     try:
-        fetched_at_dt = datetime.fromisoformat(cache_entry.fetched_at)
+        fetched_at_dt = parse_metadata_datetime(cache_entry.fetched_at)
     except ValueError:
         return "invalid-fetched-at"
     if datetime.now(UTC) - fetched_at_dt > OPERATIONAL_CACHE_TTL:
@@ -5516,6 +5525,7 @@ ENRICHMENT_REFRESH_REASON_PRIORITY = {
     "invalid-refresh-after": 2,
     "invalid-fetched-at": 2,
     "missing-input-signature": 2,
+    "missing-photo-url": 3,
     "legacy-cache-entry": 3,
     "refresh-window-expired": 4,
     "forced": 5,
@@ -5627,6 +5637,8 @@ def cache_refresh_ttl(cache_entry: EnrichmentCacheEntry) -> timedelta:
         return LOW_CONFIDENCE_CACHE_TTL
 
     place = cache_entry.place
+    if cache_entry_needs_photo_url_retry(cache_entry):
+        return PHOTOLESS_REAL_PLACE_CACHE_TTL
     if place.business_status and place.business_status != "OPERATIONAL":
         return NON_OPERATIONAL_CACHE_TTL
     if place.rating is not None or place.user_rating_count is not None:
@@ -5672,6 +5684,27 @@ def build_cache_entry(
 
 def cache_entry_has_publishable_enrichment(entry: EnrichmentCacheEntry | None) -> bool:
     return bool(entry and entry.error is None and entry.matched is True and entry.place is not None)
+
+
+def cache_entry_needs_photo_url_retry(entry: EnrichmentCacheEntry) -> bool:
+    place = entry.place
+    return bool(
+        entry.error is None
+        and entry.matched is True
+        and entry.source != "google_places_api"
+        and place is not None
+        and not place.main_photo_url
+        and not place.photo_url
+        and enrichment_place_has_real_place_identity(place)
+    )
+
+
+def enrichment_place_has_real_place_identity(place: EnrichmentPlace) -> bool:
+    return bool(
+        place.google_place_id
+        or place.google_place_resource_name
+        or resolved_google_maps_url_is_place_page(place.google_maps_uri)
+    )
 
 
 def append_unique_reason(reasons: list[str], reason: str) -> None:
@@ -8511,7 +8544,7 @@ def coerce_json_object_list(value: Any) -> list[dict[str, Any]]:
     return items
 
 
-SEMANTIC_LLM_PROMPT_VERSION = "favorite-places-semantic-v9"
+SEMANTIC_LLM_PROMPT_VERSION = "favorite-places-semantic-v11"
 SEMANTIC_ENRICHMENT_SYSTEM_PROMPT = """
 You classify saved places for a travel guide. Return only compact JSON.
 
@@ -8545,6 +8578,8 @@ Description:
 - Do not mention reviewers, reviews, review counts, or source language such as "reviews say" or "customers praise."
 - Use direct factual wording instead of review/source phrasing: write "with warm service" rather than "praised for warm service."
 - Avoid hype and ranking claims such as "one of the best," "one of the most," "most photographed," "top-rated," "widely hailed," or "regarded as."
+- Do not write curation-meta copy about the saved list, favorite-worthiness, surfacing, ranking, manual curation, or tourist checklists.
+- Do not write accessibility or amenities boilerplate such as wheelchair accessibility, accessible facilities, accessible amenities, parking, restrooms, or service options unless the place is primarily about accessibility.
 - Do not preserve individual complaints.
 - Do not include one-off caveats or reviewer-style warnings such as "just expect..." or "separate charge."
 - Do not repeat raw UI labels, badges, or attributes like Accessibility, Service options, wheelchair-accessible, or LGBTQ+-friendly unless they are central to the place identity.
@@ -9755,6 +9790,10 @@ def sanitize_semantic_description(value: Any) -> str | None:
         return None
     if looks_like_semantic_description_review_source_leak(description):
         return None
+    if looks_like_semantic_description_curation_meta(description):
+        return None
+    if looks_like_semantic_description_attribute_boilerplate(description):
+        return None
     return description
 
 
@@ -9807,6 +9846,42 @@ SEMANTIC_DESCRIPTION_REVIEW_SOURCE_LEAK_RE = re.compile(
 
 def looks_like_semantic_description_review_source_leak(value: str) -> bool:
     return SEMANTIC_DESCRIPTION_REVIEW_SOURCE_LEAK_RE.search(value) is not None
+
+
+SEMANTIC_DESCRIPTION_CURATION_META_RE = re.compile(
+    r"\b(?:"
+    r"favorite[-\s]?worthy|"
+    r"surface(?:s|d|ing)?\s+(?:without|in|on|as|for)\b|"
+    r"(?:extra\s+)?manual\s+curation|"
+    r"tourist\s+checklists?|"
+    r"personal\s+recommendation|"
+    r"saved[-\s]?list\s+(?:context|copy|curation|metadata|note)|"
+    r"curation\s+(?:copy|metadata|note)"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def looks_like_semantic_description_curation_meta(value: str) -> bool:
+    return SEMANTIC_DESCRIPTION_CURATION_META_RE.search(value) is not None
+
+
+SEMANTIC_DESCRIPTION_ATTRIBUTE_BOILERPLATE_RE = re.compile(
+    r"\b(?:"
+    r"(?:full|easy)?\s*wheelchair\s+accessibility|"
+    r"wheelchair[-\s]?(?:friendly|access|accessible|amenit(?:y|ies))|"
+    r"(?:family[-\s]?friendly|notable|comprehensive|visitor|onsite)?\s*accessibility(?:[-\s]?(?:conscious|features?|amenit(?:y|ies)))?|"
+    r"accessible\s+(?:amenit(?:y|ies)|facilit(?:y|ies)|parking|restrooms?|seating|setting|green\s+space)|"
+    r"(?:with|featuring|offering|and)\s+(?:accessible|full accessibility)\b|"
+    r"full\s+accessibility(?:\s+features?)?|"
+    r"\bthis\s+accessible\s+\w+"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def looks_like_semantic_description_attribute_boilerplate(value: str) -> bool:
+    return SEMANTIC_DESCRIPTION_ATTRIBUTE_BOILERPLATE_RE.search(value) is not None
 
 
 def usable_semantic_description(

--- a/scripts/pipeline_models.py
+++ b/scripts/pipeline_models.py
@@ -227,6 +227,7 @@ class EnrichmentCacheEntry(PipelineModel):
     last_verified_at: str | None = None
     refresh_after: str | None = None
     source: Literal["google_maps_page", "google_places_api"] | None = None
+    merged_sources: list[Literal["google_maps_page", "google_places_api"]] = Field(default_factory=list)
     query: str
     input_signature: str | None = None
     matched: bool | None = None

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -9508,6 +9508,7 @@ class BuildDataTests(unittest.TestCase):
             [{"title": "Amenities", "items": [{"label": "Restroom"}]}],
         )
         self.assertEqual(entry.place.google_maps_uri, "https://maps.google.com/?cid=1")
+        self.assertEqual(entry.merged_sources, ["google_maps_page", "google_places_api"])
 
     def test_fetch_places_enrichment_keeps_page_result_when_api_fallback_fails(self) -> None:
         place = RawPlace(
@@ -10923,6 +10924,53 @@ class BuildDataTests(unittest.TestCase):
         )
 
         self.assertIsNone(refresh_reason)
+
+    def test_cache_refresh_reason_retries_merged_api_page_entry_without_photo_url(self) -> None:
+        place = RawPlace(
+            name="Tokyo Metropolitan Government Building",
+            address=None,
+            maps_url="https://maps.google.com/?cid=6924439272315041697",
+            cid="6924439272315041697",
+            lat=35.6894807,
+            lng=139.6916863,
+        )
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at=(
+                datetime.now(UTC)
+                - build_data.PHOTOLESS_REAL_PLACE_CACHE_TTL
+                - timedelta(hours=1)
+            ).isoformat(),
+            refresh_after=(datetime.now(UTC) + timedelta(days=6)).isoformat(),
+            source="google_places_api",
+            merged_sources=["google_maps_page", "google_places_api"],
+            query="Tokyo Metropolitan Government Building, Tokyo, Japan",
+            input_signature=build_data.enrichment_input_signature(
+                place,
+                city_name="Tokyo",
+                country_name="Japan",
+            ),
+            matched=True,
+            score=build_data.STRONG_MATCH_SCORE,
+            place=EnrichmentPlace(
+                display_name="Tokyo Metropolitan Government Building",
+                formatted_address="2 Chome-8-1 Nishishinjuku, Shinjuku City, Tokyo 160-0023, Japan",
+                google_place_id="ChIJ-d5eaQCNGGARG9gXAP513iw",
+                google_place_resource_name="places/ChIJ-d5eaQCNGGARG9gXAP513iw",
+                google_maps_uri=(
+                    "https://www.google.com/maps/place/Tokyo+Metropolitan+Government+Building/"
+                    "@35.6895569,139.6919911,17z"
+                ),
+            ),
+        )
+
+        refresh_reason = build_data.cache_refresh_reason(
+            place,
+            cache_entry,
+            city_name="Tokyo",
+            country_name="Japan",
+        )
+
+        self.assertEqual(refresh_reason, "missing-photo-url")
 
     def test_cache_refresh_ttl_uses_short_retry_for_real_place_without_photo_url(self) -> None:
         cache_entry = EnrichmentCacheEntry(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -6068,7 +6068,7 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(fake_client.started["as_type"], "generation")
         self.assertEqual(fake_client.started["name"], "favorite-places.semantic-enrichment")
         self.assertEqual(fake_client.started["model"], "gpt-test")
-        self.assertEqual(fake_client.started["metadata"]["prompt_version"], "favorite-places-semantic-v9")
+        self.assertEqual(fake_client.started["metadata"]["prompt_version"], "favorite-places-semantic-v11")
         self.assertTrue(fake_client.manager.closed)
         self.assertEqual(
             fake_client.observation.updates[-1]["usage_details"],
@@ -6583,6 +6583,29 @@ class BuildDataTests(unittest.TestCase):
                 "plats à partager, des cocktails raffinés et une sélection de vins "
                 "méticuleusement choisis / Annette reçoit dans un décor tendance et feutré"
             ),
+        ):
+            with self.subTest(description=description):
+                self.assertIsNone(build_data.sanitize_semantic_description(description))
+
+    def test_semantic_description_rejects_curation_meta_copy(self) -> None:
+        for description in (
+            "A favorite-worthy dinner stop, so it should surface without extra manual curation.",
+            "Feels more like a personal recommendation than a tourist checklist stop.",
+            "Saved-list metadata for a top pick in the guide.",
+        ):
+            with self.subTest(description=description):
+                self.assertIsNone(build_data.sanitize_semantic_description(description))
+
+    def test_semantic_description_rejects_attribute_boilerplate(self) -> None:
+        for description in (
+            "Upscale restaurant in De Pijp with full wheelchair accessibility and a refined dining experience.",
+            "A scenic waterfall with suspension bridges and observation decks, featuring free admission and accessible facilities.",
+            "Women-owned taquería offering fast service, great cocktails, and accessible amenities.",
+            "High-end Hawaiian fusion dishes served in a contemporary, accessible setting.",
+            "This accessible izakaya offers counter and outdoor seating with accommodating staff.",
+            "A cozy spot drawing solo diners and accessibility-conscious visitors alike.",
+            "Museum showcasing vintage cars with a multilingual audio guide and family-friendly accessibility.",
+            "Hand-made dumplings served in a cozy setting with notable accessibility.",
         ):
             with self.subTest(description=description):
                 self.assertIsNone(build_data.sanitize_semantic_description(description))
@@ -10735,6 +10758,189 @@ class BuildDataTests(unittest.TestCase):
         )
 
         self.assertEqual(refresh_reason, "raw-place-changed")
+
+    def test_cache_refresh_reason_retries_old_real_place_without_photo_url(self) -> None:
+        place = RawPlace(
+            name="Tokyo Metropolitan Government Building",
+            address=None,
+            maps_url="https://maps.google.com/?cid=6924439272315041697",
+            cid="6924439272315041697",
+            lat=35.6894807,
+            lng=139.6916863,
+        )
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at=(
+                datetime.now(UTC)
+                - build_data.PHOTOLESS_REAL_PLACE_CACHE_TTL
+                - timedelta(hours=1)
+            ).isoformat(),
+            refresh_after=(datetime.now(UTC) + timedelta(days=6)).isoformat(),
+            source="google_maps_page",
+            query="Tokyo Metropolitan Government Building, Tokyo, Japan",
+            input_signature=build_data.enrichment_input_signature(
+                place,
+                city_name="Tokyo",
+                country_name="Japan",
+            ),
+            matched=True,
+            score=build_data.STRONG_MATCH_SCORE,
+            place=EnrichmentPlace(
+                display_name="Tokyo Metropolitan Government Building",
+                formatted_address="2 Chome-8-1 Nishishinjuku, Shinjuku City, Tokyo 160-0023, Japan",
+                google_place_id="ChIJ-d5eaQCNGGARG9gXAP513iw",
+                google_maps_uri=(
+                    "https://www.google.com/maps/place/Tokyo+Metropolitan+Government+Building/"
+                    "@35.6895569,139.6919911,17z"
+                ),
+            ),
+        )
+
+        refresh_reason = build_data.cache_refresh_reason(
+            place,
+            cache_entry,
+            city_name="Tokyo",
+            country_name="Japan",
+        )
+
+        self.assertEqual(refresh_reason, "missing-photo-url")
+
+    def test_cache_refresh_reason_keeps_fresh_real_place_without_photo_url(self) -> None:
+        place = RawPlace(
+            name="Zass",
+            address=None,
+            maps_url="https://maps.google.com/?cid=1385867432453075065",
+            cid="1385867432453075065",
+            lat=40.6231077,
+            lng=14.5037538,
+        )
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at=datetime.now(UTC).isoformat(),
+            refresh_after=(datetime.now(UTC) + timedelta(days=1)).isoformat(),
+            source="google_maps_page",
+            query="Zass, Amalfi Coast, Italy",
+            input_signature=build_data.enrichment_input_signature(
+                place,
+                city_name="Amalfi Coast",
+                country_name="Italy",
+            ),
+            matched=True,
+            score=build_data.STRONG_MATCH_SCORE,
+            place=EnrichmentPlace(
+                display_name="Zass",
+                formatted_address="Via Laurito, 2, 84017 Positano SA, Italy",
+                google_place_id="ChIJTTegVVqXOxMRX4nA4MSAv-I",
+            ),
+        )
+
+        refresh_reason = build_data.cache_refresh_reason(
+            place,
+            cache_entry,
+            city_name="Amalfi Coast",
+            country_name="Italy",
+        )
+
+        self.assertIsNone(refresh_reason)
+
+    def test_cache_refresh_reason_handles_naive_photo_retry_timestamp(self) -> None:
+        place = RawPlace(
+            name="Tokyo Metropolitan Government Building",
+            address=None,
+            maps_url="https://maps.google.com/?cid=6924439272315041697",
+            cid="6924439272315041697",
+            lat=35.6894807,
+            lng=139.6916863,
+        )
+        naive_fetched_at = (
+            datetime.now(UTC)
+            - build_data.PHOTOLESS_REAL_PLACE_CACHE_TTL
+            - timedelta(hours=1)
+        ).replace(tzinfo=None)
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at=naive_fetched_at.isoformat(),
+            refresh_after=(datetime.now(UTC) + timedelta(days=6)).isoformat(),
+            source="google_maps_page",
+            query="Tokyo Metropolitan Government Building, Tokyo, Japan",
+            input_signature=build_data.enrichment_input_signature(
+                place,
+                city_name="Tokyo",
+                country_name="Japan",
+            ),
+            matched=True,
+            score=build_data.STRONG_MATCH_SCORE,
+            place=EnrichmentPlace(
+                display_name="Tokyo Metropolitan Government Building",
+                google_place_id="ChIJ-d5eaQCNGGARG9gXAP513iw",
+            ),
+        )
+
+        refresh_reason = build_data.cache_refresh_reason(
+            place,
+            cache_entry,
+            city_name="Tokyo",
+            country_name="Japan",
+        )
+
+        self.assertEqual(refresh_reason, "missing-photo-url")
+
+    def test_cache_refresh_reason_does_not_photo_retry_api_only_entry(self) -> None:
+        place = RawPlace(
+            name="Michael's",
+            address="9777 Las Vegas Blvd S, Las Vegas, NV 89183, USA",
+            maps_url="https://maps.google.com/?cid=3558656038997305861",
+            cid="3558656038997305861",
+            lat=36.012782,
+            lng=-115.175648,
+        )
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at=(
+                datetime.now(UTC)
+                - build_data.PHOTOLESS_REAL_PLACE_CACHE_TTL
+                - timedelta(hours=1)
+            ).isoformat(),
+            refresh_after=(datetime.now(UTC) + timedelta(days=6)).isoformat(),
+            source="google_places_api",
+            query="Michael's, Las Vegas",
+            input_signature=build_data.enrichment_input_signature(
+                place,
+                city_name="Las Vegas",
+                country_name="USA",
+            ),
+            matched=True,
+            score=build_data.STRONG_MATCH_SCORE,
+            place=EnrichmentPlace(
+                display_name="Michael's",
+                formatted_address="9777 Las Vegas Blvd S, Las Vegas, NV 89183, USA",
+                google_place_id="ChIJwZX119rOyIAR5Tx-nEKkSgE",
+                google_place_resource_name="places/ChIJwZX119rOyIAR5Tx-nEKkSgE",
+            ),
+        )
+
+        refresh_reason = build_data.cache_refresh_reason(
+            place,
+            cache_entry,
+            city_name="Las Vegas",
+            country_name="USA",
+        )
+
+        self.assertIsNone(refresh_reason)
+
+    def test_cache_refresh_ttl_uses_short_retry_for_real_place_without_photo_url(self) -> None:
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at=datetime.now(UTC).isoformat(),
+            source="google_maps_page",
+            query="Tokyo Metropolitan Government Building, Tokyo, Japan",
+            matched=True,
+            score=build_data.STRONG_MATCH_SCORE,
+            place=EnrichmentPlace(
+                display_name="Tokyo Metropolitan Government Building",
+                google_place_id="ChIJ-d5eaQCNGGARG9gXAP513iw",
+            ),
+        )
+
+        self.assertEqual(
+            build_data.cache_refresh_ttl(cache_entry),
+            build_data.PHOTOLESS_REAL_PLACE_CACHE_TTL,
+        )
 
     def test_build_places_sqlite_signature_changes_when_version_or_schema_changes(self) -> None:
         raw = RawSavedList(


### PR DESCRIPTION
## Summary
- retry matched real-place enrichment rows that still have no photo URL after a short 1-day photo retry window
- refresh the place cache and add five recovered optimized place photo assets
- tighten semantic-description cleanup for curation-meta and accessibility/amenities boilerplate, plus Tokyo override copy

## Root Cause
Matched places without photo URLs were treated as fresh under the normal enrichment TTL, so sparse Google Maps scrapes could remain photoless for a week or more unless manually forced.

## Validation
- `uv run python -m unittest tests.python.test_build_data.BuildDataTests.test_cache_refresh_reason_retries_old_real_place_without_photo_url tests.python.test_build_data.BuildDataTests.test_cache_refresh_reason_keeps_fresh_real_place_without_photo_url tests.python.test_build_data.BuildDataTests.test_cache_refresh_ttl_uses_short_retry_for_real_place_without_photo_url tests.python.test_build_data.BuildDataTests.test_cache_refresh_reason_invalidates_legacy_unbiased_name_only_search_entry tests.python.test_build_data.BuildDataTests.test_semantic_description_rejects_curation_meta_copy tests.python.test_build_data.BuildDataTests.test_semantic_description_rejects_attribute_boilerplate`
- `uv run python scripts/build_data.py`
- `bun run check`
- `bun run build`