### PR TITLE
[codex] Prevent refresh browser launch timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.11.6"
           enable-cache: true
@@ -145,7 +145,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.11.6"
           enable-cache: true

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -180,7 +180,7 @@ jobs:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.11.6"
           enable-cache: true

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Set up uv
         if: steps.e2e_tests.outputs.should_run == 'true'
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "0.11.6"
           enable-cache: true

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -342,6 +342,8 @@ class PlacesSqliteRows:
 
 SCRAPER_SESSION_RESET_ERROR_MARKERS = SCRAPER_BLOCK_ERROR_MARKERS + (
     "failed to load http cookie jar",
+    "failed to launch browser context",
+    "launch_persistent_context",
 )
 COUNTRY_LOCALITY_ALIASES = (
     "England",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -31,6 +31,19 @@ from scripts.pipeline_models import (
 
 
 class BuildDataTests(unittest.TestCase):
+    def test_scraper_session_reset_detects_browser_launch_failures(self) -> None:
+        cases = (
+            "Failed to launch browser context: Timeout 180000ms exceeded",
+            "BrowserType.launch_persistent_context: Timeout 180000ms exceeded",
+        )
+        for message in cases:
+            with self.subTest(message=message):
+                self.assertTrue(
+                    build_data.should_reset_scraper_session(
+                        build_data.ScrapeError(message)
+                    )
+                )
+
     def test_raw_saved_list_keeps_owner_metadata_from_json(self) -> None:
         saved_list = RawSavedList.model_validate(
             {

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -2147,10 +2147,13 @@ def collect_place_snapshot(
     overview_screenshot_path: Path | None = None,
 ) -> dict[str, object]:
     """Collect a normalized DOM snapshot for a Google Maps place page."""
-    context = _launch_browser_context(
-        headless=headless,
-        browser_session=browser_session,
-    )
+    try:
+        context = _launch_browser_context(
+            headless=headless,
+            browser_session=browser_session,
+        )
+    except Exception as exc:  # pragma: no cover - browser launch error path
+        raise ScrapeError(f"Failed to launch browser context: {exc}") from exc
     try:
         return _collect_place_snapshot_with_context(
             place_url,

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -167,6 +167,14 @@ class PlaceScraperTests(unittest.TestCase):
             review_signal.assert_not_called()
             self.assertEqual(screenshot_path.read_bytes(), b"screenshot")
 
+    def test_collect_place_snapshot_wraps_browser_launch_failures(self) -> None:
+        with patch(
+            "gmaps_scraper.place_scraper._launch_browser_context",
+            side_effect=RuntimeError("context launch failed"),
+        ):
+            with self.assertRaisesRegex(ScrapeError, "Failed to launch browser context"):
+                collect_place_snapshot("https://www.google.com/maps/place/Den")
+
     def test_scrape_places_reuses_context_and_retries_quality_flags(self) -> None:
         class _FakeContext:
             def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- wrap Google Maps place browser launch failures as recoverable scraper errors
- rotate scraper session state after launch-context failures so stuck browser profiles get retried cleanly
- update setup-uv from v6 to v8.1.0 so GitHub Actions uses Node 24

## Root cause
The scheduled data refresh failed when Playwright timed out launching a persistent CloakBrowser context for a Google Maps enrichment job. That timeout escaped the per-place recoverable scrape path, so the worker future re-raised and failed the whole workflow.

## Validation
- `uv run python3 -m unittest vendor/gmaps-scraper/tests/test_place_scraper.py tests/python/test_build_data.py`
- `bun run check`
- `bun run build`
- `git diff --check`
- commit hooks: ruff and mypy