### PR TITLE
Hide map select controls for unmapped places

### DIFF
--- a/src/components/PlaceCard.astro
+++ b/src/components/PlaceCard.astro
@@ -66,6 +66,7 @@ const whyRecommendedHtml = renderRichText(place.why_recommended ?? place.note);
 const placePhotosEnabled = (import.meta.env.PUBLIC_PLACE_PHOTOS || "on").toLowerCase() !== "off";
 const photoSrc = place.main_photo_path ?? (guidePhotoMode === "remote_url" ? place.photo_url : null);
 const hasPhoto = Boolean(siteConfig.placeCard.showPhoto && placePhotosEnabled && photoSrc);
+const hasMapCoordinates = place.lat !== null && place.lng !== null;
 const ratingValue = typeof place.rating === "number" ? place.rating : null;
 const reviewCount = typeof place.user_rating_count === "number" ? place.user_rating_count : null;
 const priceRange = typeof place.price_range === "string" && place.price_range.trim().length > 0 ? place.price_range.trim() : null;
@@ -354,15 +355,17 @@ const displayedPlaceAttribution = showPlaceAttribution ? placeAttribution : null
       <div class="place-card-name-row">
         <h3 class="ui-card-title" title={place.name}>{place.name}</h3>
         <div class="place-card-title-actions">
-          <button
-            type="button"
-            class="place-card-map-select"
-            data-place-card-map-select
-            aria-label={`Show ${place.name} on the guide map`}
-            title="Show on guide map"
-          >
-            <span class="place-card-map-select-icon" aria-hidden="true" set:html={markerSvg} />
-          </button>
+          {hasMapCoordinates && (
+            <button
+              type="button"
+              class="place-card-map-select"
+              data-place-card-map-select
+              aria-label={`Show ${place.name} on the guide map`}
+              title="Show on guide map"
+            >
+              <span class="place-card-map-select-icon" aria-hidden="true" set:html={markerSvg} />
+            </button>
+          )}
           {isTemporarilyClosed && (
             <button
               type="button"

--- a/tests/frontend/guideMapInteractions.test.mjs
+++ b/tests/frontend/guideMapInteractions.test.mjs
@@ -194,8 +194,12 @@ describe("guide map interactions", () => {
     expect(placeCard).toContain(
       "getMapMarkerColors(place.marker_icon, { topPick: featured || place.top_pick })",
     );
+    expect(placeCard).toContain(
+      "const hasMapCoordinates = place.lat !== null && place.lng !== null;",
+    );
     expect(placeCard).toContain('class="place-card-name-row"');
     expect(placeCard).toContain('class="place-card-marker"');
+    expect(placeCard).toContain("{hasMapCoordinates && (");
     expect(placeCard).toContain("data-place-card-map-select");
     expect(placeCard).toContain("aria-label={`Show ${place.name} on the guide map`}");
     expect(placeCard).toContain('class="place-card-map-link"');


### PR DESCRIPTION
## Summary
- Only render the place-card “show on guide map” button when the place has both `lat` and `lng`
- Match the same mappable-place condition used by `GuideMap` before it builds map markers
- Add a frontend regression assertion for the conditional render

## Test plan
- [x] `bun run check`
- [x] `bun run test:frontend`
- [x] `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Show on guide map" button now only appears when valid map coordinates are available for a place, preventing display of non-functional buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->