### PR TITLE
Coalesce map accessibility patching

### DIFF
--- a/src/lib/mapAccessibility.ts
+++ b/src/lib/mapAccessibility.ts
@@ -15,7 +15,7 @@ function mapRoots(root?: HTMLElement | null) {
 }
 
 function anchorAccessibleName(anchor: HTMLAnchorElement): string | null {
-  const text = anchor.innerText?.trim();
+  const text = anchor.textContent?.trim();
   if (text) return text;
 
   const ariaLabel = anchor.getAttribute("aria-label")?.trim();
@@ -37,7 +37,13 @@ function anchorAccessibleName(anchor: HTMLAnchorElement): string | null {
 
 function patchAnchors(container: ParentNode) {
   container.querySelectorAll<HTMLAnchorElement>("a[href]").forEach((anchor) => {
-    if (anchor.innerText?.trim() || anchor.getAttribute("aria-label")?.trim()) return;
+    if (
+      anchor.textContent?.trim() ||
+      anchor.getAttribute("aria-label")?.trim() ||
+      anchor.getAttribute("aria-labelledby")?.trim()
+    ) {
+      return;
+    }
 
     const imgAlt = anchor.querySelector("img")?.getAttribute("alt")?.trim();
     if (imgAlt) {
@@ -76,24 +82,39 @@ function patchMapAccessibility(label: string, root?: HTMLElement | null) {
 
 export function installMapAccessibility(root: HTMLElement, label: string) {
   const patch = () => patchMapAccessibility(label, root);
+  let pendingPatchFrame: number | null = null;
+
+  const schedulePatch = () => {
+    if (pendingPatchFrame !== null) return;
+
+    pendingPatchFrame = window.requestAnimationFrame(() => {
+      pendingPatchFrame = null;
+      patch();
+    });
+  };
 
   patch();
 
   const observers = mapRoots(root).map((mapRoot) => {
-    const observer = new MutationObserver(patch);
+    const observer = new MutationObserver(schedulePatch);
     observer.observe(mapRoot, {
       attributes: true,
-      attributeFilter: ["href", "src", "title", "aria-label"],
+      attributeFilter: ["href", "src", "title", "aria-label", "aria-labelledby"],
       childList: true,
       subtree: true,
     });
     return observer;
   });
 
-  const delayedPatchTimers = [250, 1000, 3000].map((delay) => window.setTimeout(patch, delay));
+  const delayedPatchTimers = [250, 1000, 3000].map((delay) =>
+    window.setTimeout(schedulePatch, delay),
+  );
 
   return () => {
     observers.forEach((observer) => observer.disconnect());
     delayedPatchTimers.forEach((timer) => window.clearTimeout(timer));
+    if (pendingPatchFrame !== null) {
+      window.cancelAnimationFrame(pendingPatchFrame);
+    }
   };
 }

--- a/tests/frontend/mapAccessibility.test.mjs
+++ b/tests/frontend/mapAccessibility.test.mjs
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = () => readFileSync("src/lib/mapAccessibility.ts", "utf8");
+const functionBody = (sourceText, functionName) =>
+  sourceText.slice(
+    sourceText.indexOf(`function ${functionName}`),
+    sourceText.indexOf(`function ${functionName}`) + 800,
+  );
+
+describe("map accessibility patching", () => {
+  it("avoids layout-triggering text reads and preserves existing labelled anchors", () => {
+    const mapAccessibility = source();
+
+    expect(mapAccessibility).not.toContain("innerText");
+    expect(mapAccessibility).toContain("anchor.textContent?.trim()");
+    expect(mapAccessibility).toContain('"aria-label", "aria-labelledby"');
+    expect(functionBody(mapAccessibility, "patchAnchors")).toContain(
+      'anchor.getAttribute("aria-labelledby")?.trim()',
+    );
+    expect(functionBody(mapAccessibility, "anchorAccessibleName")).not.toContain(
+      'anchor.getAttribute("aria-labelledby")?.trim()',
+    );
+  });
+
+  it("coalesces mutation patches through animation frames", () => {
+    const mapAccessibility = source();
+
+    expect(mapAccessibility).toContain("let pendingPatchFrame: number | null = null;");
+    expect(mapAccessibility).toContain("const schedulePatch = () => {");
+    expect(mapAccessibility).toContain("window.requestAnimationFrame");
+    expect(mapAccessibility).toContain("new MutationObserver(schedulePatch)");
+    expect(mapAccessibility).toContain("window.setTimeout(schedulePatch, delay)");
+    expect(mapAccessibility).toContain("window.cancelAnimationFrame(pendingPatchFrame)");
+  });
+});


### PR DESCRIPTION
## Summary
- Use `textContent` instead of `innerText` when checking map anchor text to avoid layout-triggering reads
- Treat `aria-labelledby` as an existing accessible name so map link patching does not overwrite labelled anchors
- Coalesce map MutationObserver and delayed accessibility patch calls through `requestAnimationFrame`, with cleanup cancellation
- Add frontend regression coverage for the map accessibility helper

## Test plan
- [x] `bun run check`
- [x] `bun run test:frontend`
- [x] `bun run build`