### PR TITLE
[codex] Remove trust cache path override

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -255,8 +255,7 @@ Common variables:
 - `GMAPS_SCRAPER_PROXY`: route scraper traffic through a proxy
 - `FAVORITE_PLACES_GMAPS_SCRAPER_STATE_DIR`: optionally override the scraper browser-profile and HTTP-cookie-jar root; point multiple worktrees at the same absolute path to reuse scraper session state
 - `BRAVE_SEARCH_API_KEY` / `BRAVE_API_KEY`: enable Brave Search for optional trust-signal refreshes
-- `FAVORITE_PLACES_TRUST_CACHE_PATH`: override the default SQLite trust-signal cache path
-- `FAVORITE_PLACES_TRUST_STORE_URL`: override trust-signal storage with an explicit SQLAlchemy URL
+- `FAVORITE_PLACES_TRUST_STORE_URL`: override trust-signal storage with an explicit SQLAlchemy URL, including local SQLite file URLs
 - `FAVORITE_PLACES_TRUST_GOOGLE_FALLBACK`: allow Google Search HTML fallback for trust-signal refreshes when set to `true`
 - `FAVORITE_PLACES_MICHELIN_REGION_URLS`: JSON object of `"country/city"` to MICHELIN region URL overrides for full-guide snapshots
 

--- a/scripts/trust_signals.py
+++ b/scripts/trust_signals.py
@@ -39,7 +39,6 @@ except ModuleNotFoundError:
     from pipeline_models import EnrichmentCacheEntry, RawPlace, RawSavedList, TrustSignal
 
 TRUST_STORE_URL_ENV = "FAVORITE_PLACES_TRUST_STORE_URL"
-TRUST_CACHE_PATH_ENV = "FAVORITE_PLACES_TRUST_CACHE_PATH"
 BRAVE_SEARCH_API_KEY_ENV = "BRAVE_SEARCH_API_KEY"
 BRAVE_API_KEY_ENV = "BRAVE_API_KEY"
 GOOGLE_FALLBACK_ENV = "FAVORITE_PLACES_TRUST_GOOGLE_FALLBACK"
@@ -566,10 +565,6 @@ def resolve_trust_store_url(root: Path, *, env: Mapping[str, str] | None = None)
     configured_store_url = env.get(TRUST_STORE_URL_ENV)
     if configured_store_url:
         return configured_store_url
-
-    configured_cache_path = env.get(TRUST_CACHE_PATH_ENV)
-    if configured_cache_path:
-        return sqlite_url_for_path(resolve_path(configured_cache_path, root=root))
 
     return sqlite_url_for_path(default_trust_cache_path(root, env=env))
 

--- a/tests/python/test_trust_signals.py
+++ b/tests/python/test_trust_signals.py
@@ -188,7 +188,7 @@ class TrustSignalsTest(unittest.TestCase):
                 patch.dict(
                     os.environ,
                     {
-                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TRUST_STORE_URL": sqlite_url_for_path(db_path),
                         "BRAVE_SEARCH_API_KEY": "",
                         "BRAVE_API_KEY": "",
                         "FAVORITE_PLACES_TRUST_GOOGLE_FALLBACK": "",
@@ -257,7 +257,7 @@ class TrustSignalsTest(unittest.TestCase):
                 patch.dict(
                     os.environ,
                     {
-                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TRUST_STORE_URL": sqlite_url_for_path(db_path),
                         "BRAVE_SEARCH_API_KEY": "brave-key",
                         "BRAVE_API_KEY": "",
                         "FAVORITE_PLACES_TRUST_GOOGLE_FALLBACK": "",
@@ -300,7 +300,7 @@ class TrustSignalsTest(unittest.TestCase):
                 patch.dict(
                     os.environ,
                     {
-                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TRUST_STORE_URL": sqlite_url_for_path(db_path),
                         "BRAVE_SEARCH_API_KEY": "brave-key",
                         "BRAVE_API_KEY": "",
                         "FAVORITE_PLACES_TRUST_GOOGLE_FALLBACK": "",
@@ -367,7 +367,7 @@ class TrustSignalsTest(unittest.TestCase):
                 patch.dict(
                     os.environ,
                     {
-                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TRUST_STORE_URL": sqlite_url_for_path(db_path),
                         "FAVORITE_PLACES_TABELOG_SOURCE_URLS": '{"award":"https://award.tabelog.com/en/restaurants"}',
                         "BRAVE_SEARCH_API_KEY": "",
                         "BRAVE_API_KEY": "",
@@ -427,7 +427,7 @@ class TrustSignalsTest(unittest.TestCase):
                 patch.dict(
                     os.environ,
                     {
-                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TRUST_STORE_URL": sqlite_url_for_path(db_path),
                         "FAVORITE_PLACES_TABELOG_SOURCE_URLS": '{"hyakumeiten":"https://award.tabelog.com/hyakumeiten"}',
                         "BRAVE_SEARCH_API_KEY": "",
                         "BRAVE_API_KEY": "",
@@ -514,7 +514,7 @@ class TrustSignalsTest(unittest.TestCase):
                 patch.dict(
                     os.environ,
                     {
-                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TRUST_STORE_URL": sqlite_url_for_path(db_path),
                         "FAVORITE_PLACES_TABELOG_SOURCE_URLS": '{"hyakumeiten":"https://award.tabelog.com/hyakumeiten"}',
                         "BRAVE_SEARCH_API_KEY": "",
                         "BRAVE_API_KEY": "",


### PR DESCRIPTION
## Summary

- remove `FAVORITE_PLACES_TRUST_CACHE_PATH` support from trust-store resolution
- use `FAVORITE_PLACES_TRUST_STORE_URL` for explicit SQLite file overrides in trust-signal tests
- keep `XDG_CACHE_HOME` as the standard way to move the default cache root

## Why

`FAVORITE_PLACES_TRUST_STORE_URL` already supports local SQLite file URLs, so the separate path-only override created two ways to configure the same thing. Keeping only the SQLAlchemy URL override reduces configuration surface area.

## Validation

- `uv run python3 -m unittest tests.python.test_trust_signals`
- commit hooks: vendor Ruff, vendor mypy, root Ruff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated trust signal store configuration handling to use a single environment variable for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->