### PR TITLE
Stagger Tabelog trust refreshes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
               - "bunfig.toml"
               - "bun.lock"
               - "tsconfig.json"
+              - "vitest.config.mjs"
               - "tests/frontend/**"
             python_pipeline:
               - "scripts/**"

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -256,8 +256,11 @@ jobs:
           git add -A -- \
             site/data/raw \
             site/data/cache \
-            site/public/author-photos \
             site/public/place-photos
+
+          if [[ -d site/public/author-photos ]]; then
+            git add -A -- site/public/author-photos
+          fi
 
           if git diff --cached --quiet; then
             echo "changed=false" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -263,14 +263,19 @@ jobs:
           fi
           site_dir="${site_dir%/}"
 
+          stage_optional_path() {
+            local path="$1"
+            if [[ -e "${path}" ]] || git ls-files -- "${path}" | grep -q .; then
+              git add -A -- "${path}"
+            fi
+          }
+
           git add -A -- \
             "${site_dir}/data/raw" \
-            "${site_dir}/data/cache" \
-            "${site_dir}/public/place-photos"
+            "${site_dir}/data/cache"
 
-          if [[ -d "${site_dir}/public/author-photos" ]]; then
-            git add -A -- "${site_dir}/public/author-photos"
-          fi
+          stage_optional_path "${site_dir}/public/place-photos"
+          stage_optional_path "${site_dir}/public/author-photos"
 
           if git diff --cached --quiet; then
             echo "changed=false" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -253,13 +253,23 @@ jobs:
         run: |
           set -euo pipefail
 
-          git add -A -- \
-            site/data/raw \
-            site/data/cache \
-            site/public/place-photos
+          site_dir="${FAVORITE_PLACES_SITE_DIR:-}"
+          if [[ -z "${site_dir}" ]]; then
+            if [[ -e site ]]; then
+              site_dir="site"
+            else
+              site_dir="site.example"
+            fi
+          fi
+          site_dir="${site_dir%/}"
 
-          if [[ -d site/public/author-photos ]]; then
-            git add -A -- site/public/author-photos
+          git add -A -- \
+            "${site_dir}/data/raw" \
+            "${site_dir}/data/cache" \
+            "${site_dir}/public/place-photos"
+
+          if [[ -d "${site_dir}/public/author-photos" ]]; then
+            git add -A -- "${site_dir}/public/author-photos"
           fi
 
           if git diff --cached --quiet; then

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -256,6 +256,7 @@ jobs:
           git add -A -- \
             site/data/raw \
             site/data/cache \
+            site/public/author-photos \
             site/public/place-photos
 
           if git diff --cached --quiet; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dev = [
 ]
 
 [tool.uv]
-exclude-newer = "7 days"
+exclude-newer = "P7D"
 
 [tool.uv.sources]
 gmaps-scraper = { path = "vendor/gmaps-scraper" }

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -2567,6 +2567,10 @@ def load_all_trust_signal_maps(
 
     store = TrustSignalStore(store_url, initialize=False)
     trust_signal_maps: dict[str, dict[str, list[TrustSignal]]] = {}
+    guide_location_contexts = {
+        slug: guide_location_context(slug, raw)
+        for slug, raw in raw_lists.items()
+    }
     for slug, raw in raw_lists.items():
         trust_signal_maps[slug] = load_trust_signals_for_places(
             store,
@@ -2574,6 +2578,7 @@ def load_all_trust_signal_maps(
             raw,
             enrichment_caches.get(slug, {}),
             stable_place_ids=stable_place_ids,
+            location_context=guide_location_contexts.get(slug),
         )
     return trust_signal_maps
 

--- a/scripts/trust_signals.py
+++ b/scripts/trust_signals.py
@@ -331,6 +331,8 @@ class TrustSignalStore:
         place_keys: Iterable[str],
         *,
         include_low_confidence: bool = False,
+        match_signatures_by_key: Mapping[str, set[str]] | None = None,
+        now: datetime | None = None,
     ) -> dict[str, list[TrustSignal]]:
         keys = sorted({key for key in place_keys if key})
         if not keys:
@@ -340,6 +342,8 @@ class TrustSignalStore:
             rows = connection.execute(
                 select(
                     trust_place_signals.c.place_key,
+                    trust_place_signals.c.refresh_after,
+                    trust_place_signals.c.match_signature,
                     trust_place_signals.c.signal_json,
                 )
                 .where(trust_place_signals.c.place_key.in_(keys))
@@ -351,8 +355,15 @@ class TrustSignalStore:
             ).fetchall()
 
         signals_by_key: dict[str, list[TrustSignal]] = {}
-        for place_key, signal_json in rows:
+        for place_key, refresh_after, match_signature, signal_json in rows:
             if not isinstance(place_key, str) or not isinstance(signal_json, str):
+                continue
+            if now is not None:
+                parsed_refresh_after = metadata_datetime_or_none(refresh_after)
+                if parsed_refresh_after is not None and parsed_refresh_after <= now:
+                    continue
+            expected_match_signatures = match_signatures_by_key.get(place_key) if match_signatures_by_key is not None else None
+            if expected_match_signatures is not None and match_signature not in expected_match_signatures:
                 continue
             signal = TrustSignal.model_validate_json(signal_json)
             if signal.confidence == "low" and not include_low_confidence:
@@ -852,13 +863,27 @@ def load_trust_signals_for_places(
     enrichment_cache: Mapping[str, EnrichmentCacheEntry],
     *,
     stable_place_ids: Mapping[tuple[str, int], str],
+    location_context: tuple[str | None, str | None] | None = None,
+    now: datetime | None = None,
 ) -> dict[str, list[TrustSignal]]:
     lookup_keys: dict[str, list[str]] = {}
+    match_signatures_by_key: dict[str, set[str]] = {}
     all_keys: set[str] = set()
+    city_name = (
+        location_context[0]
+        if location_context is not None and location_context[0]
+        else infer_city_name(raw.title or slug)
+    )
+    country_name = (
+        location_context[1]
+        if location_context is not None and location_context[1]
+        else infer_country_name(raw.title or slug)
+    )
     for index, place in enumerate(raw.places):
         place_id = stable_place_ids.get((slug, index))
         if place_id is None:
             continue
+        match_signature = trust_match_signature(place.name, city_name, country_name)
         keys = trust_place_keys(
             place,
             place_id=place_id,
@@ -866,8 +891,14 @@ def load_trust_signals_for_places(
         )
         lookup_keys[place_id] = keys
         all_keys.update(keys)
+        for key in keys:
+            match_signatures_by_key.setdefault(key, set()).add(match_signature)
 
-    signals_by_key = store.load_signals_for_place_keys(all_keys)
+    signals_by_key = store.load_signals_for_place_keys(
+        all_keys,
+        match_signatures_by_key=match_signatures_by_key,
+        now=now or datetime.now(UTC),
+    )
     signals_by_place_id: dict[str, list[TrustSignal]] = {}
     for place_id, keys in lookup_keys.items():
         signals: list[TrustSignal] = []

--- a/scripts/trust_signals.py
+++ b/scripts/trust_signals.py
@@ -565,6 +565,75 @@ class TrustSignalStore:
         with self.engine.begin() as connection:
             upsert_rows(connection, trust_place_source_urls, rows, ["place_key", "source", "url"])
 
+    def load_place_source_urls(
+        self,
+        place_keys: Iterable[str],
+        *,
+        source: str,
+        match_signature: str,
+        now: datetime,
+    ) -> list[PlaceSourceUrl]:
+        keys = sorted({key for key in place_keys if key})
+        if not keys:
+            return []
+
+        with self.engine.connect() as connection:
+            rows = connection.execute(
+                select(
+                    trust_place_source_urls.c.source,
+                    trust_place_source_urls.c.url,
+                    trust_place_source_urls.c.title,
+                    trust_place_source_urls.c.fetched_at,
+                    trust_place_source_urls.c.refresh_after,
+                    trust_place_source_urls.c.confidence,
+                    trust_place_source_urls.c.match_reason,
+                    trust_place_source_urls.c.match_signature,
+                )
+                .where(
+                    and_(
+                        trust_place_source_urls.c.place_key.in_(keys),
+                        trust_place_source_urls.c.source == source,
+                    )
+                )
+                .order_by(
+                    trust_place_source_urls.c.source,
+                    trust_place_source_urls.c.url,
+                )
+            ).fetchall()
+
+        source_urls: list[PlaceSourceUrl] = []
+        for (
+            row_source,
+            url,
+            title,
+            fetched_at,
+            refresh_after,
+            confidence,
+            match_reason,
+            row_match_signature,
+        ) in rows:
+            if row_match_signature != match_signature:
+                continue
+            parsed_refresh_after = metadata_datetime_or_none(refresh_after)
+            if parsed_refresh_after is not None and parsed_refresh_after <= now:
+                continue
+            if not isinstance(row_source, str) or not isinstance(url, str):
+                continue
+            if not isinstance(fetched_at, str) or not isinstance(confidence, str) or not isinstance(match_reason, str):
+                continue
+            source_urls.append(
+                PlaceSourceUrl(
+                    source=row_source,
+                    url=url,
+                    title=title if isinstance(title, str) else None,
+                    fetched_at=fetched_at,
+                    refresh_after=refresh_after if isinstance(refresh_after, str) else None,
+                    confidence=confidence,
+                    match_reason=match_reason,
+                )
+            )
+        return dedupe_place_source_urls(source_urls)
+
     def cached_michelin_detail_snapshot(
         self,
         restaurant_url: str,
@@ -967,13 +1036,30 @@ def refresh_trust_signals_for_raw_guides(
                 ),
                 fetched_at=now,
             )
+            match_signature = trust_match_signature(place.name, city_name, country_name)
+            saved_tabelog_source_urls = store.load_place_source_urls(
+                keys,
+                source="tabelog",
+                match_signature=match_signature,
+                now=now,
+            )
+            saved_tabelog_url_signals = signals_from_tabelog_source_urls(
+                tabelog_restaurants,
+                saved_tabelog_source_urls,
+                fetched_at=now,
+            )
             tabelog_search_signals: list[TrustSignal] = []
             should_search_tabelog = tabelog_search_place_is_eligible(
                 place,
                 enrichment_entry=enrichment_cache.get(place_id),
-                has_tabelog_source_match=bool(tabelog_signals),
+                has_tabelog_source_match=bool(tabelog_signals or saved_tabelog_source_urls),
             )
-            if guide_has_tabelog_sources and tabelog_restaurants and should_search_tabelog:
+            if (
+                guide_has_tabelog_sources
+                and tabelog_restaurants
+                and should_search_tabelog
+                and not saved_tabelog_url_signals
+            ):
                 tabelog_query = tabelog_search_query(place.name)
                 try:
                     tabelog_results = cached_or_fetch_search_results(
@@ -1009,12 +1095,13 @@ def refresh_trust_signals_for_raw_guides(
                             store.save_place_source_urls(
                                 key,
                                 tabelog_source_urls,
-                                match_signature=trust_match_signature(place.name, city_name, country_name),
+                                match_signature=match_signature,
                             )
             if (
                 not results
                 and not michelin_signals
                 and not tabelog_signals
+                and not saved_tabelog_url_signals
                 and not tabelog_search_signals
                 and not brave_api_key
                 and not google_fallback_enabled
@@ -1032,7 +1119,7 @@ def refresh_trust_signals_for_raw_guides(
                         store.replace_search_signals(
                             key,
                             [],
-                            match_signature=trust_match_signature(place.name, city_name, country_name),
+                            match_signature=match_signature,
                             now=now,
                             replaceable_sources=replaceable_sources,
                         )
@@ -1045,9 +1132,10 @@ def refresh_trust_signals_for_raw_guides(
             signals = [
                 *michelin_signals,
                 *tabelog_signals,
+                *saved_tabelog_url_signals,
                 *tabelog_search_signals,
                 *search_signals_without_duplicate_award_urls(
-                    [*michelin_signals, *tabelog_signals, *tabelog_search_signals],
+                    [*michelin_signals, *tabelog_signals, *saved_tabelog_url_signals, *tabelog_search_signals],
                     signals_from_search_results(
                         results,
                         place_name=place.name,
@@ -1061,7 +1149,7 @@ def refresh_trust_signals_for_raw_guides(
                 store.replace_search_signals(
                     key,
                     signals,
-                    match_signature=trust_match_signature(place.name, city_name, country_name),
+                    match_signature=match_signature,
                     now=now,
                     replaceable_sources=[
                         source
@@ -2018,6 +2106,44 @@ def signals_from_tabelog_search_results(
                     fetched_at=fetched_at.isoformat(),
                     confidence="high",
                     match_reason="Tabelog direct search URL match",
+                )
+            )
+    return sort_trust_signals(dedupe_trust_signals(signals))
+
+
+def signals_from_tabelog_source_urls(
+    restaurants: list[TabelogRestaurant],
+    source_urls: list[PlaceSourceUrl],
+    *,
+    fetched_at: datetime,
+) -> list[TrustSignal]:
+    restaurants_by_url: dict[str, list[TabelogRestaurant]] = {}
+    for restaurant in restaurants:
+        restaurants_by_url.setdefault(canonical_tabelog_url(restaurant.url), []).append(restaurant)
+
+    signals: list[TrustSignal] = []
+    matched_urls: set[str] = set()
+    for source_url in source_urls:
+        if source_url.source != "tabelog":
+            continue
+        url = canonical_tabelog_url(source_url.url)
+        matched_restaurants = restaurants_by_url.get(url)
+        if not matched_restaurants or url in matched_urls:
+            continue
+        matched_urls.add(url)
+        for restaurant in matched_restaurants:
+            signals.append(
+                TrustSignal(
+                    source="tabelog",
+                    label=restaurant.label,
+                    tier=restaurant.tier,
+                    award_year=restaurant.award_year,
+                    is_current=restaurant.is_current,
+                    url=restaurant.url,
+                    title=restaurant.name,
+                    fetched_at=fetched_at.isoformat(),
+                    confidence=source_url.confidence,
+                    match_reason="Tabelog saved source URL match",
                 )
             )
     return sort_trust_signals(dedupe_trust_signals(signals))

--- a/scripts/trust_signals.py
+++ b/scripts/trust_signals.py
@@ -2679,7 +2679,9 @@ def dedupe_place_source_urls(source_urls: Iterable[PlaceSourceUrl]) -> list[Plac
     for source_url in source_urls:
         key = (source_url.source, source_url.url)
         existing = by_key.get(key)
-        if existing is None or source_url.confidence < existing.confidence:
+        if existing is None or TRUST_SIGNAL_CONFIDENCE_PRIORITY.get(
+            source_url.confidence, 99
+        ) < TRUST_SIGNAL_CONFIDENCE_PRIORITY.get(existing.confidence, 99):
             by_key[key] = source_url
     return sorted(by_key.values(), key=lambda value: (value.source, value.url))
 

--- a/scripts/trust_signals.py
+++ b/scripts/trust_signals.py
@@ -598,12 +598,12 @@ class TrustSignalStore:
                     trust_place_source_urls.c.refresh_after,
                     trust_place_source_urls.c.confidence,
                     trust_place_source_urls.c.match_reason,
-                    trust_place_source_urls.c.match_signature,
                 )
                 .where(
                     and_(
                         trust_place_source_urls.c.place_key.in_(keys),
                         trust_place_source_urls.c.source == source,
+                        trust_place_source_urls.c.match_signature == match_signature,
                     )
                 )
                 .order_by(
@@ -621,10 +621,7 @@ class TrustSignalStore:
             refresh_after,
             confidence,
             match_reason,
-            row_match_signature,
         ) in rows:
-            if row_match_signature != match_signature:
-                continue
             parsed_refresh_after = metadata_datetime_or_none(refresh_after)
             if parsed_refresh_after is not None and parsed_refresh_after <= now:
                 continue
@@ -1068,12 +1065,46 @@ def refresh_trust_signals_for_raw_guides(
                 fetched_at=now,
             )
             match_signature = trust_match_signature(place.name, city_name, country_name)
+            existing_signals_by_key = store.load_signals_for_place_keys(
+                keys,
+                include_low_confidence=True,
+                match_signatures_by_key={key: {match_signature} for key in keys},
+                now=now,
+            )
+            existing_tabelog_direct_signals = sort_trust_signals(
+                dedupe_trust_signals(
+                    signal
+                    for signals in existing_signals_by_key.values()
+                    for signal in signals
+                    if signal.source == "tabelog"
+                    and signal.match_reason == "Tabelog direct search URL match"
+                )
+            )
             saved_tabelog_source_urls = store.load_place_source_urls(
                 keys,
                 source="tabelog",
                 match_signature=match_signature,
                 now=now,
             )
+            legacy_tabelog_source_urls = place_source_urls_from_tabelog_signals(
+                existing_tabelog_direct_signals,
+                fetched_at=now,
+                refresh_after=search_snapshot_refresh_after(
+                    "tabelog_search",
+                    tabelog_search_query(place.name),
+                    now=now,
+                ),
+            )
+            if legacy_tabelog_source_urls:
+                for key in keys:
+                    store.save_place_source_urls(
+                        key,
+                        legacy_tabelog_source_urls,
+                        match_signature=match_signature,
+                    )
+                saved_tabelog_source_urls = dedupe_place_source_urls(
+                    [*saved_tabelog_source_urls, *legacy_tabelog_source_urls]
+                )
             saved_tabelog_url_signals = signals_from_tabelog_source_urls(
                 tabelog_restaurants,
                 saved_tabelog_source_urls,
@@ -1083,13 +1114,18 @@ def refresh_trust_signals_for_raw_guides(
             should_search_tabelog = tabelog_search_place_is_eligible(
                 place,
                 enrichment_entry=enrichment_cache.get(place_id),
-                has_tabelog_source_match=bool(tabelog_signals or saved_tabelog_source_urls),
+                has_tabelog_source_match=bool(
+                    tabelog_signals
+                    or saved_tabelog_source_urls
+                    or existing_tabelog_direct_signals
+                ),
             )
             if (
                 guide_has_tabelog_sources
                 and tabelog_restaurants
                 and should_search_tabelog
                 and not saved_tabelog_url_signals
+                and not existing_tabelog_direct_signals
             ):
                 tabelog_query = tabelog_search_query(place.name)
                 try:
@@ -1133,6 +1169,7 @@ def refresh_trust_signals_for_raw_guides(
                 and not michelin_signals
                 and not tabelog_signals
                 and not saved_tabelog_url_signals
+                and not existing_tabelog_direct_signals
                 and not tabelog_search_signals
                 and not brave_api_key
                 and not google_fallback_enabled
@@ -1164,9 +1201,16 @@ def refresh_trust_signals_for_raw_guides(
                 *michelin_signals,
                 *tabelog_signals,
                 *saved_tabelog_url_signals,
+                *existing_tabelog_direct_signals,
                 *tabelog_search_signals,
                 *search_signals_without_duplicate_award_urls(
-                    [*michelin_signals, *tabelog_signals, *saved_tabelog_url_signals, *tabelog_search_signals],
+                    [
+                        *michelin_signals,
+                        *tabelog_signals,
+                        *saved_tabelog_url_signals,
+                        *existing_tabelog_direct_signals,
+                        *tabelog_search_signals,
+                    ],
                     signals_from_search_results(
                         results,
                         place_name=place.name,
@@ -2178,6 +2222,30 @@ def signals_from_tabelog_source_urls(
                 )
             )
     return sort_trust_signals(dedupe_trust_signals(signals))
+
+
+def place_source_urls_from_tabelog_signals(
+    signals: list[TrustSignal],
+    *,
+    fetched_at: datetime,
+    refresh_after: datetime,
+) -> list[PlaceSourceUrl]:
+    source_urls: list[PlaceSourceUrl] = []
+    for signal in signals:
+        if signal.source != "tabelog" or not signal.url:
+            continue
+        source_urls.append(
+            PlaceSourceUrl(
+                source="tabelog",
+                url=canonical_tabelog_url(signal.url),
+                title=signal.title,
+                fetched_at=fetched_at.isoformat(),
+                refresh_after=refresh_after.isoformat(),
+                confidence=signal.confidence,
+                match_reason="Existing Tabelog direct signal",
+            )
+        )
+    return dedupe_place_source_urls(source_urls)
 
 
 def place_source_urls_from_tabelog_search_results(

--- a/scripts/trust_signals.py
+++ b/scripts/trust_signals.py
@@ -492,14 +492,25 @@ class TrustSignalStore:
         with self.engine.connect() as connection:
             row = connection.execute(
                 select(
+                    trust_source_snapshots.c.fetched_at,
                     trust_source_snapshots.c.refresh_after,
                     trust_source_snapshots.c.payload_json,
                 ).where(trust_source_snapshots.c.source_key == source_key)
             ).fetchone()
         if row is None:
             return None
-        refresh_after, payload_json = row
+        fetched_at, refresh_after, payload_json = row
         parsed_refresh_after = metadata_datetime_or_none(refresh_after)
+        fetched_at_dt = metadata_datetime_or_none(fetched_at)
+        policy_refresh_after = tabelog_source_refresh_after(source, now=fetched_at_dt or now)
+        if parsed_refresh_after != policy_refresh_after:
+            parsed_refresh_after = policy_refresh_after
+            with self.engine.begin() as connection:
+                connection.execute(
+                    trust_source_snapshots.update()
+                    .where(trust_source_snapshots.c.source_key == source_key)
+                    .values(refresh_after=policy_refresh_after.isoformat())
+                )
         if parsed_refresh_after is None or parsed_refresh_after <= now:
             return None
         payload = json.loads(payload_json)

--- a/scripts/trust_signals.py
+++ b/scripts/trust_signals.py
@@ -47,6 +47,10 @@ MICHELIN_REGION_URLS_ENV = "FAVORITE_PLACES_MICHELIN_REGION_URLS"
 TABELOG_SOURCE_URLS_ENV = "FAVORITE_PLACES_TABELOG_SOURCE_URLS"
 TRUST_SIGNAL_REFRESH_TTL = timedelta(days=90)
 MICHELIN_REGION_REFRESH_TTL = timedelta(days=365)
+TABELOG_AWARD_REFRESH_STAGGER = timedelta(days=180)
+TABELOG_HYAKUMEITEN_REFRESH_TTL = timedelta(days=30)
+TABELOG_HYAKUMEITEN_REFRESH_STAGGER = timedelta(days=14)
+TABELOG_SEARCH_REFRESH_STAGGER = timedelta(days=180)
 MICHELIN_SOURCE_CACHE_VERSION = 3
 MICHELIN_DETAIL_CACHE_VERSION = 2
 TABELOG_SOURCE_CACHE_VERSION = 1
@@ -106,6 +110,77 @@ RESTAURANT_NAME_STOPWORDS = {
     "steakhouse",
     "sushi",
 }
+TABELOG_ELIGIBLE_CATEGORY_TERMS = (
+    "bar",
+    "bakery",
+    "bistro",
+    "brewery",
+    "cafe",
+    "café",
+    "coffee",
+    "confectionery",
+    "dessert",
+    "dining",
+    "drink",
+    "food",
+    "izakaya",
+    "kitchen",
+    "pub",
+    "ramen",
+    "restaurant",
+    "sake",
+    "soba",
+    "steak",
+    "sushi",
+    "tea",
+    "tempura",
+    "udon",
+    "wine",
+    "yakitori",
+    "yakiniku",
+)
+TABELOG_INELIGIBLE_CATEGORY_TERMS = (
+    "airport",
+    "aquarium",
+    "art gallery",
+    "attraction",
+    "beach",
+    "bridge",
+    "bus station",
+    "castle",
+    "church",
+    "department store",
+    "garden",
+    "guest house",
+    "historic",
+    "hostel",
+    "hotel",
+    "inn",
+    "landmark",
+    "lodging",
+    "mall",
+    "market",
+    "monument",
+    "museum",
+    "observation",
+    "onsen",
+    "park",
+    "resort",
+    "river",
+    "scenic",
+    "shopping",
+    "shrine",
+    "spa",
+    "station",
+    "store",
+    "temple",
+    "theme park",
+    "tourist",
+    "trail",
+    "train",
+    "villa",
+    "zoo",
+)
 
 metadata = MetaData()
 
@@ -141,6 +216,20 @@ trust_place_signals = Table(
     Column("match_reason", Text, nullable=False),
     Column("match_signature", String, nullable=False),
     Column("signal_json", Text, nullable=False),
+)
+
+trust_place_source_urls = Table(
+    "trust_place_source_urls",
+    metadata,
+    Column("place_key", String, primary_key=True),
+    Column("source", String, primary_key=True),
+    Column("url", Text, primary_key=True),
+    Column("title", Text),
+    Column("fetched_at", String, nullable=False),
+    Column("refresh_after", String),
+    Column("confidence", String, nullable=False),
+    Column("match_reason", Text, nullable=False),
+    Column("match_signature", String, nullable=False),
 )
 
 class SearchResult(BaseModel):
@@ -189,6 +278,18 @@ class TabelogSource(BaseModel):
     source_type: Literal["award", "hyakumeiten"]
     region_key: str
     url: str
+
+
+class PlaceSourceUrl(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source: str
+    url: str
+    title: str | None = None
+    fetched_at: str
+    refresh_after: str | None = None
+    confidence: str
+    match_reason: str
 
 
 class MichelinDetailSnapshot(BaseModel):
@@ -282,14 +383,29 @@ class TrustSignalStore:
         with self.engine.connect() as connection:
             row = connection.execute(
                 select(
+                    trust_source_snapshots.c.fetched_at,
                     trust_source_snapshots.c.refresh_after,
                     trust_source_snapshots.c.payload_json,
                 ).where(trust_source_snapshots.c.source_key == source_key)
             ).fetchone()
         if row is None:
             return None
-        refresh_after, payload_json = row
+        fetched_at, refresh_after, payload_json = row
         parsed_refresh_after = metadata_datetime_or_none(refresh_after)
+        fetched_at_dt = metadata_datetime_or_none(fetched_at)
+        policy_refresh_after = search_snapshot_refresh_after(
+            provider,
+            query,
+            now=fetched_at_dt or now,
+        )
+        if provider == "tabelog_search" and parsed_refresh_after != policy_refresh_after:
+            parsed_refresh_after = policy_refresh_after
+            with self.engine.begin() as connection:
+                connection.execute(
+                    trust_source_snapshots.update()
+                    .where(trust_source_snapshots.c.source_key == source_key)
+                    .values(refresh_after=policy_refresh_after.isoformat())
+                )
         if parsed_refresh_after is None or parsed_refresh_after <= now:
             return None
         payload = json.loads(payload_json)
@@ -305,7 +421,7 @@ class TrustSignalStore:
         *,
         now: datetime,
     ) -> None:
-        refresh_after = now + TRUST_SIGNAL_REFRESH_TTL
+        refresh_after = search_snapshot_refresh_after(provider, query, now=now)
         row = {
             "source_key": source_snapshot_key(provider, query),
             "source_type": provider,
@@ -398,7 +514,7 @@ class TrustSignalStore:
         *,
         now: datetime,
     ) -> None:
-        refresh_after = now + MICHELIN_REGION_REFRESH_TTL
+        refresh_after = tabelog_source_refresh_after(source, now=now)
         row = {
             "source_key": tabelog_source_key(source),
             "source_type": f"tabelog_{source.source_type}",
@@ -413,6 +529,30 @@ class TrustSignalStore:
             ),
         }
         upsert_row(self.engine, trust_source_snapshots, row, ["source_key"])
+
+    def save_place_source_urls(
+        self,
+        place_key: str,
+        source_urls: list[PlaceSourceUrl],
+        *,
+        match_signature: str,
+    ) -> None:
+        rows = [
+            {
+                "place_key": place_key,
+                "source": source_url.source,
+                "url": source_url.url,
+                "title": source_url.title,
+                "fetched_at": source_url.fetched_at,
+                "refresh_after": source_url.refresh_after,
+                "confidence": source_url.confidence,
+                "match_reason": source_url.match_reason,
+                "match_signature": match_signature,
+            }
+            for source_url in dedupe_place_source_urls(source_urls)
+        ]
+        with self.engine.begin() as connection:
+            upsert_rows(connection, trust_place_source_urls, rows, ["place_key", "source", "url"])
 
     def cached_michelin_detail_snapshot(
         self,
@@ -817,7 +957,12 @@ def refresh_trust_signals_for_raw_guides(
                 fetched_at=now,
             )
             tabelog_search_signals: list[TrustSignal] = []
-            if guide_has_tabelog_sources and tabelog_restaurants:
+            should_search_tabelog = tabelog_search_place_is_eligible(
+                place,
+                enrichment_entry=enrichment_cache.get(place_id),
+                has_tabelog_source_match=bool(tabelog_signals),
+            )
+            if guide_has_tabelog_sources and tabelog_restaurants and should_search_tabelog:
                 tabelog_query = tabelog_search_query(place.name)
                 try:
                     tabelog_results = cached_or_fetch_search_results(
@@ -838,6 +983,23 @@ def refresh_trust_signals_for_raw_guides(
                         place_name=place.name,
                         fetched_at=now,
                     )
+                    tabelog_source_urls = place_source_urls_from_tabelog_search_results(
+                        tabelog_results,
+                        place_name=place.name,
+                        fetched_at=now,
+                        refresh_after=search_snapshot_refresh_after(
+                            "tabelog_search",
+                            tabelog_query,
+                            now=now,
+                        ),
+                    )
+                    if tabelog_source_urls:
+                        for key in keys:
+                            store.save_place_source_urls(
+                                key,
+                                tabelog_source_urls,
+                                match_signature=trust_match_signature(place.name, city_name, country_name),
+                            )
             if (
                 not results
                 and not michelin_signals
@@ -1850,6 +2012,37 @@ def signals_from_tabelog_search_results(
     return sort_trust_signals(dedupe_trust_signals(signals))
 
 
+def place_source_urls_from_tabelog_search_results(
+    results: list[SearchResult],
+    *,
+    place_name: str,
+    fetched_at: datetime,
+    refresh_after: datetime,
+) -> list[PlaceSourceUrl]:
+    source_urls: list[PlaceSourceUrl] = []
+    matched_urls: set[str] = set()
+    normalized_place_name = normalize_restaurant_name_for_match(place_name)
+    for result in results:
+        url = canonical_tabelog_url(result.url)
+        if url in matched_urls:
+            continue
+        if not tabelog_search_result_matches_place(result, normalized_place_name):
+            continue
+        matched_urls.add(url)
+        source_urls.append(
+            PlaceSourceUrl(
+                source="tabelog",
+                url=url,
+                title=result.title,
+                fetched_at=fetched_at.isoformat(),
+                refresh_after=refresh_after.isoformat(),
+                confidence="medium",
+                match_reason="Tabelog search result name match",
+            )
+        )
+    return dedupe_place_source_urls(source_urls)
+
+
 def tabelog_search_result_matches_place(result: SearchResult, normalized_place_name: str) -> bool:
     result_name = normalize_restaurant_name_for_match(result.title)
     if not normalized_place_name or not result_name:
@@ -2295,6 +2488,106 @@ def tabelog_search_query(place_name: str) -> str:
     return place_name.strip()
 
 
+def tabelog_search_place_is_eligible(
+    place: RawPlace,
+    *,
+    enrichment_entry: EnrichmentCacheEntry | None,
+    has_tabelog_source_match: bool = False,
+) -> bool:
+    if has_tabelog_source_match:
+        return True
+    category_terms = tabelog_category_terms(place, enrichment_entry=enrichment_entry)
+    if not category_terms:
+        return True
+    normalized_terms = [normalize_search_text(term) for term in category_terms]
+    if any(term_contains_any(normalized, TABELOG_ELIGIBLE_CATEGORY_TERMS) for normalized in normalized_terms):
+        return True
+    if any(term_contains_any(normalized, TABELOG_INELIGIBLE_CATEGORY_TERMS) for normalized in normalized_terms):
+        return False
+    return True
+
+
+def tabelog_category_terms(
+    place: RawPlace,
+    *,
+    enrichment_entry: EnrichmentCacheEntry | None,
+) -> list[str]:
+    terms: list[str] = []
+    terms.extend(place.types)
+    enrichment_place = enrichment_entry.place if enrichment_entry is not None else None
+    if enrichment_place is not None:
+        terms.extend(
+            term
+            for term in (
+                enrichment_place.primary_type,
+                enrichment_place.primary_type_display_name,
+                enrichment_place.primary_type_display_name_localized,
+                enrichment_place.category_display_en,
+            )
+            if term
+        )
+        terms.extend(enrichment_place.types)
+        terms.extend(enrichment_place.semantic_types)
+    return [term for term in terms if as_nonempty_string(term)]
+
+
+def term_contains_any(value: str, needles: Iterable[str]) -> bool:
+    tokens = value.split()
+    token_set = set(tokens)
+    for needle in needles:
+        normalized_needle = normalize_search_text(needle)
+        needle_tokens = normalized_needle.split()
+        if not needle_tokens:
+            continue
+        if len(needle_tokens) == 1:
+            if needle_tokens[0] in token_set:
+                return True
+            continue
+        for index in range(0, len(tokens) - len(needle_tokens) + 1):
+            if tokens[index:index + len(needle_tokens)] == needle_tokens:
+                return True
+    return False
+
+
+def search_snapshot_refresh_after(provider: str, query: str, *, now: datetime) -> datetime:
+    if provider != "tabelog_search":
+        return now + TRUST_SIGNAL_REFRESH_TTL
+    stagger_seconds = stable_stagger_seconds(
+        f"{provider}:{query}",
+        max_offset=TABELOG_SEARCH_REFRESH_STAGGER,
+    )
+    return next_tabelog_award_refresh_base(now) + timedelta(seconds=stagger_seconds)
+
+
+def tabelog_source_refresh_after(source: TabelogSource, *, now: datetime) -> datetime:
+    if source.source_type == "award":
+        stagger_seconds = stable_stagger_seconds(
+            tabelog_source_key(source),
+            max_offset=TABELOG_AWARD_REFRESH_STAGGER,
+        )
+        return next_tabelog_award_refresh_base(now) + timedelta(seconds=stagger_seconds)
+    stagger_seconds = stable_stagger_seconds(
+        tabelog_source_key(source),
+        max_offset=TABELOG_HYAKUMEITEN_REFRESH_STAGGER,
+    )
+    return now + TABELOG_HYAKUMEITEN_REFRESH_TTL + timedelta(seconds=stagger_seconds)
+
+
+def next_tabelog_award_refresh_base(now: datetime) -> datetime:
+    base = datetime(now.year, 2, 1, tzinfo=UTC)
+    if now >= base:
+        base = datetime(now.year + 1, 2, 1, tzinfo=UTC)
+    return base
+
+
+def stable_stagger_seconds(value: str, *, max_offset: timedelta) -> int:
+    max_seconds = int(max_offset.total_seconds())
+    if max_seconds <= 0:
+        return 0
+    digest = hashlib.sha256(value.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big") % (max_seconds + 1)
+
+
 def trust_signal_row(
     place_key: str,
     signal: TrustSignal,
@@ -2379,6 +2672,16 @@ def dedupe_trust_signals(signals: Iterable[TrustSignal]) -> list[TrustSignal]:
         if existing is None or trust_signal_sort_key(signal) < trust_signal_sort_key(existing):
             by_key[key] = signal
     return list(by_key.values())
+
+
+def dedupe_place_source_urls(source_urls: Iterable[PlaceSourceUrl]) -> list[PlaceSourceUrl]:
+    by_key: dict[tuple[str, str], PlaceSourceUrl] = {}
+    for source_url in source_urls:
+        key = (source_url.source, source_url.url)
+        existing = by_key.get(key)
+        if existing is None or source_url.confidence < existing.confidence:
+            by_key[key] = source_url
+    return sorted(by_key.values(), key=lambda value: (value.source, value.url))
 
 
 def sort_trust_signals(signals: Iterable[TrustSignal]) -> list[TrustSignal]:

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -1738,11 +1738,20 @@ const mapPlaces = places
       card.dataset.mapInteractionInitialized = "true";
 
       const placeId = card.dataset.placeId || "";
+      const interactiveSelector = "a, button, input, select, textarea, summary, [role='button']";
+      const isNestedInteractiveTarget = (target: EventTarget | null) =>
+        target instanceof Element && target !== card && Boolean(target.closest(interactiveSelector));
+      if (!card.hasAttribute("tabindex")) card.tabIndex = 0;
       card.addEventListener("pointerenter", () => hoverPlace(placeId));
       card.addEventListener("pointerleave", () => clearHoveredPlace(placeId));
       card.addEventListener("click", (event) => {
-        const target = event.target instanceof Element ? event.target : null;
-        if (target?.closest("a, button, input, select, textarea, summary, [role='button']")) return;
+        if (isNestedInteractiveTarget(event.target)) return;
+        selectPlace(placeId, { expandCollapsed: true });
+      });
+      card.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        if (isNestedInteractiveTarget(event.target)) return;
+        event.preventDefault();
         selectPlace(placeId, { expandCollapsed: true });
       });
     });

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -1739,8 +1739,11 @@ const mapPlaces = places
 
       const placeId = card.dataset.placeId || "";
       const interactiveSelector = "a, button, input, select, textarea, summary, [role='button']";
-      const isNestedInteractiveTarget = (target: EventTarget | null) =>
-        target instanceof Element && target !== card && Boolean(target.closest(interactiveSelector));
+      const isNestedInteractiveTarget = (target: EventTarget | null) => {
+        if (!(target instanceof Element)) return false;
+        const nestedInteractive = target.closest(interactiveSelector);
+        return Boolean(nestedInteractive && nestedInteractive !== card);
+      };
       if (!card.hasAttribute("tabindex")) card.tabIndex = 0;
       if (!card.hasAttribute("role")) card.setAttribute("role", "button");
       card.addEventListener("pointerenter", () => hoverPlace(placeId));

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -1742,6 +1742,7 @@ const mapPlaces = places
       const isNestedInteractiveTarget = (target: EventTarget | null) =>
         target instanceof Element && target !== card && Boolean(target.closest(interactiveSelector));
       if (!card.hasAttribute("tabindex")) card.tabIndex = 0;
+      if (!card.hasAttribute("role")) card.setAttribute("role", "button");
       card.addEventListener("pointerenter", () => hoverPlace(placeId));
       card.addEventListener("pointerleave", () => clearHoveredPlace(placeId));
       card.addEventListener("click", (event) => {

--- a/src/components/GuideMap.astro
+++ b/src/components/GuideMap.astro
@@ -1750,6 +1750,7 @@ const mapPlaces = places
       });
       card.addEventListener("keydown", (event) => {
         if (event.key !== "Enter" && event.key !== " ") return;
+        if (event.repeat) return;
         if (isNestedInteractiveTarget(event.target)) return;
         event.preventDefault();
         selectPlace(placeId, { expandCollapsed: true });

--- a/tests/python/test_trust_signals.py
+++ b/tests/python/test_trust_signals.py
@@ -732,6 +732,86 @@ class TrustSignalsTest(unittest.TestCase):
         self.assertEqual(loaded["place-1"][0].tier, "寿司 TOKYO 百名店")
         self.assertEqual(loaded["place-1"][0].match_reason, "Tabelog direct search URL match")
 
+    def test_refresh_reuses_saved_tabelog_source_url_for_ineligible_categories(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "trust.sqlite"
+            now = datetime(2026, 6, 15, tzinfo=UTC)
+            store = TrustSignalStore(sqlite_url_for_path(db_path))
+            store.save_place_source_urls(
+                "place-1",
+                [
+                    PlaceSourceUrl(
+                        source="tabelog",
+                        url="https://tabelog.com/tokyo/A1314/A131401/13196420/",
+                        title="Higashiazabu Amamoto",
+                        fetched_at=now.isoformat(),
+                        refresh_after=(now + timedelta(days=90)).isoformat(),
+                        confidence="medium",
+                        match_reason="Tabelog search result name match",
+                    )
+                ],
+                match_signature=trust_match_signature("Higashiazabu Amamoto", "Tokyo", "Japan"),
+            )
+            raw_lists = {
+                "tokyo-japan": RawSavedList(
+                    title="Tokyo, Japan",
+                    places=[
+                        RawPlace(
+                            name="Higashiazabu Amamoto",
+                            address="Akabanebashi, Tokyo, Japan",
+                            maps_url="https://maps.google.com/?q=higashiazabu-amamoto",
+                        )
+                    ],
+                )
+            }
+            enrichment_entry = EnrichmentCacheEntry(
+                fetched_at=now.isoformat(),
+                query="Higashiazabu Amamoto",
+                place=EnrichmentPlace(primary_type_display_name="Hotel"),
+            )
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TABELOG_SOURCE_URLS": '{"hyakumeiten":"https://award.tabelog.com/hyakumeiten"}',
+                        "BRAVE_SEARCH_API_KEY": "",
+                        "BRAVE_API_KEY": "",
+                        "FAVORITE_PLACES_TRUST_GOOGLE_FALLBACK": "",
+                    },
+                ),
+                patch("scripts.trust_signals.scrape_michelin_region_source", return_value=[]),
+                patch(
+                    "scripts.trust_signals.scrape_tabelog_source",
+                    return_value=[
+                        TabelogRestaurant(
+                            name="東麻布 天本",
+                            url="https://tabelog.com/tokyo/A1314/A131401/13196420/",
+                            label="Tabelog Hyakumeiten",
+                            tier="寿司 TOKYO 百名店",
+                            award_year=2025,
+                            is_current=True,
+                            region_key="japan",
+                        )
+                    ],
+                ),
+                patch("scripts.trust_signals.tabelog_search", side_effect=AssertionError("unexpected Tabelog search")),
+            ):
+                summary = refresh_trust_signals_for_raw_guides(
+                    root=Path(tmpdir),
+                    raw_lists=raw_lists,
+                    enrichment_caches={"tokyo-japan": {"place-1": enrichment_entry}},
+                    stable_place_ids={("tokyo-japan", 0): "place-1"},
+                )
+
+            loaded = store.load_signals_for_place_keys(["place-1"])
+
+        self.assertEqual(summary.tabelog_sources_refreshed, 1)
+        self.assertEqual(len(loaded["place-1"]), 1)
+        self.assertEqual(loaded["place-1"][0].source, "tabelog")
+        self.assertEqual(loaded["place-1"][0].match_reason, "Tabelog saved source URL match")
+
     def test_refresh_preserves_tabelog_rows_when_tabelog_search_fails(self) -> None:
         with TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "trust.sqlite"

--- a/tests/python/test_trust_signals.py
+++ b/tests/python/test_trust_signals.py
@@ -116,6 +116,50 @@ class TrustSignalsTest(unittest.TestCase):
 
         self.assertEqual(loaded, {"cid:111": [signal]})
 
+    def test_store_filters_cached_place_signals_by_freshness_and_signature(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "trust.sqlite"
+            store = TrustSignalStore(sqlite_url_for_path(db_path))
+            fetched_at = datetime(2026, 6, 15, tzinfo=UTC)
+            signal = TrustSignal(
+                source="michelin",
+                label="MICHELIN Guide",
+                tier="Bib Gourmand",
+                url="https://guide.michelin.com/en/jp/tokyo-region/restaurant/coffee-house",
+                title="Coffee House - Tokyo - a MICHELIN Guide Restaurant",
+                fetched_at=fetched_at.isoformat(),
+                confidence="high",
+                match_reason="name plus source/location match",
+            )
+            match_signature = trust_match_signature("Coffee House", "Tokyo", "Japan")
+
+            store.replace_search_signals(
+                "cid:111",
+                [signal],
+                match_signature=match_signature,
+                now=fetched_at,
+            )
+
+            fresh_loaded = store.load_signals_for_place_keys(
+                ["cid:111"],
+                match_signatures_by_key={"cid:111": {match_signature}},
+                now=fetched_at + timedelta(days=89),
+            )
+            expired_loaded = store.load_signals_for_place_keys(
+                ["cid:111"],
+                match_signatures_by_key={"cid:111": {match_signature}},
+                now=fetched_at + timedelta(days=91),
+            )
+            renamed_loaded = store.load_signals_for_place_keys(
+                ["cid:111"],
+                match_signatures_by_key={"cid:111": {trust_match_signature("Renamed Coffee", "Tokyo", "Japan")}},
+                now=fetched_at + timedelta(days=1),
+            )
+
+        self.assertEqual(fresh_loaded, {"cid:111": [signal]})
+        self.assertEqual(expired_loaded, {})
+        self.assertEqual(renamed_loaded, {})
+
     def test_store_uses_post_award_stagger_for_tabelog_search_snapshots(self) -> None:
         with TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "trust.sqlite"

--- a/tests/python/test_trust_signals.py
+++ b/tests/python/test_trust_signals.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from tempfile import TemporaryDirectory
 from pathlib import Path
 from unittest.mock import patch
 import os
 import unittest
 
-from scripts.pipeline_models import TrustSignal
+from sqlalchemy import select
+
+from scripts.pipeline_models import EnrichmentCacheEntry, EnrichmentPlace, TrustSignal
 from scripts.pipeline_models import RawPlace, RawSavedList
 from scripts import build_data
 from scripts.trust_signals import (
@@ -29,6 +31,7 @@ from scripts.trust_signals import (
     parse_tabelog_search_results,
     parse_wikipedia_michelin_starred_page,
     parse_google_search_results,
+    place_source_urls_from_tabelog_search_results,
     refresh_trust_signals_for_raw_guides,
     scrape_official_michelin_region,
     search_signals_without_duplicate_award_urls,
@@ -39,8 +42,13 @@ from scripts.trust_signals import (
     signals_from_tabelog_search_results,
     signals_from_search_results,
     sqlite_url_for_path,
+    source_snapshot_key,
     tabelog_hyakumeiten_category_urls,
+    tabelog_search_place_is_eligible,
+    tabelog_source_refresh_after,
     tabelog_sources_for_guides,
+    trust_place_source_urls,
+    trust_source_snapshots,
     trust_match_signature,
 )
 
@@ -82,7 +90,7 @@ class TrustSignalsTest(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "trust.sqlite"
             store = TrustSignalStore(sqlite_url_for_path(db_path))
-            fetched_at = datetime(2026, 1, 15, tzinfo=UTC)
+            fetched_at = datetime(2026, 6, 15, tzinfo=UTC)
             signal = TrustSignal(
                 source="michelin",
                 label="MICHELIN Guide",
@@ -104,6 +112,183 @@ class TrustSignalsTest(unittest.TestCase):
             loaded = store.load_signals_for_place_keys(["cid:111"])
 
         self.assertEqual(loaded, {"cid:111": [signal]})
+
+    def test_store_uses_post_award_stagger_for_tabelog_search_snapshots(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "trust.sqlite"
+            store = TrustSignalStore(sqlite_url_for_path(db_path))
+            now = datetime(2026, 6, 15, tzinfo=UTC)
+            result = SearchResult(title="Higashiazabu Amamoto", url="https://tabelog.com/tokyo/A1314/A131401/13196420/")
+
+            store.save_search_results("tabelog_search", "Higashiazabu Amamoto", [result], now=now)
+            store.save_search_results("tabelog_search", "GINZA KOKORO", [], now=now)
+
+            with store.engine.connect() as connection:
+                rows = connection.execute(
+                    select(
+                        trust_source_snapshots.c.query,
+                        trust_source_snapshots.c.refresh_after,
+                    )
+                    .where(trust_source_snapshots.c.source_type == "tabelog_search")
+                    .order_by(trust_source_snapshots.c.query)
+                ).fetchall()
+
+            refresh_afters = {
+                query: datetime.fromisoformat(refresh_after)
+                for query, refresh_after in rows
+                if isinstance(query, str) and isinstance(refresh_after, str)
+            }
+
+        self.assertEqual(set(refresh_afters), {"GINZA KOKORO", "Higashiazabu Amamoto"})
+        self.assertTrue(
+            datetime(2027, 2, 1, tzinfo=UTC)
+            <= refresh_afters["Higashiazabu Amamoto"]
+            <= datetime(2027, 7, 31, tzinfo=UTC)
+        )
+        self.assertTrue(
+            datetime(2027, 2, 1, tzinfo=UTC)
+            <= refresh_afters["GINZA KOKORO"]
+            <= datetime(2027, 7, 31, tzinfo=UTC)
+        )
+        self.assertNotEqual(refresh_afters["Higashiazabu Amamoto"], refresh_afters["GINZA KOKORO"])
+
+    def test_store_normalizes_existing_tabelog_search_snapshot_on_read(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "trust.sqlite"
+            store = TrustSignalStore(sqlite_url_for_path(db_path))
+            fetched_at = datetime(2026, 6, 15, tzinfo=UTC)
+            query = "Higashiazabu Amamoto"
+            result = SearchResult(title="Higashiazabu Amamoto", url="https://tabelog.com/tokyo/A1314/A131401/13196420/")
+            source_key = source_snapshot_key("tabelog_search", query)
+            store.save_search_results("tabelog_search", query, [result], now=fetched_at)
+            short_refresh_after = fetched_at + timedelta(days=90)
+            with store.engine.begin() as connection:
+                connection.execute(
+                    trust_source_snapshots.update()
+                    .where(trust_source_snapshots.c.source_key == source_key)
+                    .values(refresh_after=short_refresh_after.isoformat())
+                )
+
+            cached = store.cached_search_results(
+                "tabelog_search",
+                query,
+                now=fetched_at + timedelta(days=91),
+            )
+            with store.engine.connect() as connection:
+                refresh_after = connection.execute(
+                    select(trust_source_snapshots.c.refresh_after).where(
+                        trust_source_snapshots.c.source_key == source_key
+                    )
+                ).scalar_one()
+
+        self.assertEqual(cached, [result])
+        self.assertGreaterEqual(datetime.fromisoformat(refresh_after), datetime(2027, 2, 1, tzinfo=UTC))
+        self.assertLessEqual(datetime.fromisoformat(refresh_after), datetime(2027, 7, 31, tzinfo=UTC))
+
+    def test_tabelog_award_source_refresh_starts_after_next_award_ceremony(self) -> None:
+        award_source = TabelogSource(
+            source_type="award",
+            region_key="japan",
+            url="https://award.tabelog.com/en/restaurants",
+        )
+        hyakumeiten_source = TabelogSource(
+            source_type="hyakumeiten",
+            region_key="japan",
+            url="https://award.tabelog.com/hyakumeiten",
+        )
+        now = datetime(2026, 6, 15, tzinfo=UTC)
+
+        award_refresh_after = tabelog_source_refresh_after(award_source, now=now)
+        hyakumeiten_refresh_after = tabelog_source_refresh_after(hyakumeiten_source, now=now)
+
+        self.assertTrue(datetime(2027, 2, 1, tzinfo=UTC) <= award_refresh_after <= datetime(2027, 7, 31, tzinfo=UTC))
+        self.assertTrue(now + timedelta(days=30) <= hyakumeiten_refresh_after <= now + timedelta(days=44))
+
+    def test_store_saves_tabelog_restaurant_url_matches_for_future_use(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "trust.sqlite"
+            store = TrustSignalStore(sqlite_url_for_path(db_path))
+            now = datetime(2026, 6, 15, tzinfo=UTC)
+            source_urls = place_source_urls_from_tabelog_search_results(
+                [
+                    SearchResult(
+                        title="Higashiazabu Amamoto",
+                        url="https://tabelog.com/en/tokyo/A1314/A131401/13196420/",
+                    )
+                ],
+                place_name="Higashiazabu Amamoto",
+                fetched_at=now,
+                refresh_after=datetime(2027, 2, 1, tzinfo=UTC),
+            )
+
+            store.save_place_source_urls(
+                "place-1",
+                source_urls,
+                match_signature=trust_match_signature("Higashiazabu Amamoto", "Tokyo", "Japan"),
+            )
+            with store.engine.connect() as connection:
+                rows = connection.execute(
+                    select(
+                        trust_place_source_urls.c.place_key,
+                        trust_place_source_urls.c.source,
+                        trust_place_source_urls.c.url,
+                        trust_place_source_urls.c.title,
+                    )
+                ).fetchall()
+
+        self.assertEqual(
+            rows,
+            [
+                (
+                    "place-1",
+                    "tabelog",
+                    "https://tabelog.com/tokyo/A1314/A131401/13196420/",
+                    "Higashiazabu Amamoto",
+                )
+            ],
+        )
+
+    def test_tabelog_search_eligibility_skips_obvious_non_restaurants(self) -> None:
+        cases = [
+            ("Ohori Park", "Park", False),
+            ("Edo-Tokyo Museum", "Museum", False),
+            ("Aman Tokyo", "Hotel", False),
+            ("Yakiniku Sumiya", "Yakiniku restaurant", True),
+            ("Bar Benfiddich", "Cocktail bar", True),
+            ("Koffee Mameya", "Coffee shop", True),
+            ("Hotel Restaurant", "Hotel restaurant", True),
+        ]
+        for name, category, expected in cases:
+            with self.subTest(category=category):
+                place = RawPlace(name=name, maps_url="https://maps.google.com/?q=test")
+                enrichment_entry = EnrichmentCacheEntry(
+                    fetched_at="2026-06-15T00:00:00+00:00",
+                    query=name,
+                    place=EnrichmentPlace(primary_type_display_name=category),
+                )
+
+                self.assertEqual(
+                    tabelog_search_place_is_eligible(place, enrichment_entry=enrichment_entry),
+                    expected,
+                )
+
+    def test_tabelog_search_eligibility_allows_unknown_or_existing_source_match(self) -> None:
+        unknown_place = RawPlace(name="GINZA KOKORO", maps_url="https://maps.google.com/?q=test")
+        park_place = RawPlace(name="Awarded Place In A Park", maps_url="https://maps.google.com/?q=test")
+        park_entry = EnrichmentCacheEntry(
+            fetched_at="2026-06-15T00:00:00+00:00",
+            query="Awarded Place In A Park",
+            place=EnrichmentPlace(types=["park"]),
+        )
+
+        self.assertTrue(tabelog_search_place_is_eligible(unknown_place, enrichment_entry=None))
+        self.assertTrue(
+            tabelog_search_place_is_eligible(
+                park_place,
+                enrichment_entry=park_entry,
+                has_tabelog_source_match=True,
+            )
+        )
 
     def test_store_refresh_replaces_stale_michelin_rows_for_place(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/tests/python/test_trust_signals.py
+++ b/tests/python/test_trust_signals.py
@@ -45,6 +45,7 @@ from scripts.trust_signals import (
     signals_from_search_results,
     sqlite_url_for_path,
     source_snapshot_key,
+    tabelog_source_key,
     tabelog_hyakumeiten_category_urls,
     tabelog_search_place_is_eligible,
     tabelog_source_refresh_after,
@@ -205,6 +206,46 @@ class TrustSignalsTest(unittest.TestCase):
 
         self.assertTrue(datetime(2027, 2, 1, tzinfo=UTC) <= award_refresh_after <= datetime(2027, 7, 31, tzinfo=UTC))
         self.assertTrue(now + timedelta(days=30) <= hyakumeiten_refresh_after <= now + timedelta(days=44))
+
+    def test_store_normalizes_existing_tabelog_source_snapshot_on_read(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "trust.sqlite"
+            store = TrustSignalStore(sqlite_url_for_path(db_path))
+            fetched_at = datetime(2026, 6, 15, tzinfo=UTC)
+            source = TabelogSource(
+                source_type="hyakumeiten",
+                region_key="japan",
+                url="https://award.tabelog.com/hyakumeiten",
+            )
+            restaurant = TabelogRestaurant(
+                name="GINZA KOKORO",
+                url="https://tabelog.com/tokyo/A1301/A130101/13204171/",
+                label="Tabelog Hyakumeiten",
+                tier="sushi",
+                region_key="japan",
+            )
+            source_key = tabelog_source_key(source)
+            store.save_tabelog_restaurants(source, [restaurant], now=fetched_at)
+            stale_refresh_after = fetched_at + timedelta(days=365)
+            with store.engine.begin() as connection:
+                connection.execute(
+                    trust_source_snapshots.update()
+                    .where(trust_source_snapshots.c.source_key == source_key)
+                    .values(refresh_after=stale_refresh_after.isoformat())
+                )
+
+            cached = store.cached_tabelog_restaurants(source, now=fetched_at + timedelta(days=45))
+            with store.engine.connect() as connection:
+                refresh_after = connection.execute(
+                    select(trust_source_snapshots.c.refresh_after).where(
+                        trust_source_snapshots.c.source_key == source_key
+                    )
+                ).scalar_one()
+
+        self.assertIsNone(cached)
+        self.assertTrue(
+            fetched_at + timedelta(days=30) <= datetime.fromisoformat(refresh_after) <= fetched_at + timedelta(days=44)
+        )
 
     def test_store_saves_tabelog_restaurant_url_matches_for_future_use(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/tests/python/test_trust_signals.py
+++ b/tests/python/test_trust_signals.py
@@ -16,11 +16,13 @@ from scripts.trust_signals import (
     MichelinRegionSource,
     MichelinRestaurant,
     MichelinMatchContext,
+    PlaceSourceUrl,
     TabelogRestaurant,
     TabelogSource,
     SearchResult,
     TrustSignalStore,
     default_trust_cache_path,
+    dedupe_place_source_urls,
     michelin_next_page_url,
     michelin_region_sources_for_guides,
     parse_michelin_full_list_article_page,
@@ -247,6 +249,36 @@ class TrustSignalsTest(unittest.TestCase):
                 )
             ],
         )
+
+    def test_place_source_url_dedupe_uses_confidence_priority(self) -> None:
+        now = datetime(2026, 6, 15, tzinfo=UTC)
+        refresh_after = datetime(2027, 2, 1, tzinfo=UTC)
+        base_url = PlaceSourceUrl(
+            source="tabelog",
+            url="https://tabelog.com/tokyo/A1314/A131401/13196420/",
+            title="Low Confidence",
+            fetched_at=now.isoformat(),
+            refresh_after=refresh_after.isoformat(),
+            confidence="low",
+            match_reason="fallback title match",
+        )
+        medium_url = base_url.model_copy(
+            update={
+                "title": "Medium Confidence",
+                "confidence": "medium",
+                "match_reason": "normalized name match",
+            }
+        )
+        high_url = base_url.model_copy(
+            update={
+                "title": "High Confidence",
+                "confidence": "high",
+                "match_reason": "exact name match",
+            }
+        )
+
+        self.assertEqual(dedupe_place_source_urls([base_url, medium_url]), [medium_url])
+        self.assertEqual(dedupe_place_source_urls([medium_url, high_url]), [high_url])
 
     def test_tabelog_search_eligibility_skips_obvious_non_restaurants(self) -> None:
         cases = [

--- a/tests/python/test_trust_signals.py
+++ b/tests/python/test_trust_signals.py
@@ -490,7 +490,7 @@ class TrustSignalsTest(unittest.TestCase):
                 patch.dict(
                     os.environ,
                     {
-                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TRUST_STORE_URL": sqlite_url_for_path(db_path),
                         "BRAVE_SEARCH_API_KEY": "",
                         "BRAVE_API_KEY": "",
                         "FAVORITE_PLACES_TRUST_GOOGLE_FALLBACK": "",
@@ -559,7 +559,7 @@ class TrustSignalsTest(unittest.TestCase):
                 patch.dict(
                     os.environ,
                     {
-                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TRUST_STORE_URL": sqlite_url_for_path(db_path),
                         "BRAVE_SEARCH_API_KEY": "brave-key",
                         "BRAVE_API_KEY": "",
                         "FAVORITE_PLACES_TRUST_GOOGLE_FALLBACK": "",
@@ -602,7 +602,7 @@ class TrustSignalsTest(unittest.TestCase):
                 patch.dict(
                     os.environ,
                     {
-                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TRUST_STORE_URL": sqlite_url_for_path(db_path),
                         "BRAVE_SEARCH_API_KEY": "brave-key",
                         "BRAVE_API_KEY": "",
                         "FAVORITE_PLACES_TRUST_GOOGLE_FALLBACK": "",
@@ -669,7 +669,7 @@ class TrustSignalsTest(unittest.TestCase):
                 patch.dict(
                     os.environ,
                     {
-                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TRUST_STORE_URL": sqlite_url_for_path(db_path),
                         "FAVORITE_PLACES_TABELOG_SOURCE_URLS": '{"award":"https://award.tabelog.com/en/restaurants"}',
                         "BRAVE_SEARCH_API_KEY": "",
                         "BRAVE_API_KEY": "",
@@ -729,7 +729,7 @@ class TrustSignalsTest(unittest.TestCase):
                 patch.dict(
                     os.environ,
                     {
-                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TRUST_STORE_URL": sqlite_url_for_path(db_path),
                         "FAVORITE_PLACES_TABELOG_SOURCE_URLS": '{"hyakumeiten":"https://award.tabelog.com/hyakumeiten"}',
                         "BRAVE_SEARCH_API_KEY": "",
                         "BRAVE_API_KEY": "",
@@ -818,7 +818,7 @@ class TrustSignalsTest(unittest.TestCase):
                 patch.dict(
                     os.environ,
                     {
-                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TRUST_STORE_URL": sqlite_url_for_path(db_path),
                         "FAVORITE_PLACES_TABELOG_SOURCE_URLS": '{"hyakumeiten":"https://award.tabelog.com/hyakumeiten"}',
                         "BRAVE_SEARCH_API_KEY": "",
                         "BRAVE_API_KEY": "",
@@ -901,7 +901,7 @@ class TrustSignalsTest(unittest.TestCase):
                 patch.dict(
                     os.environ,
                     {
-                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TRUST_STORE_URL": sqlite_url_for_path(db_path),
                         "FAVORITE_PLACES_TABELOG_SOURCE_URLS": '{"hyakumeiten":"https://award.tabelog.com/hyakumeiten"}',
                         "BRAVE_SEARCH_API_KEY": "",
                         "BRAVE_API_KEY": "",
@@ -979,7 +979,7 @@ class TrustSignalsTest(unittest.TestCase):
                 patch.dict(
                     os.environ,
                     {
-                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TRUST_STORE_URL": sqlite_url_for_path(db_path),
                         "FAVORITE_PLACES_TABELOG_SOURCE_URLS": '{"hyakumeiten":"https://award.tabelog.com/hyakumeiten"}',
                         "BRAVE_SEARCH_API_KEY": "",
                         "BRAVE_API_KEY": "",

--- a/tests/python/test_trust_signals.py
+++ b/tests/python/test_trust_signals.py
@@ -789,7 +789,7 @@ class TrustSignalsTest(unittest.TestCase):
                         url="https://tabelog.com/tokyo/A1314/A131401/13196420/",
                         title="Higashiazabu Amamoto",
                         fetched_at=now.isoformat(),
-                        refresh_after=(now + timedelta(days=90)).isoformat(),
+                        refresh_after=datetime(2099, 1, 1, tzinfo=UTC).isoformat(),
                         confidence="medium",
                         match_reason="Tabelog search result name match",
                     )

--- a/tests/python/test_trust_signals.py
+++ b/tests/python/test_trust_signals.py
@@ -856,6 +856,89 @@ class TrustSignalsTest(unittest.TestCase):
         self.assertEqual(loaded["place-1"][0].source, "tabelog")
         self.assertEqual(loaded["place-1"][0].match_reason, "Tabelog saved source URL match")
 
+    def test_refresh_reuses_existing_direct_tabelog_signal_before_search_gate(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "trust.sqlite"
+            now = datetime(2026, 6, 15, tzinfo=UTC)
+            existing_signal = TrustSignal(
+                source="tabelog",
+                label="Tabelog Hyakumeiten",
+                tier="寿司 TOKYO 百名店",
+                award_year=2025,
+                is_current=True,
+                url="https://tabelog.com/tokyo/A1314/A131401/13196420/",
+                title="東麻布 天本",
+                fetched_at=now.isoformat(),
+                confidence="high",
+                match_reason="Tabelog direct search URL match",
+            )
+            store = TrustSignalStore(sqlite_url_for_path(db_path))
+            store.replace_search_signals(
+                "place-1",
+                [existing_signal],
+                match_signature=trust_match_signature("Higashiazabu Amamoto", "Tokyo", "Japan"),
+                now=now,
+            )
+            raw_lists = {
+                "tokyo-japan": RawSavedList(
+                    title="Tokyo, Japan",
+                    places=[
+                        RawPlace(
+                            name="Higashiazabu Amamoto",
+                            address="Akabanebashi, Tokyo, Japan",
+                            maps_url="https://maps.google.com/?q=higashiazabu-amamoto",
+                        )
+                    ],
+                )
+            }
+            enrichment_entry = EnrichmentCacheEntry(
+                fetched_at=now.isoformat(),
+                query="Higashiazabu Amamoto",
+                place=EnrichmentPlace(primary_type_display_name="Hotel"),
+            )
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "FAVORITE_PLACES_TRUST_CACHE_PATH": str(db_path),
+                        "FAVORITE_PLACES_TABELOG_SOURCE_URLS": '{"hyakumeiten":"https://award.tabelog.com/hyakumeiten"}',
+                        "BRAVE_SEARCH_API_KEY": "",
+                        "BRAVE_API_KEY": "",
+                        "FAVORITE_PLACES_TRUST_GOOGLE_FALLBACK": "",
+                    },
+                ),
+                patch("scripts.trust_signals.scrape_michelin_region_source", return_value=[]),
+                patch(
+                    "scripts.trust_signals.scrape_tabelog_source",
+                    return_value=[
+                        TabelogRestaurant(
+                            name="東麻布 天本",
+                            url="https://tabelog.com/tokyo/A1314/A131401/13196420/",
+                            label="Tabelog Hyakumeiten",
+                            tier="寿司 TOKYO 百名店",
+                            award_year=2025,
+                            is_current=True,
+                            region_key="japan",
+                        )
+                    ],
+                ),
+                patch("scripts.trust_signals.tabelog_search", side_effect=AssertionError("unexpected Tabelog search")),
+            ):
+                refresh_trust_signals_for_raw_guides(
+                    root=Path(tmpdir),
+                    raw_lists=raw_lists,
+                    enrichment_caches={"tokyo-japan": {"place-1": enrichment_entry}},
+                    stable_place_ids={("tokyo-japan", 0): "place-1"},
+                )
+
+            loaded = store.load_signals_for_place_keys(["place-1"])
+
+        self.assertEqual(len(loaded["place-1"]), 1)
+        self.assertEqual(loaded["place-1"][0].source, "tabelog")
+        self.assertEqual(loaded["place-1"][0].url, existing_signal.url)
+        self.assertEqual(loaded["place-1"][0].match_reason, "Tabelog saved source URL match")
+
     def test_refresh_preserves_tabelog_rows_when_tabelog_search_fails(self) -> None:
         with TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "trust.sqlite"


### PR DESCRIPTION
## Summary

- Align Tabelog Award/search refreshes to the post-award February window with deterministic staggering.
- Refresh Hyakumeiten source snapshots on a shorter rolling TTL.
- Skip direct Tabelog searches for obvious non-food/drink places using existing category/type enrichment.
- Save matched Tabelog restaurant URLs in the shared trust cache for future reuse.
- Stage refreshed author photos in the self-hosted data refresh workflow.

## Why

The trust-signal refresh was retrying too many Tabelog searches at once and also querying obvious non-restaurant places such as parks, museums, temples, and hotels. It also saved Tabelog URL matches only indirectly inside query snapshots. The workflow change prevents refreshed byline JSON from pointing at unstaged author photo assets.

## Validation

- `uv run python3 -m unittest tests.python.test_trust_signals`
- `bun install --frozen-lockfile`
- `bun run check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist place source URLs discovered from Tabelog searches for future use

* **Improvements**
  * Data refresh now only stages author photos when present
  * More granular, provider-specific refresh scheduling and eligibility to reduce unnecessary Tabelog queries
  * Deduplication of persisted source URLs preferring higher-confidence matches

* **Tests**
  * Expanded tests for storage, refresh timing, eligibility, and URL deduplication
<!-- end of auto-generated comment: release notes by coderabbit.ai -->