### PR TITLE
[codex] Refine guide-first home search

### DIFF
--- a/public/scripts/home-browser.js
+++ b/public/scripts/home-browser.js
@@ -322,6 +322,7 @@ if (root) {
       const itemMeta = document.createElement("span");
       itemMeta.className = "search-country-item-meta";
       itemMeta.textContent = [entry.category, entry.neighborhood].filter(Boolean).join(" · ");
+      itemMeta.hidden = !itemMeta.textContent;
 
       const rating = ratingValue(entry.rating);
       const reviewCount = reviewCountValue(entry.user_rating_count);
@@ -547,8 +548,28 @@ if (root) {
       searchIndex && rawQuery
         ? new Set(searchGuides(rawQuery, { index: searchIndex }).map((result) => result.guide.slug))
         : null;
+    const scopedGuideMatchCount = guideMatches
+      ? countryBlocks.reduce((count, block) => {
+          const country = block.dataset.country || "";
+          if (activeCountry && country !== activeCountry) {
+            return count;
+          }
+
+          const cards = Array.from(block.querySelectorAll("[data-guide-card]"));
+          return (
+            count +
+            cards.filter((card) => {
+              const guideSlug = card.dataset.guideSlug || "";
+              return (
+                guideMatches.has(guideSlug) &&
+                (!nearbyGuideSlugs || nearbyGuideSlugs.has(guideSlug))
+              );
+            }).length
+          );
+        }, 0)
+      : 0;
     const shouldUsePlaceMatchFallback =
-      Boolean(rawQuery) && Boolean(placeMatchGuideSlugs) && (guideMatches?.size ?? 0) === 0;
+      Boolean(rawQuery) && (placeMatchGuideSlugs?.size ?? 0) > 0 && scopedGuideMatchCount === 0;
     const matchingGuidesByCountry = new Map();
     const visibleGuideSlugs = [];
     let visibleGuideCount = 0;

--- a/public/scripts/home-browser.js
+++ b/public/scripts/home-browser.js
@@ -182,21 +182,31 @@ if (root) {
     [
       ...results
         .reduce((groups, result) => {
-          const country = result.entry.country || "Unknown";
-          if (!groups.has(country)) {
-            groups.set(country, []);
+          const key = result.entry.guide_slug || result.entry.guide_title || "unknown-guide";
+          if (!groups.has(key)) {
+            groups.set(key, []);
           }
-          groups.get(country).push(result);
+          groups.get(key).push(result);
           return groups;
         }, new Map())
         .entries(),
     ]
-      .map(([country, items]) => ({ country, items }))
+      .map(([key, items]) => {
+        const entry = items[0]?.entry || {};
+        return {
+          key,
+          guideSlug: entry.guide_slug || "",
+          guideTitle: entry.guide_title || "Guide",
+          city: entry.city || "",
+          country: entry.country || "",
+          items,
+        };
+      })
       .sort(
         (left, right) =>
           right.items.length - left.items.length ||
           right.items[0].score - left.items[0].score ||
-          left.country.localeCompare(right.country),
+          left.guideTitle.localeCompare(right.guideTitle),
       );
 
   const updateSearchViewButtons = () => {
@@ -267,15 +277,25 @@ if (root) {
     return card;
   };
 
-  const createGroupedCountryCard = (group, query) => {
+  const createGroupedGuideCard = (group, query) => {
     const card = document.createElement("article");
     card.className = "search-country-card";
 
     const header = document.createElement("div");
     header.className = "search-country-card-head";
 
+    const titleBlock = document.createElement("div");
+    titleBlock.className = "search-country-card-title";
+
     const title = document.createElement("h4");
-    title.textContent = group.country;
+    title.textContent = group.guideTitle;
+
+    const meta = document.createElement("p");
+    meta.className = "search-country-item-meta";
+    meta.textContent = [group.city, group.country].filter(Boolean).join(", ");
+    meta.hidden = !meta.textContent;
+
+    titleBlock.append(title, meta);
 
     const count = document.createElement("p");
     count.className = "small-copy";
@@ -284,7 +304,7 @@ if (root) {
         ? `${pluralize(group.items.length, "match", "matches")} · top ${GROUP_LIMIT} shown`
         : pluralize(group.items.length, "match", "matches");
 
-    header.append(title, count);
+    header.append(titleBlock, count);
 
     const list = document.createElement("div");
     list.className = "search-country-list";
@@ -301,13 +321,7 @@ if (root) {
 
       const itemMeta = document.createElement("span");
       itemMeta.className = "search-country-item-meta";
-      itemMeta.textContent = [
-        entry.guide_title,
-        [entry.category, entry.neighborhood].filter(Boolean).join(" · "),
-        entry.city,
-      ]
-        .filter(Boolean)
-        .join(" · ");
+      itemMeta.textContent = [entry.category, entry.neighborhood].filter(Boolean).join(" · ");
 
       const rating = ratingValue(entry.rating);
       const reviewCount = reviewCountValue(entry.user_rating_count);
@@ -432,7 +446,7 @@ if (root) {
       ...visibleIndividualResults.map((result) => createSearchResultCard(result, query)),
     );
     groupedResultsList.replaceChildren(
-      ...groupedResults.map((group) => createGroupedCountryCard(group, query)),
+      ...groupedResults.map((group) => createGroupedGuideCard(group, query)),
     );
 
     globalResultsList.hidden = searchResultView !== "individual";
@@ -453,8 +467,7 @@ if (root) {
         searchResultView === "grouped"
           ? `${pluralize(visibleResults.length, "matching place")} across ${pluralize(
               groupedResults.length,
-              "country",
-              "countries",
+              "guide",
             )}`
           : `${pluralize(visibleResults.length, "matching place")}`;
     }
@@ -477,7 +490,7 @@ if (root) {
       }
 
       if (searchResultView === "grouped" && visibleResults.length > 0) {
-        summaryBits.push(`Showing up to ${GROUP_LIMIT} places per country`);
+        summaryBits.push(`Showing up to ${GROUP_LIMIT} places per guide`);
       } else if (
         searchResultView === "individual" &&
         visibleResults.length > INDIVIDUAL_RESULT_LIMIT
@@ -534,6 +547,8 @@ if (root) {
       searchIndex && rawQuery
         ? new Set(searchGuides(rawQuery, { index: searchIndex }).map((result) => result.guide.slug))
         : null;
+    const shouldUsePlaceMatchFallback =
+      Boolean(rawQuery) && Boolean(placeMatchGuideSlugs) && (guideMatches?.size ?? 0) === 0;
     const matchingGuidesByCountry = new Map();
     const visibleGuideSlugs = [];
     let visibleGuideCount = 0;
@@ -552,8 +567,8 @@ if (root) {
           return true;
         }
         return (
-          placeMatchGuideSlugs?.has(guideSlug) ||
           guideMatches?.has(guideSlug) ||
+          (shouldUsePlaceMatchFallback && placeMatchGuideSlugs?.has(guideSlug)) ||
           (!searchIndex && (card.dataset.search || "").includes(normalizedQuery))
         );
       });
@@ -665,11 +680,12 @@ if (root) {
   const setSearchView = (view) => {
     const nextView = view === "individual" ? "individual" : "grouped";
     if (searchResultView === nextView) {
+      renderGlobalSearch((searchInput?.value || "").trim());
       return;
     }
 
     searchResultView = nextView;
-    renderGlobalSearch((searchInput?.value || "").trim().toLowerCase());
+    renderGlobalSearch((searchInput?.value || "").trim());
   };
 
   searchInput?.addEventListener("input", update);

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -161,7 +161,7 @@ const defaultSiteConfig: SiteConfig = {
     guidesEyebrow: "Guides",
     guidesHeading: "Browse by country",
     guidesLinkText: null,
-    searchPlaceholder: "Search quiet coffee, date night, rainy day museums",
+    searchPlaceholder: "Search a city, country, or guide",
     showHero: true,
     showHeroStats: true,
     showGuideBrowser: true,
@@ -176,7 +176,7 @@ const defaultSiteConfig: SiteConfig = {
     emptyStateText: "No matching guides. Try a broader search or choose all countries.",
     searchResultsEyebrow: "Search results",
     searchResultsHeading: "Matching places",
-    searchResultsGroupedLabel: "By country",
+    searchResultsGroupedLabel: "By guide",
     searchResultsIndividualLabel: "Individual",
     searchResultsEmptyText: "No matching places. Try a broader search.",
     guideCard: {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -296,6 +296,28 @@ const homeJsonLd = [
       {siteConfig.home.emptyStateText}
     </div>
 
+    {siteConfig.home.showMap && <HomeGuideMap guides={locationGuideCandidates} />}
+
+    {guidesByCountry.map(({ countryName, countryGuides, countryFlag }) => (
+      <div class="country-block ui-country-block" data-country-block data-country={countryName.toLowerCase()}>
+        <div class="ui-section-head country-section-head">
+          <div class="country-title-row">
+            <h3 class="ui-section-title">{countryFlag ? `${countryName} ${countryFlag}` : countryName}</h3>
+            <span class="count-chip country-guide-count">
+              <strong>{countryGuides.length}</strong>
+              <span>guide{countryGuides.length === 1 ? "" : "s"}</span>
+            </span>
+          </div>
+        </div>
+
+        <div class="card-grid ui-card-grid">
+          {countryGuides.map((guide) => (
+            <GuideCard guide={guide} />
+          ))}
+        </div>
+      </div>
+    ))}
+
     <div
       class="global-search-results ui-search-results"
       data-global-search-results
@@ -341,28 +363,6 @@ const homeJsonLd = [
         {siteConfig.home.searchResultsEmptyText}
       </div>
     </div>
-
-    {siteConfig.home.showMap && <HomeGuideMap guides={locationGuideCandidates} />}
-
-    {guidesByCountry.map(({ countryName, countryGuides, countryFlag }) => (
-      <div class="country-block ui-country-block" data-country-block data-country={countryName.toLowerCase()}>
-        <div class="ui-section-head country-section-head">
-          <div class="country-title-row">
-            <h3 class="ui-section-title">{countryFlag ? `${countryName} ${countryFlag}` : countryName}</h3>
-            <span class="count-chip country-guide-count">
-              <strong>{countryGuides.length}</strong>
-              <span>guide{countryGuides.length === 1 ? "" : "s"}</span>
-            </span>
-          </div>
-        </div>
-
-        <div class="card-grid ui-card-grid">
-          {countryGuides.map((guide) => (
-            <GuideCard guide={guide} />
-          ))}
-        </div>
-      </div>
-    ))}
   </section>
   )}
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -573,12 +573,15 @@
 
   .search-country-grid {
     display: grid;
+    align-items: start;
     gap: 1rem;
   }
 
   .search-country-card {
     padding: 1rem;
     display: grid;
+    align-content: start;
+    align-self: start;
     gap: 0.8rem;
     border: 1px solid var(--line);
     border-radius: var(--radius-lg);
@@ -598,6 +601,11 @@
     color: var(--ink);
     font-size: 1.14rem;
     line-height: 1.25;
+  }
+
+  .search-country-card-title {
+    display: grid;
+    gap: 0.2rem;
   }
 
   .search-country-list {
@@ -657,6 +665,8 @@
     min-width: 0;
     padding: 1rem;
     display: grid;
+    align-content: start;
+    align-self: start;
     gap: 0.7rem;
     border: 1px solid var(--line);
     border-radius: var(--radius-lg);
@@ -785,6 +795,8 @@
     min-width: 0;
     padding: 1.25rem;
     display: grid;
+    align-content: start;
+    align-self: start;
     gap: 1rem;
     transition:
       border-color 160ms ease,

--- a/tests/e2e/home-browser.spec.ts
+++ b/tests/e2e/home-browser.spec.ts
@@ -16,6 +16,10 @@ test("filters guides by country and renders global place search results", async 
   await expect(page.locator('[data-guide-card][data-guide-slug="taipei-taiwan"]')).toBeVisible();
   await expect(page.locator('[data-guide-card][data-guide-slug="tokyo-japan"]')).toBeHidden();
 
+  await page.locator("[data-home-search-input]").fill("bar");
+  await expect(page.locator("[data-home-results-count]")).toHaveText("1 guide across 1 country");
+  await expect(page.locator('[data-guide-card][data-guide-slug="taipei-taiwan"]')).toBeVisible();
+
   await page.locator("[data-home-search-input]").fill("museum");
   await expect(page.locator("[data-global-search-results]")).toBeVisible();
   await expect(page.locator("[data-global-search-title]")).toContainText("matching");

--- a/tests/e2e/home-browser.spec.ts
+++ b/tests/e2e/home-browser.spec.ts
@@ -19,7 +19,9 @@ test("filters guides by country and renders global place search results", async 
   await page.locator("[data-home-search-input]").fill("museum");
   await expect(page.locator("[data-global-search-results]")).toBeVisible();
   await expect(page.locator("[data-global-search-title]")).toContainText("matching");
-  await expect(page.locator("[data-grouped-search-list]")).toContainText("Taiwan");
+  await expect(page.locator("[data-global-search-disclosure]")).toHaveCount(0);
+  await expect(page.locator("[data-grouped-search-list]")).toBeVisible();
+  await expect(page.locator("[data-grouped-search-list]")).toContainText("Taipei");
   await expect(page.locator("[data-grouped-search-list]")).toContainText(
     "Museum of Contemporary Art Taipei",
   );


### PR DESCRIPTION
## Summary

Refines the home guide browser so search stays oriented around finding the right guide first, while keeping matching places available below the guide results.

- Moves the matching places section below the guide cards.
- Groups matching places by guide instead of country.
- Updates home search copy and grouped-result toggle copy for guide discovery.
- Top-aligns guide cards and place-result cards so mixed-height result rows read consistently.
- Keeps place matches visible by default and removes the unnecessary hide/show control.

## Impact

Users looking for a specific guide can scan matching guides first, then review matching places within each guide without cross-country grouping noise.

## Validation

- `bun run check`
- `bun run build`
- `bun run test:e2e -- tests/e2e/home-browser.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now grouped by guide instead of country with updated card presentation
  * Updated search placeholder text and grouped results label
  * Reorganized page layout for improved content flow

* **Style**
  * Enhanced card alignment and positioning across the interface

* **Tests**
  * Updated end-to-end test assertions for search functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->