### PR TITLE
Polish metric filters and speed data builds

### DIFF
--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -772,7 +772,7 @@ if (root) {
     }
 
     if (activeBudgetSelections.length === 0) {
-      budgetSummary.textContent = "Any";
+      budgetSummary.textContent = "";
       return;
     }
 
@@ -796,14 +796,14 @@ if (root) {
     if (!ratingSummary) {
       return;
     }
-    ratingSummary.textContent = activeMinRating > 0 ? `${activeMinRating.toFixed(1)}+` : "Any";
+    ratingSummary.textContent = activeMinRating > 0 ? `${activeMinRating.toFixed(1)}+` : "";
   };
 
   const updateReviewSummary = () => {
     if (!reviewSummary) {
       return;
     }
-    reviewSummary.textContent = activeMinReviews > 0 ? `${activeMinReviews}+` : "Any";
+    reviewSummary.textContent = activeMinReviews > 0 ? `${activeMinReviews}+` : "";
   };
 
   const getAutocompleteState = (value) => {

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6177,12 +6177,17 @@ def coerce_string_list(value: Any) -> list[str]:
     return [item.strip() for item in value if isinstance(item, str) and item.strip()]
 
 
+@lru_cache(maxsize=1)
+def places_settings() -> PlacesSettings:
+    return PlacesSettings()
+
+
 def google_places_api_key() -> str | None:
-    return PlacesSettings().google_places_api_key
+    return places_settings().google_places_api_key
 
 
 def google_places_enrichment_strategy() -> Literal["scrape", "api", "scrape_then_api"]:
-    return PlacesSettings().google_places_enrichment_strategy
+    return places_settings().google_places_enrichment_strategy
 
 
 @lru_cache(maxsize=1)
@@ -6202,7 +6207,7 @@ def site_google_maps_place_config_value(key: str) -> Any:
 
 
 def google_maps_place_llm_repair_mode() -> Literal["off", "dom", "dom_then_translation"]:
-    configured = PlacesSettings().google_maps_place_llm_repair
+    configured = places_settings().google_maps_place_llm_repair
     if configured is not None:
         return configured
     site_value = as_string(site_google_maps_place_config_value("llm_repair"))
@@ -6217,7 +6222,7 @@ def google_maps_place_llm_repair_mode() -> Literal["off", "dom", "dom_then_trans
 
 
 def google_maps_place_llm_cache_dir() -> Path:
-    configured = PlacesSettings().google_maps_place_llm_cache_dir
+    configured = places_settings().google_maps_place_llm_cache_dir
     if configured:
         path = Path(configured).expanduser()
         return path if path.is_absolute() else ROOT / path
@@ -6225,7 +6230,7 @@ def google_maps_place_llm_cache_dir() -> Path:
 
 
 def google_maps_place_collect_reviews() -> bool:
-    configured = PlacesSettings().google_maps_place_collect_reviews
+    configured = places_settings().google_maps_place_collect_reviews
     if configured is not None:
         return configured
     site_value = as_bool(site_google_maps_place_config_value("collect_reviews"))
@@ -6233,7 +6238,7 @@ def google_maps_place_collect_reviews() -> bool:
 
 
 def google_maps_place_collect_about() -> bool:
-    configured = PlacesSettings().google_maps_place_collect_about
+    configured = places_settings().google_maps_place_collect_about
     if configured is not None:
         return configured
     site_value = as_bool(site_google_maps_place_config_value("collect_about"))
@@ -6241,7 +6246,7 @@ def google_maps_place_collect_about() -> bool:
 
 
 def google_maps_place_semantic_llm_enabled() -> bool:
-    configured = PlacesSettings().google_maps_place_semantic_llm
+    configured = places_settings().google_maps_place_semantic_llm
     if configured is not None:
         return configured
     site_value = as_bool(site_google_maps_place_config_value("semantic_llm"))
@@ -6249,7 +6254,7 @@ def google_maps_place_semantic_llm_enabled() -> bool:
 
 
 def google_maps_place_semantic_descriptions_enabled() -> bool:
-    configured = PlacesSettings().google_maps_place_semantic_descriptions
+    configured = places_settings().google_maps_place_semantic_descriptions
     if configured is not None:
         return configured
     site_value = as_bool(site_google_maps_place_config_value("semantic_descriptions"))
@@ -6257,7 +6262,7 @@ def google_maps_place_semantic_descriptions_enabled() -> bool:
 
 
 def google_maps_place_semantic_description_force_refresh() -> bool:
-    configured = PlacesSettings().google_maps_place_semantic_description_force_refresh
+    configured = places_settings().google_maps_place_semantic_description_force_refresh
     if configured is not None:
         return configured
     site_value = as_bool(site_google_maps_place_config_value("semantic_description_force_refresh"))

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -461,7 +461,7 @@ const guideJsonLd = [
                     <details class="price-filter-menu metric-filter-menu metric-filter-price">
                       <summary class="price-filter-trigger">
                         <span class="price-filter-title">Price</span>
-                        <span class="price-filter-summary" data-budget-summary>Any</span>
+                        <span class="price-filter-summary" data-budget-summary></span>
                       </summary>
                       <div class="price-filter-panel metric-filter-panel metric-filter-price-panel">
                         {budgetRows.map((row) => (
@@ -505,8 +505,8 @@ const guideJsonLd = [
                   {ratingFilterOptions.length > 0 && (
                     <details class="price-filter-menu metric-filter-menu metric-filter-rating">
                       <summary class="price-filter-trigger">
-                        <span class="price-filter-title">★</span>
-                        <span class="price-filter-summary" data-rating-summary>Any</span>
+                        <span class="price-filter-title">Rating</span>
+                        <span class="price-filter-summary" data-rating-summary></span>
                       </summary>
                       <div class="price-filter-panel metric-filter-panel">
                         <fieldset class="price-filter-options metric-filter-options" aria-label="Minimum rating">
@@ -534,7 +534,7 @@ const guideJsonLd = [
                     <details class="price-filter-menu metric-filter-menu metric-filter-reviews">
                       <summary class="price-filter-trigger">
                         <span class="price-filter-title">Reviews</span>
-                        <span class="price-filter-summary" data-review-summary>Any</span>
+                        <span class="price-filter-summary" data-review-summary></span>
                       </summary>
                       <div class="price-filter-panel metric-filter-panel">
                         <fieldset class="price-filter-options metric-filter-options" aria-label="Minimum review count">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1959,15 +1959,15 @@
   }
 
   .metric-filter-price {
-    width: clamp(7.8rem, 22vw, 9.25rem);
+    width: clamp(6.2rem, 14vw, 6.8rem);
   }
 
   .metric-filter-rating {
-    width: clamp(5rem, 12vw, 5.75rem);
+    width: clamp(6rem, 10vw, 6.35rem);
   }
 
   .metric-filter-reviews {
-    width: clamp(7rem, 16vw, 7.8rem);
+    width: clamp(6.5rem, 13vw, 7rem);
   }
 
   .metric-filter-menu .price-filter-trigger {
@@ -2000,11 +2000,11 @@
     padding-inline: 0.48rem;
   }
 
-  .metric-filter-panel {
-    width: min(18rem, calc(100vw - 2rem));
+  .price-filter-panel.metric-filter-panel {
+    width: min(22rem, calc(100vw - 2rem));
   }
 
-  .metric-filter-price-panel {
+  .price-filter-panel.metric-filter-price-panel {
     width: min(32rem, calc(100vw - 2rem));
   }
 
@@ -2014,12 +2014,11 @@
   }
 
   .metric-filter-reviews .metric-filter-panel {
-    right: 0;
-    left: auto;
+    left: 0;
   }
 
-  .metric-filter-options {
-    grid-template-columns: repeat(auto-fit, minmax(3.5rem, 1fr));
+  .price-filter-options.metric-filter-options {
+    grid-template-columns: repeat(auto-fit, minmax(5.75rem, 1fr));
   }
 
   .price-filter-title {
@@ -2039,6 +2038,10 @@
     color: var(--ink);
     font-size: 0.82rem;
     font-weight: 700;
+  }
+
+  .price-filter-summary:empty {
+    display: none;
   }
 
   .price-filter-panel {
@@ -3321,15 +3324,15 @@
     }
 
     .metric-filter-price {
-      width: 7.4rem;
+      width: 5.9rem;
     }
 
     .metric-filter-rating {
-      width: 4.95rem;
+      width: 6.1rem;
     }
 
     .metric-filter-reviews {
-      width: 6.95rem;
+      width: 6.6rem;
     }
 
     .price-filter-panel {
@@ -3340,16 +3343,21 @@
       box-shadow: none;
     }
 
-    .metric-filter-panel {
+    .price-filter-panel.metric-filter-panel {
       position: absolute;
       top: calc(100% + 0.45rem);
-      width: min(18rem, calc(100vw - 2rem));
+      width: min(22rem, calc(100vw - 2rem));
       margin-top: 0;
       box-shadow: 0 16px 34px rgba(31, 37, 34, 0.14);
     }
 
-    .metric-filter-price-panel {
+    .price-filter-panel.metric-filter-price-panel {
       width: min(32rem, calc(100vw - 4.5rem));
+    }
+
+    .metric-filter-reviews .metric-filter-panel {
+      right: 0;
+      left: auto;
     }
 
     .price-filter-row {


### PR DESCRIPTION
## Summary
- label the metric filter as Rating instead of a star-only control
- keep Price, Rating, and Reviews controls compact while letting dropdown options wrap without clipping
- cache PlacesSettings during data builds to avoid repeated Pydantic settings parsing per place

## Benchmark
- before: build:data sample was 45.1s wall-clock, script timer 43.7s
- after: build:data samples were 20.9s and 20.0s wall-clock, script timers 19.7s and 19.0s

## Validation
- bun run check
- bunx vitest run tests/frontend/guideFilters.test.mjs tests/frontend/seo.test.ts
- bun run test:python
- bun run build
- Playwright layout probe on /guides/tokyo-japan/ at 390x844 and 1440x900

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filter summaries for Price, Rating, and Reviews now display more cleanly when not actively selected.

* **Style**
  * Improved filter panel layouts and adjusted spacing for better user interface consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->