### PR TITLE
[codex] Include place matches in guide filtering

### DIFF
--- a/public/scripts/home-browser.js
+++ b/public/scripts/home-browser.js
@@ -548,28 +548,6 @@ if (root) {
       searchIndex && rawQuery
         ? new Set(searchGuides(rawQuery, { index: searchIndex }).map((result) => result.guide.slug))
         : null;
-    const scopedGuideMatchCount = guideMatches
-      ? countryBlocks.reduce((count, block) => {
-          const country = block.dataset.country || "";
-          if (activeCountry && country !== activeCountry) {
-            return count;
-          }
-
-          const cards = Array.from(block.querySelectorAll("[data-guide-card]"));
-          return (
-            count +
-            cards.filter((card) => {
-              const guideSlug = card.dataset.guideSlug || "";
-              return (
-                guideMatches.has(guideSlug) &&
-                (!nearbyGuideSlugs || nearbyGuideSlugs.has(guideSlug))
-              );
-            }).length
-          );
-        }, 0)
-      : 0;
-    const shouldUsePlaceMatchFallback =
-      Boolean(rawQuery) && (placeMatchGuideSlugs?.size ?? 0) > 0 && scopedGuideMatchCount === 0;
     const matchingGuidesByCountry = new Map();
     const visibleGuideSlugs = [];
     let visibleGuideCount = 0;
@@ -589,7 +567,7 @@ if (root) {
         }
         return (
           guideMatches?.has(guideSlug) ||
-          (shouldUsePlaceMatchFallback && placeMatchGuideSlugs?.has(guideSlug)) ||
+          placeMatchGuideSlugs?.has(guideSlug) ||
           (!searchIndex && (card.dataset.search || "").includes(normalizedQuery))
         );
       });

--- a/tests/e2e/home-browser.spec.ts
+++ b/tests/e2e/home-browser.spec.ts
@@ -10,6 +10,15 @@ test("filters guides by country and renders global place search results", async 
     page.locator('[data-guide-card][data-guide-slug="hong-kong-wanderlog-example"]'),
   ).toBeVisible();
 
+  await page.locator("[data-home-search-input]").fill("bar");
+  await expect(page.locator("[data-home-results-count]")).toHaveText("3 guides across 3 countries");
+  await expect(page.locator('[data-guide-card][data-guide-slug="tokyo-japan"]')).toBeVisible();
+  await expect(page.locator('[data-guide-card][data-guide-slug="taipei-taiwan"]')).toBeVisible();
+  await expect(
+    page.locator('[data-guide-card][data-guide-slug="hong-kong-wanderlog-example"]'),
+  ).toBeVisible();
+  await page.locator("[data-home-search-input]").clear();
+
   await page.locator('[data-country-filter][data-country="taiwan"]').click();
 
   await expect(page.locator("[data-home-results-count]")).toHaveText("1 guide across 1 country");


### PR DESCRIPTION
## Summary

- Include place-level guide matches whenever the search index has matching places, even if guide-level matches also exist.
- Remove the zero-guide-match fallback gate that could make guide cards, country counts, and map markers disagree with matching-place results.
- Add Playwright coverage for the mixed `bar` search case where guide search matches one guide and place search matches multiple guides.

## Context

This addresses downstream review feedback on michaelmwu/demflyers-favorites#81: the guide browser should include guides with matching places even when another guide matches at the guide level.

## Validation

- `bun install --frozen-lockfile`
- `uv sync --locked`
- `bun run check`
- `bun run test:e2e -- tests/e2e/home-browser.spec.ts`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guide search results by simplifying the fallback logic to directly include place-match results in filtering.

* **Tests**
  * Enhanced end-to-end tests to verify search functionality and country filtering work correctly across multiple regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->