### PR TITLE
[codex] Use Pyrefly for Python type checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,11 @@ jobs:
       - name: Install Python dependencies
         run: uv sync --frozen
 
+      - name: Type-check Python pipeline
+        run: |
+          uv run pyrefly check
+          uv run pyrefly check --config vendor/gmaps-scraper/pyproject.toml
+
       - name: Run Python tests
         run: |
           uv run python3 -m unittest discover -s tests/python -p 'test_*.py'

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ prek install
 prek run --all-files
 ```
 
-This installs a `prek`-managed pre-commit hook that runs Biome checks on staged frontend files, `ruff` on staged Python files under `scripts/` and `tests/python/`, and `mypy` on the typed pipeline helper modules under `scripts/`.
+This installs a `prek`-managed pre-commit hook that runs Biome checks on staged frontend files, `ruff` on staged Python files under `scripts/` and `tests/python/`, and Pyrefly on the typed pipeline helper modules under `scripts/`.
 
 Keep editor- or agent-specific launch configs local. Files under `.claude/` are not part of the repo contract and should remain untracked.
 

--- a/prek.toml
+++ b/prek.toml
@@ -16,8 +16,8 @@ entry = "uv run ruff check --force-exclude"
 files = "^(scripts|tests/python)/.*\\.py$"
 
 [[repos.hooks]]
-id = "mypy-check"
-name = "mypy"
+id = "pyrefly-check"
+name = "Pyrefly"
 language = "system"
-entry = "uv run mypy --config-file pyproject.toml"
+entry = "uv run pyrefly check"
 files = "^scripts/(pipeline_models|refresh_profiles|refresh_summary)\\.py$"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-  "mypy>=1.18.2,<2.0.0",
+  "pyrefly>=1.0.0,<2.0.0",
   "ruff>=0.14.1,<0.15.0",
 ]
 
@@ -30,16 +30,16 @@ gmaps-scraper = { path = "vendor/gmaps-scraper" }
 target-version = "py314"
 extend-exclude = ["vendor"]
 
-[tool.mypy]
-python_version = "3.14"
-files = [
+[tool.pyrefly]
+project-includes = [
   "scripts/pipeline_models.py",
   "scripts/refresh_profiles.py",
   "scripts/refresh_summary.py",
 ]
-exclude = ["^vendor/"]
-check_untyped_defs = true
-follow_imports = "silent"
-ignore_missing_imports = true
-warn_redundant_casts = true
-warn_unused_ignores = true
+project-excludes = ["**/vendor/"]
+python-version = "3.14.0"
+preset = "legacy"
+ignore-missing-imports = ["*"]
+
+[tool.pyrefly.errors]
+redundant-cast = "warn"

--- a/uv.lock
+++ b/uv.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "mypy" },
+    { name = "pyrefly" },
     { name = "ruff" },
 ]
 
@@ -198,7 +198,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=1.18.2,<2.0.0" },
+    { name = "pyrefly", specifier = ">=1.0.0,<2.0.0" },
     { name = "ruff", specifier = ">=0.14.1,<0.15.0" },
 ]
 
@@ -219,8 +219,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy" },
     { name = "prek" },
+    { name = "pyrefly", specifier = ">=1.0.0,<2.0.0" },
     { name = "ruff" },
 ]
 
@@ -341,40 +341,6 @@ wheels = [
 ]
 
 [[package]]
-name = "librt"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/6b/3d5c13fb3e3c4f43206c8f9dfed13778c2ed4f000bacaa0b7ce3c402a265/librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d", size = 184368, upload-time = "2026-04-09T16:06:26.173Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/c1/184e539543f06ea2912f4b92a5ffaede4f9b392689e3f00acbf8134bee92/librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb", size = 67830, upload-time = "2026-04-09T16:05:34.517Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/ad/23399bdcb7afca819acacdef31b37ee59de261bd66b503a7995c03c4b0dc/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499", size = 70280, upload-time = "2026-04-09T16:05:35.649Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/0b/4542dc5a2b8772dbf92cafb9194701230157e73c14b017b6961a23598b03/librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f", size = 201925, upload-time = "2026-04-09T16:05:36.739Z" },
-    { url = "https://files.pythonhosted.org/packages/31/d4/8ee7358b08fd0cfce051ef96695380f09b3c2c11b77c9bfbc367c921cce5/librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1", size = 212381, upload-time = "2026-04-09T16:05:38.043Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/94/a2025fe442abedf8b038038dab3dba942009ad42b38ea064a1a9e6094241/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f", size = 227065, upload-time = "2026-04-09T16:05:39.394Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/e9/b9fcf6afa909f957cfbbf918802f9dada1bd5d3c1da43d722fd6a310dc3f/librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a", size = 221333, upload-time = "2026-04-09T16:05:40.999Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/7c/ba54cd6aa6a3c8cd12757a6870e0c79a64b1e6327f5248dcff98423f4d43/librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f", size = 229051, upload-time = "2026-04-09T16:05:42.605Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/4b/8cfdbad314c8677a0148bf0b70591d6d18587f9884d930276098a235461b/librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845", size = 222492, upload-time = "2026-04-09T16:05:43.842Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/d1/2eda69563a1a88706808decdce035e4b32755dbfbb0d05e1a65db9547ed1/librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b", size = 223849, upload-time = "2026-04-09T16:05:45.054Z" },
-    { url = "https://files.pythonhosted.org/packages/04/44/b2ed37df6be5b3d42cfe36318e0598e80843d5c6308dd63d0bf4e0ce5028/librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b", size = 245001, upload-time = "2026-04-09T16:05:46.34Z" },
-    { url = "https://files.pythonhosted.org/packages/47/e7/617e412426df89169dd2a9ed0cc8752d5763336252c65dbf945199915119/librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9", size = 51799, upload-time = "2026-04-09T16:05:47.738Z" },
-    { url = "https://files.pythonhosted.org/packages/24/ed/c22ca4db0ca3cbc285e4d9206108746beda561a9792289c3c31281d7e9df/librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e", size = 59165, upload-time = "2026-04-09T16:05:49.198Z" },
-    { url = "https://files.pythonhosted.org/packages/24/56/875398fafa4cbc8f15b89366fc3287304ddd3314d861f182a4b87595ace0/librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f", size = 49292, upload-time = "2026-04-09T16:05:50.362Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/61/bc448ecbf9b2d69c5cff88fe41496b19ab2a1cbda0065e47d4d0d51c0867/librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4", size = 70175, upload-time = "2026-04-09T16:05:51.564Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f2/c47bb71069a73e2f04e70acbd196c1e5cc411578ac99039a224b98920fd4/librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228", size = 72951, upload-time = "2026-04-09T16:05:52.699Z" },
-    { url = "https://files.pythonhosted.org/packages/29/19/0549df59060631732df758e8886d92088da5fdbedb35b80e4643664e8412/librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54", size = 225864, upload-time = "2026-04-09T16:05:53.895Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/f8/3b144396d302ac08e50f89e64452c38db84bc7b23f6c60479c5d3abd303c/librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71", size = 241155, upload-time = "2026-04-09T16:05:55.191Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/ce/ee67ec14581de4043e61d05786d2aed6c9b5338816b7859bcf07455c6a9f/librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938", size = 252235, upload-time = "2026-04-09T16:05:56.549Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/fa/0ead15daa2b293a54101550b08d4bafe387b7d4a9fc6d2b985602bae69b6/librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3", size = 244963, upload-time = "2026-04-09T16:05:57.858Z" },
-    { url = "https://files.pythonhosted.org/packages/29/68/9fbf9a9aa704ba87689e40017e720aced8d9a4d2b46b82451d8142f91ec9/librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283", size = 257364, upload-time = "2026-04-09T16:05:59.686Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/8d/9d60869f1b6716c762e45f66ed945b1e5dd649f7377684c3b176ae424648/librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee", size = 247661, upload-time = "2026-04-09T16:06:00.938Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ff/a5c365093962310bfdb4f6af256f191085078ffb529b3f0cbebb5b33ebe2/librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c", size = 248238, upload-time = "2026-04-09T16:06:02.537Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/3c/2d34365177f412c9e19c0a29f969d70f5343f27634b76b765a54d8b27705/librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15", size = 269457, upload-time = "2026-04-09T16:06:03.833Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -393,44 +359,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
-name = "mypy"
-version = "1.20.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30", size = 14524561, upload-time = "2026-04-21T17:06:27.325Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924", size = 13363883, upload-time = "2026-04-21T17:11:11.239Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/56/983916806bf4eddeaaa2c9230903c3669c6718552a921154e1c5182c701f/mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb", size = 13742945, upload-time = "2026-04-21T17:08:34.181Z" },
-    { url = "https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc", size = 14706163, upload-time = "2026-04-21T17:05:15.51Z" },
-    { url = "https://files.pythonhosted.org/packages/94/97/48ff3b297cafcc94d185243a9190836fb1b01c1b0918fff64e941e973cc9/mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558", size = 14938677, upload-time = "2026-04-21T17:05:39.562Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8", size = 11089322, upload-time = "2026-04-21T17:06:44.29Z" },
-    { url = "https://files.pythonhosted.org/packages/78/c2/ce7ee2ba36aeb954ba50f18fa25d9c1188578654b97d02a66a15b6f09531/mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3", size = 10017775, upload-time = "2026-04-21T17:07:20.732Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/a1/9d93a7d0b5859af0ead82b4888b46df6c8797e1bc5e1e262a08518c6d48e/mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609", size = 15549002, upload-time = "2026-04-21T17:08:23.107Z" },
-    { url = "https://files.pythonhosted.org/packages/00/d2/09a6a10ee1bf0008f6c144d9676f2ca6a12512151b4e0ad0ff6c4fac5337/mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2", size = 14401942, upload-time = "2026-04-21T17:07:31.837Z" },
-    { url = "https://files.pythonhosted.org/packages/57/da/9594b75c3c019e805250bed3583bdf4443ff9e6ef08f97e39ae308cb06f2/mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c", size = 15041649, upload-time = "2026-04-21T17:09:34.653Z" },
-    { url = "https://files.pythonhosted.org/packages/97/77/f75a65c278e6e8eba2071f7f5a90481891053ecc39878cc444634d892abe/mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744", size = 15864588, upload-time = "2026-04-21T17:11:44.936Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/46/1a4e1c66e96c1a3246ddf5403d122ac9b0a8d2b7e65730b9d6533ba7a6d3/mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6", size = 16093956, upload-time = "2026-04-21T17:10:17.683Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/2c/78a8851264dec38cd736ca5b8bc9380674df0dd0be7792f538916157716c/mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec", size = 12568661, upload-time = "2026-04-21T17:11:54.473Z" },
-    { url = "https://files.pythonhosted.org/packages/83/01/cd7318aa03493322ce275a0e14f4f52b8896335e4e79d4fb8153a7ad2b77/mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382", size = 10389240, upload-time = "2026-04-21T17:09:42.719Z" },
-    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314, upload-time = "2026-04-21T17:05:54.5Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -522,15 +450,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
 ]
 
 [[package]]
@@ -707,6 +626,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyrefly"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/20/976165fa4b1517a1a92f393b3f4d4badabfff1165eff09d4cd4908428183/pyrefly-1.1.1.tar.gz", hash = "sha256:6deda959f8603a7dbdf112c48983e2275b2903cf33c8c739ed65d7e71a4fd520", size = 5880491, upload-time = "2026-06-18T23:45:43.785Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/d6/02ba666018c6a1cb4ddfa2db98ada721adddd374db5c29ba47a0bf2637fa/pyrefly-1.1.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f4b8595f91885bc8b5e3c282ab68d1df21201668a84e6508b1e15f2feec0bb8d", size = 13631867, upload-time = "2026-06-18T23:45:13.923Z" },
+    { url = "https://files.pythonhosted.org/packages/71/47/7a3457dbbddb513a83cf4fe527d5d5ebda5201a1010ad2a6034030e3e358/pyrefly-1.1.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d6b238e1362622d47a6eb5af704fd8b613c94e8c303386efd6350e3da59fecc8", size = 13075304, upload-time = "2026-06-18T23:45:16.865Z" },
+    { url = "https://files.pythonhosted.org/packages/84/df/70f4b3f42d58ed686a80df31e04eca54d88036cea4f9b96195c64ad0b2b5/pyrefly-1.1.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b50d4510e4f8aaea79e2c4b343a4d7a060c9451c0b2aa9bfe10d7ca1ef33d68d", size = 13446966, upload-time = "2026-06-18T23:45:19.644Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/53/12a19bd6c7af985bcbc13c6910d0f9f6684069ead2282a5c08c2bfbb5d03/pyrefly-1.1.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f330cf039ef3da3b910c84f3a7e431f0cf8d0c1d2dad26491d6cadf3c7cd4759", size = 14449222, upload-time = "2026-06-18T23:45:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f0/e55c48a50076fc0f9ecf4bdedec50456db383e01162f5e2121f8468be071/pyrefly-1.1.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a6342d87c52b04f72156da04f554c4d57f3616f2b32d1763969efb22d05a1407", size = 14472947, upload-time = "2026-06-18T23:45:24.858Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e7/30e085b31fed978ecb675bdbb54df566673ab550469e5af2d350f6af0be6/pyrefly-1.1.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c08b814ad03175e9cf47111390537161828b472044c39ab3320252b3ac6b2edd", size = 13975252, upload-time = "2026-06-18T23:45:27.247Z" },
+    { url = "https://files.pythonhosted.org/packages/47/58/49c3e67641133d3fe5d8d9a660dc0826c6c37ca197d86cad05fa7dd8bfd6/pyrefly-1.1.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d50cad97f19fc893b04deff7239626cffff5dd27ffb29b7d303a1b770247b208", size = 13471780, upload-time = "2026-06-18T23:45:29.775Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1e/65a7ba8355e2c39d8331832905fb74dcc85fc122a3f1dfd6dbf2a88907ad/pyrefly-1.1.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2150b450ee6a6bcbe69b2d45d9a4ebc934a609e1abcf65e490433f38eb873d84", size = 13989306, upload-time = "2026-06-18T23:45:32.576Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/b7ee1ab2392c36945738246fba7524439810befa3cfcc03cb6157567fc10/pyrefly-1.1.1-py3-none-win32.whl", hash = "sha256:5ffd8a8ed62fe4e6bf0afe1837d1bad149bb3b9f80e928ef248c96b836db3742", size = 12608469, upload-time = "2026-06-18T23:45:35.419Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9c/a0f5b52934bf80e9c7eff08222e7caf318287b9aef76acb8d9ac5740581b/pyrefly-1.1.1-py3-none-win_amd64.whl", hash = "sha256:4e0430f3ef69c8ac73505fd6584db70ed504665a9f0816fef7f723de510f26cb", size = 13502172, upload-time = "2026-06-18T23:45:38.375Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/4c6bcb3d456835f51445d3662a428f56c3ea5643ec798c577030ae34298c/pyrefly-1.1.1-py3-none-win_arm64.whl", hash = "sha256:83baf0db71e172665db1fca0ced50b8f7773f5192ca57e8ac6773a772b6d2fc5", size = 12895979, upload-time = "2026-06-18T23:45:41.026Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -220,7 +220,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "prek" },
-    { name = "pyrefly", specifier = ">=1.0.0,<2.0.0" },
+    { name = "pyrefly", specifier = ">=1.1.1" },
     { name = "ruff" },
 ]
 

--- a/vendor/gmaps-scraper/.editorconfig
+++ b/vendor/gmaps-scraper/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/vendor/gmaps-scraper/.github/FUNDING.yml
+++ b/vendor/gmaps-scraper/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: 508-dev

--- a/vendor/gmaps-scraper/.github/ISSUE_TEMPLATE/docs_request.yml
+++ b/vendor/gmaps-scraper/.github/ISSUE_TEMPLATE/docs_request.yml
@@ -1,0 +1,29 @@
+name: Documentation Request
+description: Request new or improved documentation.
+title: "docs: "
+labels:
+  - documentation
+body:
+  - type: textarea
+    id: gap
+    attributes:
+      label: Documentation Gap
+      description: What is missing, unclear, stale, or hard to find?
+    validations:
+      required: true
+  - type: textarea
+    id: audience
+    attributes:
+      label: Audience
+      description: Who needs this documentation?
+      placeholder: API consumers, scraper operators, contributors, agents, etc.
+    validations:
+      required: false
+  - type: textarea
+    id: suggested-location
+    attributes:
+      label: Suggested Location
+      description: Where should this live?
+      placeholder: README.md, docs/USAGE.md, docs/ARCHITECTURE.md, CONTRIBUTING.md
+    validations:
+      required: false

--- a/vendor/gmaps-scraper/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/vendor/gmaps-scraper/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Propose a new scraper capability or workflow.
+title: "feature: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user, scraper, or downstream-consumer problem should this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution
+      description: What should change?
+    validations:
+      required: true
+  - type: textarea
+    id: output-contract
+    attributes:
+      label: Output Contract
+      description: Describe any expected JSON shape, field additions, or compatibility constraints.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches are available?
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Links, sanitized payloads, screenshots, examples, constraints, or non-goals.
+    validations:
+      required: false

--- a/vendor/gmaps-scraper/.github/PULL_REQUEST_TEMPLATE.md
+++ b/vendor/gmaps-scraper/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,21 @@
-<!--- Provide a general summary of your changes in the Title above. -->
+## Summary
 
-<!--- Optionally prefix with feat/chore/fix: -->
+-
 
-## Description
+## Scraper Impact
 
-<!--- Describe your changes in detail. What component does this change affect? -->
+- [ ] Saved-list extraction
+- [ ] Place-page extraction
+- [ ] CLI or public API
+- [ ] Documentation/tooling only
 
-## Related Issue
+## Validation
 
-<!--- If there are any related issues or Notion tasks, please link here, or delete this section or write N/A. -->
+- [ ] Ran the narrowest relevant checks.
+- [ ] Added or updated focused tests for parser, scraper, CLI, or public API changes.
+- [ ] Updated docs or examples when behavior changed.
 
-## How Has This Been Tested?
+## Risk
 
-<!--- Please describe how you tested or plan to test your changes. -->
+- [ ] Low risk, isolated change.
+- [ ] Needs reviewer attention for schema drift, browser behavior, LLM repair, dependency changes, or output-contract compatibility.

--- a/vendor/gmaps-scraper/.github/workflows/ci.yml
+++ b/vendor/gmaps-scraper/.github/workflows/ci.yml
@@ -5,12 +5,22 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -19,6 +29,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Sync dependencies
         run: uv sync --locked --dev
@@ -30,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -38,17 +52,21 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Sync dependencies
         run: uv sync --locked --dev
 
-      - name: Type check
+      - name: Pyrefly type check
         run: ./scripts/typecheck.sh
 
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -57,9 +75,11 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Sync dependencies
         run: uv sync --locked --dev
 
       - name: Test
-        run: uv run python -m unittest discover -s tests
+        run: ./scripts/test.sh

--- a/vendor/gmaps-scraper/.pre-commit-config.yaml
+++ b/vendor/gmaps-scraper/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         always_run: true
         pass_filenames: false
       - id: pyrefly
-        name: Pyrefly
+        name: pyrefly
         entry: ./scripts/typecheck.sh
         language: system
         always_run: true

--- a/vendor/gmaps-scraper/.pre-commit-config.yaml
+++ b/vendor/gmaps-scraper/.pre-commit-config.yaml
@@ -7,8 +7,8 @@ repos:
         language: system
         always_run: true
         pass_filenames: false
-      - id: mypy
-        name: mypy
+      - id: pyrefly
+        name: Pyrefly
         entry: ./scripts/typecheck.sh
         language: system
         always_run: true

--- a/vendor/gmaps-scraper/AGENTS.md
+++ b/vendor/gmaps-scraper/AGENTS.md
@@ -14,6 +14,37 @@ individual Google Maps place pages.
 - The latest stable patch release is `3.14.3` as of March 12, 2026, but the repo pins the `3.14` series so `uv` can use the newest available stable patch on each platform.
 - Local quality gates are `./scripts/lint.sh` and `./scripts/typecheck.sh`.
 
+## Agent Operating Rules
+
+- State assumptions when they affect the implementation. Ask only when multiple
+  reasonable interpretations would materially change the work.
+- Read before writing: inspect the target file, immediate callers, exports, and
+  obvious shared utilities before adding or changing code.
+- Keep changes minimal and scoped. Do not refactor adjacent code, reformat
+  unrelated files, or add speculative abstractions.
+- Match existing conventions for naming, formatting, error handling, tests, and
+  scraper fallbacks. When patterns conflict, choose the more recent or better
+  tested pattern, explain why, and do not blend incompatible approaches.
+- Use code for deterministic decisions such as routing, retries, status-code
+  handling, parsing, and transforms. Reserve LLM use for judgment tasks such as
+  classification, summarization, extraction repair, or English display fields
+  when policy explicitly allows it.
+- For non-trivial changes, reason about state ownership, observability,
+  coupling/blast radius, timing/order of operations, and security before
+  shipping. Surface unresolved risk instead of hiding it.
+- Tests should encode intent, not just exercise code paths. A test is weak if it
+  would keep passing after the relevant scraper behavior or business rule is
+  broken.
+- Fail loud. Do not report success if records, tests, browser steps, payloads, or
+  validations were skipped silently. Preserve diagnostics and quality flags for
+  partial or uncertain extraction.
+- Checkpoint multi-step work: keep track of what changed, what was verified, and
+  what remains. If the implementation state is no longer clear, stop and
+  restate it before continuing.
+- Ground specific claims. Numbers, rankings, source names, causal claims, and
+  performance claims must be supported by repo context, test output, cited
+  sources, or clearly labeled inference.
+
 ## Saved List Workflow
 
 1. Resolve the saved-list URL.

--- a/vendor/gmaps-scraper/CONTRIBUTING.md
+++ b/vendor/gmaps-scraper/CONTRIBUTING.md
@@ -21,8 +21,15 @@ Run the local gates before opening or updating a PR:
 ```bash
 ./scripts/lint.sh
 ./scripts/typecheck.sh
-uv run python -m unittest discover -s tests
+./scripts/test.sh
+./scripts/check-all.sh
 ```
+
+`./scripts/check-all.sh` is the same local gate in one command. It runs linting,
+type checking, and unit tests.
+
+Dependency changes should follow [docs/supply-chain.md](docs/supply-chain.md):
+keep `uv.lock` committed and prefer locked installs.
 
 ## Pull Request Expectations
 

--- a/vendor/gmaps-scraper/README.md
+++ b/vendor/gmaps-scraper/README.md
@@ -62,7 +62,7 @@ Batch scrape places:
 uv run gmaps-scraper \
   --kind place \
   --input places.txt \
-  --session-dir "$CONDUCTOR_ROOT_PATH/.gmaps-scraper/session" \
+  --session-dir .gmaps-scraper/session \
   --max-retries 2 \
   --stagger-ms 500 \
   --output place-results.json
@@ -91,7 +91,7 @@ uv run gmaps-scraper \
   --kind place \
   --input places.txt \
   --llm-repair \
-  --llm-cache-dir "$CONDUCTOR_ROOT_PATH/.gmaps-scraper/llm-cache"
+  --llm-cache-dir .gmaps-scraper/llm-cache
 ```
 
 ## Library Usage
@@ -117,6 +117,7 @@ place = scrape_place(
     place_url,
     browser_session=BrowserSessionConfig(
         profile_dir=Path(".gmaps-scraper/session"),
+        human_mouse=True,
     ),
 )
 
@@ -195,8 +196,12 @@ the CLI, when a refresh only needs overview facts.
   LLM setup, cache behavior, and downstream refresh examples
 - [Architecture](docs/ARCHITECTURE.md): extraction layers, diagnostics, LLM repair,
   translation memory, and session/concurrency design
+- [Supply Chain](docs/supply-chain.md): dependency cooldowns, locked installs,
+  and local artifact handling
 - [Contributing](CONTRIBUTING.md): local development, tests, PR expectations,
   and translation-memory promotion
+- [Security](SECURITY.md): vulnerability reporting, secret handling, and
+  dependency policy
 
 ## Development
 
@@ -204,5 +209,11 @@ the CLI, when a refresh only needs overview facts.
 uv sync --dev
 ./scripts/lint.sh
 ./scripts/typecheck.sh
-uv run python -m unittest discover -s tests
+./scripts/test.sh
+```
+
+Run the complete local gate with:
+
+```bash
+./scripts/check-all.sh
 ```

--- a/vendor/gmaps-scraper/SECURITY.md
+++ b/vendor/gmaps-scraper/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting Vulnerabilities
+
+Do not open public issues for vulnerabilities or leaked secrets.
+
+Report security concerns to the project maintainers through the repository's
+private security advisory flow or another private channel configured by the
+maintainers.
+
+## Secret Handling
+
+- Keep secrets in environment variables or local ignored files.
+- Never commit real `.env` files, tokens, private keys, credentials, Google Maps
+  session state, browser profiles, or production data.
+- Use documented examples for configuration only.
+- Keep debug dumps, screenshots, and browser artifacts out of committed docs
+  unless they are intentionally sanitized fixtures.
+
+## Dependency Policy
+
+This project uses `uv` with dependency cooldowns and locked installs:
+
+- `pyproject.toml` sets `exclude-newer = "7 days"` for `uv` and `uv pip`.
+- CI should use `uv sync --locked --dev`.
+- Dependency changes should keep `uv.lock` committed and reviewable.
+
+## GitHub Actions
+
+Workflows should use least-privilege permissions, pinned or reviewed action
+versions, and `persist-credentials: false` where practical.

--- a/vendor/gmaps-scraper/docs/USAGE.md
+++ b/vendor/gmaps-scraper/docs/USAGE.md
@@ -80,6 +80,12 @@ uv run gmaps-scraper \
   --output place-results.json
 ```
 
+Browser sessions use a weighted random desktop viewport by default. Persistent
+profile sessions keep a stable viewport for that profile path. Use
+`--disable-random-window-size` when you need CloakBrowser's default viewport,
+and `--human-mouse` when you want CloakBrowser to add humanized mouse, keyboard,
+and scroll behavior despite the extra latency.
+
 You can also pass multiple URLs directly or pipe them on stdin:
 
 ```bash

--- a/vendor/gmaps-scraper/docs/supply-chain.md
+++ b/vendor/gmaps-scraper/docs/supply-chain.md
@@ -1,0 +1,33 @@
+# Dependency Supply-Chain Policy
+
+This project is a Python package managed with `uv`.
+
+## uv
+
+Dependency resolution uses a seven-day cooldown:
+
+```toml
+[tool.uv]
+exclude-newer = "7 days"
+
+[tool.uv.pip]
+exclude-newer = "7 days"
+```
+
+Keep `uv.lock` committed. CI and release workflows should install with:
+
+```bash
+uv sync --locked --dev
+```
+
+## Runtime Dependencies
+
+Treat dependency changes as executable-code changes. Before adding or upgrading
+packages, review the package purpose, release recency, lockfile diff, and any
+native or browser automation surface area.
+
+## Local Artifacts
+
+Do not commit browser profiles, session directories, raw Google Maps payload
+dumps, LLM cache files, learned translation-memory files, or screenshots unless
+they are intentionally sanitized fixtures.

--- a/vendor/gmaps-scraper/pyproject.toml
+++ b/vendor/gmaps-scraper/pyproject.toml
@@ -20,24 +20,29 @@ gmaps-scraper = "gmaps_scraper.cli:main"
 [dependency-groups]
 dev = [
   "prek",
-  "pyrefly>=1.0.0,<2.0.0",
+  "pyrefly>=1.1.1",
   "ruff",
 ]
+
+[tool.uv]
+exclude-newer = "7 days"
+
+[tool.uv.pip]
+exclude-newer = "7 days"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/gmaps_scraper"]
 
 [tool.pyrefly]
 project-includes = ["src"]
-python-version = "3.14.0"
-preset = "legacy"
-
-[tool.pyrefly.errors]
-redundant-cast = "warn"
+python-version = "3.14"
+preset = "strict"
+check-unannotated-defs = true
 
 [tool.ruff]
 line-length = 100
 target-version = "py314"
+src = ["src", "tests"]
 
 [tool.ruff.lint]
 select = ["B", "E", "F", "I", "UP"]

--- a/vendor/gmaps-scraper/pyproject.toml
+++ b/vendor/gmaps-scraper/pyproject.toml
@@ -19,18 +19,21 @@ gmaps-scraper = "gmaps_scraper.cli:main"
 
 [dependency-groups]
 dev = [
-  "mypy",
   "prek",
+  "pyrefly>=1.0.0,<2.0.0",
   "ruff",
 ]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/gmaps_scraper"]
 
-[tool.mypy]
-files = ["src"]
-python_version = "3.14"
-strict = true
+[tool.pyrefly]
+project-includes = ["src"]
+python-version = "3.14.0"
+preset = "legacy"
+
+[tool.pyrefly.errors]
+redundant-cast = "warn"
 
 [tool.ruff]
 line-length = 100

--- a/vendor/gmaps-scraper/scripts/check-all.sh
+++ b/vendor/gmaps-scraper/scripts/check-all.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+./scripts/lint.sh
+./scripts/typecheck.sh
+./scripts/test.sh

--- a/vendor/gmaps-scraper/scripts/test.sh
+++ b/vendor/gmaps-scraper/scripts/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+uv run python -m unittest discover -s tests

--- a/vendor/gmaps-scraper/scripts/typecheck.sh
+++ b/vendor/gmaps-scraper/scripts/typecheck.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-uv run pyrefly check
+if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  uv run pyrefly check --output-format=github
+else
+  uv run pyrefly check --summarize-errors
+fi

--- a/vendor/gmaps-scraper/scripts/typecheck.sh
+++ b/vendor/gmaps-scraper/scripts/typecheck.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-uv run mypy
+uv run pyrefly check

--- a/vendor/gmaps-scraper/src/gmaps_scraper/browser_humanization.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/browser_humanization.py
@@ -1,0 +1,46 @@
+"""Browser launch randomization helpers."""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from typing import Literal
+
+type BrowserWindowSize = Literal["random"] | tuple[int, int] | None
+
+_WEIGHTED_DESKTOP_WINDOW_SIZES: tuple[tuple[int, int], ...] = (
+    *((1920, 1080),) * 35,
+    *((1366, 768),) * 26,
+    *((1536, 864),) * 16,
+    *((1280, 720),) * 9,
+    *((1440, 900),) * 9,
+    *((1600, 900),) * 5,
+)
+
+
+def resolve_browser_window_size(
+    window_size: BrowserWindowSize,
+    *,
+    profile_dir: Path | None,
+) -> tuple[int, int] | None:
+    """Resolve a configured browser window size."""
+    if window_size is None:
+        return None
+    if window_size == "random":
+        if profile_dir is None:
+            return random.choice(_WEIGHTED_DESKTOP_WINDOW_SIZES)
+        return _WEIGHTED_DESKTOP_WINDOW_SIZES[
+            _stable_hash(str(profile_dir)) % len(_WEIGHTED_DESKTOP_WINDOW_SIZES)
+        ]
+
+    width, height = window_size
+    if width <= 0 or height <= 0:
+        raise ValueError("Browser window dimensions must be positive.")
+    return width, height
+
+
+def _stable_hash(text: str) -> int:
+    value = 0
+    for character in text:
+        value = (value * 281 ^ ord(character) * 997) & 0xFFFFFFFF
+    return value

--- a/vendor/gmaps-scraper/src/gmaps_scraper/cli.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/cli.py
@@ -109,6 +109,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Reuse a persistent browser profile stored in this directory.",
     )
     parser.add_argument(
+        "--disable-random-window-size",
+        action="store_true",
+        help="Use CloakBrowser's default viewport instead of a weighted random desktop size.",
+    )
+    parser.add_argument(
+        "--human-mouse",
+        action="store_true",
+        help="Enable CloakBrowser humanized mouse, keyboard, and scroll behavior.",
+    )
+    parser.add_argument(
         "--proxy",
         default=os.environ.get("GMAPS_SCRAPER_PROXY"),
         help=(
@@ -232,10 +242,17 @@ def main() -> int:
     if not args.urls and args.input is None:
         parser.error("at least one URL or --input is required.")
     browser_session = None
-    if args.session_dir is not None or args.proxy is not None:
+    if (
+        args.session_dir is not None
+        or args.proxy is not None
+        or args.disable_random_window_size
+        or args.human_mouse
+    ):
         browser_session = BrowserSessionConfig(
             profile_dir=args.session_dir,
             proxy=args.proxy,
+            window_size=None if args.disable_random_window_size else "random",
+            human_mouse=args.human_mouse,
         )
     http_session = None
     if args.http_cookie_jar is not None or args.proxy is not None:

--- a/vendor/gmaps-scraper/src/gmaps_scraper/display_fields.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/display_fields.py
@@ -299,7 +299,9 @@ def _repaired_display_diagnostics(
     repair_source: str,
 ) -> PlaceExtractionDiagnostics:
     existing = place.diagnostics
-    quality_flags = list(existing.quality_flags) if existing is not None else []
+    quality_flags: list[str] = (
+        list(existing.quality_flags) if existing is not None else []
+    )
     if "category_display_en" in repaired_fields:
         quality_flags = [
             flag for flag in quality_flags if flag != "needs_category_display_en"

--- a/vendor/gmaps-scraper/src/gmaps_scraper/llm.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/llm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import atexit
 import importlib
 import json
 import os
@@ -78,11 +79,8 @@ class _NoopLangfuseObservation:
         return None
 
 
-_LANGFUSE_DEFAULT_TIMEOUT_SECONDS = 2
-_LANGFUSE_DEFAULT_FLUSH_AT = 8
-_LANGFUSE_DEFAULT_FLUSH_INTERVAL_SECONDS = 1.0
-type _LANGFUSE_CONFIG = tuple[str, str, str | None, int, int, float]
-_LANGFUSE_CLIENT_CACHE: dict[_LANGFUSE_CONFIG, Any] = {}
+_LANGFUSE_CLIENT_CACHE: dict[tuple[str, str, str | None], Any] = {}
+_LANGFUSE_FLUSH_CLIENT_IDS: set[int] = set()
 _LANGFUSE_CLIENT_CACHE_LOCK = threading.Lock()
 
 
@@ -93,7 +91,7 @@ def _configured_langfuse_client() -> Any | None:
     return _langfuse_client_for_config(config)
 
 
-def _langfuse_client_for_config(config: _LANGFUSE_CONFIG) -> Any | None:
+def _langfuse_client_for_config(config: tuple[str, str, str | None]) -> Any | None:
     cached = _LANGFUSE_CLIENT_CACHE.get(config)
     if cached is not None:
         return cached
@@ -101,30 +99,29 @@ def _langfuse_client_for_config(config: _LANGFUSE_CONFIG) -> Any | None:
         cached = _LANGFUSE_CLIENT_CACHE.get(config)
         if cached is not None:
             return cached
-        public_key, secret_key, base_url, timeout, flush_at, flush_interval = config
+        public_key, secret_key, base_url = config
         try:
             langfuse_module = importlib.import_module("langfuse")
             langfuse_class = langfuse_module.Langfuse
         except (ImportError, AttributeError):
             return None
-        kwargs: dict[str, object] = {
-            "public_key": public_key,
-            "secret_key": secret_key,
-            "timeout": timeout,
-            "flush_at": flush_at,
-            "flush_interval": flush_interval,
-        }
-        if base_url:
-            kwargs["base_url"] = base_url
         try:
-            client = langfuse_class(**kwargs)
+            if base_url:
+                client = langfuse_class(
+                    public_key=public_key,
+                    secret_key=secret_key,
+                    base_url=base_url,
+                )
+            else:
+                client = langfuse_class(public_key=public_key, secret_key=secret_key)
         except Exception:
             return None
         _LANGFUSE_CLIENT_CACHE[config] = client
+        _register_langfuse_flush(client)
         return client
 
 
-def _langfuse_config_from_env() -> _LANGFUSE_CONFIG | None:
+def _langfuse_config_from_env() -> tuple[str, str, str | None] | None:
     public_key = os.environ.get("LANGFUSE_PUBLIC_KEY")
     secret_key = os.environ.get("LANGFUSE_SECRET_KEY")
     base_url = _normalize_langfuse_base_url(
@@ -132,44 +129,13 @@ def _langfuse_config_from_env() -> _LANGFUSE_CONFIG | None:
     )
     if not public_key or not secret_key:
         return None
-    return (
-        public_key,
-        secret_key,
-        base_url,
-        _langfuse_int_option("LANGFUSE_TIMEOUT", default=_LANGFUSE_DEFAULT_TIMEOUT_SECONDS),
-        _langfuse_int_option("LANGFUSE_FLUSH_AT", default=_LANGFUSE_DEFAULT_FLUSH_AT),
-        _langfuse_float_option(
-            "LANGFUSE_FLUSH_INTERVAL",
-            default=_LANGFUSE_DEFAULT_FLUSH_INTERVAL_SECONDS,
-        ),
-    )
-
-
-def _langfuse_int_option(name: str, *, default: int) -> int:
-    raw_value = os.environ.get(name)
-    if not raw_value:
-        return default
-    try:
-        value = int(raw_value)
-    except ValueError:
-        return default
-    return value if value > 0 else default
-
-
-def _langfuse_float_option(name: str, *, default: float) -> float:
-    raw_value = os.environ.get(name)
-    if not raw_value:
-        return default
-    try:
-        value = float(raw_value)
-    except ValueError:
-        return default
-    return value if value > 0 else default
+    return public_key, secret_key, base_url
 
 
 def _clear_langfuse_client_cache() -> None:
     with _LANGFUSE_CLIENT_CACHE_LOCK:
         _LANGFUSE_CLIENT_CACHE.clear()
+        _LANGFUSE_FLUSH_CLIENT_IDS.clear()
 
 
 def _normalize_langfuse_base_url(value: str | None) -> str | None:
@@ -181,6 +147,21 @@ def _normalize_langfuse_base_url(value: str | None) -> str | None:
     if "://" in stripped:
         return stripped
     return f"https://{stripped}"
+
+
+def _register_langfuse_flush(client: Any) -> None:
+    client_id = id(client)
+    if client_id in _LANGFUSE_FLUSH_CLIENT_IDS:
+        return
+    _LANGFUSE_FLUSH_CLIENT_IDS.add(client_id)
+    atexit.register(_flush_langfuse_client, client)
+
+
+def _flush_langfuse_client(client: Any) -> None:
+    try:
+        client.flush()
+    except Exception:
+        return
 
 
 def _langfuse_full_capture_enabled() -> bool:

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -1028,12 +1028,6 @@ _PLACE_JS_EXTRACTOR = r"""
       String.raw`\b(find a table|reserve|reservation|book a table)\b`,
       "i",
     );
-    const providerHostPattern = new RegExp(
-      "(opentable|resy|sevenrooms|thefork|tock|quandoo|yelp|inline|"
-        + "tablecheck|exploretock|omakase|pocket-concierge|pocketconcierge|"
-        + "tabelog|hotpepper|gnavi|gurunavi|ikyu|jpneazy|byfood|autoreserve)",
-      "i",
-    );
     for (const element of panel.querySelectorAll("a[href]")) {
       const href = element.href || element.getAttribute("href") || "";
       if (!/^https?:\/\//i.test(href) || seen.has(href)) {
@@ -1045,9 +1039,8 @@ _PLACE_JS_EXTRACTOR = r"""
         element.getAttribute("aria-label"),
         element.getAttribute("title"),
         element.getAttribute("data-item-id"),
-        href,
       ].filter(Boolean).join(" ");
-      if (!reservationPattern.test(evidence) && !providerHostPattern.test(evidence)) {
+      if (!reservationPattern.test(evidence)) {
         continue;
       }
       seen.add(href);
@@ -1317,11 +1310,19 @@ _PLACE_RESERVATION_DIALOG_JS = r"""
     return cleaned || providerLabelFromUrl(href);
   };
   const providerHostPattern = new RegExp(
-    "(opentable|resy|sevenrooms|thefork|tock|quandoo|yelp|inline|"
+    "(^|[.-])(?:opentable|resy|sevenrooms|thefork|tock|quandoo|yelp|inline|"
       + "tablecheck|exploretock|omakase|pocket-concierge|pocketconcierge|"
-      + "tabelog|hotpepper|gnavi|gurunavi|ikyu|jpneazy|byfood|autoreserve)",
+      + "tabelog|hotpepper|gnavi|gurunavi|ikyu|jpneazy|byfood|autoreserve)"
+      + "([.-]|$)",
     "i",
   );
+  const providerHostMatches = (href) => {
+    try {
+      return providerHostPattern.test(new URL(href).hostname);
+    } catch {
+      return false;
+    }
+  };
   const rejectHostPattern = new RegExp(
     String.raw`(^|\.)google(?:\.[a-z]{2,}){1,2}$`
       + String.raw`|(^|\.)gstatic\.com$`
@@ -1346,7 +1347,7 @@ _PLACE_RESERVATION_DIALOG_JS = r"""
   }).sort((left, right) => {
     const leftRect = left.getBoundingClientRect();
     const rightRect = right.getBoundingClientRect();
-    return (leftRect.width * leftRect.height) - (rightRect.width * rightRect.height);
+    return (rightRect.width * rightRect.height) - (leftRect.width * leftRect.height);
   });
   const providerRoots = dialogs.length ? dialogs : providerPanels.slice(0, 1);
   const roots = providerRoots.length ? providerRoots : [document.body];
@@ -1389,11 +1390,10 @@ _PLACE_RESERVATION_DIALOG_JS = r"""
         element.getAttribute("aria-label"),
         element.getAttribute("title"),
       ].filter(Boolean).join(" ");
-      const evidence = `${rawLabel} ${href}`;
       if (rejectHostPattern.test(host) && !/\/maps\/reserve\b/i.test(href)) {
         continue;
       }
-      if (!hasTrustedProviderRoot && !providerHostPattern.test(evidence)) {
+      if (!hasTrustedProviderRoot && !providerHostMatches(href)) {
         continue;
       }
       seen.add(href);
@@ -2268,6 +2268,8 @@ def _browser_session_for_parallel_worker(
     return BrowserSessionConfig(
         profile_dir=browser_session.profile_dir / f"worker-{worker_index + 1}",
         proxy=browser_session.proxy,
+        window_size=browser_session.window_size,
+        human_mouse=browser_session.human_mouse,
     )
 
 
@@ -2377,13 +2379,10 @@ def collect_place_snapshot(
     overview_screenshot_path: Path | None = None,
 ) -> dict[str, object]:
     """Collect a normalized DOM snapshot for a Google Maps place page."""
-    try:
-        context = _launch_browser_context(
-            headless=headless,
-            browser_session=browser_session,
-        )
-    except Exception as exc:  # pragma: no cover - browser launch error path
-        raise ScrapeError(f"Failed to launch browser context: {exc}") from exc
+    context = _launch_browser_context(
+        headless=headless,
+        browser_session=browser_session,
+    )
     try:
         return _collect_place_snapshot_with_context(
             place_url,
@@ -2436,12 +2435,18 @@ def _collect_place_snapshot_with_context(
         page.wait_for_timeout(settle_time_ms)
         resolved_url = _normalize_response_url(getattr(page, "url", None))
         dom_snapshot = page.evaluate(_PLACE_JS_EXTRACTOR)
-        if isinstance(dom_snapshot, Mapping):
-            reservation_snapshot = _collect_reservation_dialog_snapshot(page, timeout_ms=timeout_ms)
-            if reservation_snapshot:
-                dom_snapshot = _merge_reservation_links(dom_snapshot, reservation_snapshot)
         if overview_screenshot_path is not None:
             _write_place_screenshot(page, overview_screenshot_path)
+        if isinstance(dom_snapshot, Mapping):
+            reservation_snapshot = _collect_reservation_dialog_snapshot(
+                page,
+                timeout_ms=timeout_ms,
+            )
+            if reservation_snapshot:
+                dom_snapshot = _merge_reservation_links(
+                    dom_snapshot,
+                    reservation_snapshot,
+                )
         if collect_reviews and isinstance(dom_snapshot, Mapping):
             review_snapshot = _collect_review_panel_snapshot(page, timeout_ms=timeout_ms)
             if review_snapshot:
@@ -2706,47 +2711,6 @@ def _collect_review_panel_snapshot(page: Any, *, timeout_ms: int) -> dict[str, o
     return result
 
 
-def _collect_reservation_dialog_snapshot(page: Any, *, timeout_ms: int) -> dict[str, object]:
-    try:
-        clicked = page.evaluate(_PLACE_RESERVATION_BUTTON_CLICK_JS)
-    except Exception:
-        return {}
-    if clicked is not True:
-        return {}
-    page.wait_for_timeout(min(max(timeout_ms // 20, 500), 1_500))
-    try:
-        links = page.evaluate(_PLACE_RESERVATION_DIALOG_JS)
-    except Exception:
-        return {}
-    if not isinstance(links, list):
-        return {}
-    return {"reservation_links": links}
-
-
-def _merge_reservation_links(
-    snapshot: Mapping[str, object],
-    reservation_snapshot: Mapping[str, object],
-) -> dict[str, object]:
-    merged = dict(snapshot)
-    links: list[object] = []
-    seen_urls: set[str] = set()
-    for source in (
-        snapshot.get("reservation_links"),
-        reservation_snapshot.get("reservation_links"),
-    ):
-        if not isinstance(source, list):
-            continue
-        for item in source:
-            url = item.get("url") if isinstance(item, Mapping) else None
-            if not isinstance(url, str) or url in seen_urls:
-                continue
-            seen_urls.add(url)
-            links.append(item)
-    if links:
-        merged["reservation_links"] = links
-    return merged
-
-
 def _collect_about_panel_snapshot(page: Any, *, timeout_ms: int) -> dict[str, object]:
     try:
         clicked = page.evaluate(_PLACE_ABOUT_TAB_CLICK_JS)
@@ -2762,6 +2726,23 @@ def _collect_about_panel_snapshot(page: Any, *, timeout_ms: int) -> dict[str, ob
     if not isinstance(sections, list):
         return {}
     return {"about_sections": sections}
+
+
+def _collect_reservation_dialog_snapshot(page: Any, *, timeout_ms: int) -> dict[str, object]:
+    try:
+        clicked = page.evaluate(_PLACE_RESERVATION_BUTTON_CLICK_JS)
+    except Exception:
+        return {}
+    if clicked is not True:
+        return {}
+    page.wait_for_timeout(min(max(timeout_ms // 20, 1_000), 1_500))
+    try:
+        reservation_links = page.evaluate(_PLACE_RESERVATION_DIALOG_JS)
+    except Exception:
+        return {}
+    if not isinstance(reservation_links, list):
+        return {}
+    return {"reservation_links": reservation_links}
 
 
 def _build_place_details(
@@ -2929,6 +2910,33 @@ def _merge_place_sources(
             merged[key] = value
             field_sources[key] = secondary_source
     merged["field_sources"] = field_sources
+    return merged
+
+
+def _merge_reservation_links(
+    primary: Mapping[str, object],
+    secondary: Mapping[str, object],
+) -> dict[str, object]:
+    merged = dict(primary)
+    links: list[object] = []
+    seen_urls: set[str] = set()
+    for source in (primary, secondary):
+        raw_links = source.get("reservation_links")
+        if not isinstance(raw_links, list):
+            continue
+        for raw_link in raw_links:
+            if not isinstance(raw_link, Mapping):
+                continue
+            raw_url = _clean_text(raw_link.get("url"))
+            if raw_url is None:
+                continue
+            url = _normalize_reservation_url(raw_url)
+            if url is None or url in seen_urls:
+                continue
+            seen_urls.add(url)
+            links.append({**raw_link, "url": url})
+    if links:
+        merged["reservation_links"] = links
     return merged
 
 
@@ -4136,19 +4144,49 @@ def _normalize_preview_website(value: str) -> str | None:
     parsed = urlparse(value)
     if parsed.scheme not in {"http", "https"}:
         return None
-    if parsed.netloc.endswith("google.com") or parsed.netloc.endswith("gstatic.com"):
+    host = (parsed.hostname or "").lower()
+    if _is_google_host(host) or _host_matches_domain(host, "gstatic.com"):
         query = parse_qs(parsed.query)
         target = query.get("q", [None])[0]
         if target is None:
             return None
         return _normalize_preview_website(unquote(target))
-    if "googleusercontent.com" in parsed.netloc:
+    if _host_matches_domain(host, "googleusercontent.com"):
         return None
-    if "streetviewpixels-pa.googleapis.com" in parsed.netloc:
+    if _host_matches_domain(host, "streetviewpixels-pa.googleapis.com"):
         return None
-    if parsed.netloc.endswith("inline.app"):
+    if _host_matches_domain(host, "inline.app"):
         return None
     return value
+
+
+def _host_matches_domain(host: str, domain: str) -> bool:
+    return host == domain or host.endswith(f".{domain}")
+
+
+def _is_google_host(host: str) -> bool:
+    return re.search(r"(^|\.)google(?:\.[a-z0-9-]+){1,2}$", host) is not None
+
+
+def _normalize_reservation_url(value: object) -> str | None:
+    url = _clean_text(value)
+    if url is None:
+        return None
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    host = (parsed.hostname or "").lower()
+    if _is_google_host(host) or _host_matches_domain(host, "gstatic.com"):
+        query = parse_qs(parsed.query)
+        target = query.get("q", [None])[0]
+        if target is not None:
+            return _normalize_reservation_url(unquote(target))
+        return url if _reservation_link_is_google_reserve(url) else None
+    if _host_matches_domain(host, "googleusercontent.com"):
+        return None
+    if _host_matches_domain(host, "streetviewpixels-pa.googleapis.com"):
+        return None
+    return url
 
 
 def _normalize_photo_url(value: object) -> str | None:
@@ -4816,12 +4854,7 @@ def _normalize_reservation_links(value: object) -> list[PlaceReservationLink]:
         url = _clean_text(raw_url)
         if url is None:
             continue
-        parsed = urlparse(url)
-        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-            continue
-        normalized_url = _normalize_preview_website(url) if "google.com" in parsed.netloc else url
-        if normalized_url is None:
-            normalized_url = url if parsed.netloc.endswith("google.com") else None
+        normalized_url = _normalize_reservation_url(url)
         if normalized_url is None or normalized_url in seen_urls:
             continue
         label = _clean_reservation_label(raw_label, normalized_url)
@@ -4834,11 +4867,8 @@ def _normalize_reservation_links(value: object) -> list[PlaceReservationLink]:
 
 def _reservation_link_is_google_reserve(url: str) -> bool:
     parsed = urlparse(url)
-    host = parsed.netloc.lower()
-    return (
-        host in {"www.google.com", "google.com", "maps.google.com"}
-        and parsed.path.startswith("/maps/reserve")
-    )
+    host = (parsed.hostname or "").lower()
+    return _is_google_host(host) and parsed.path.startswith("/maps/reserve")
 
 
 def _clean_reservation_label(value: object, url: str) -> str:

--- a/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/place_scraper.py
@@ -3309,7 +3309,7 @@ def _build_place_diagnostics(
 
     raw_sources = snapshot.get("field_sources")
     field_sources = {
-        key: str(value)
+        key: value
         for key, value in raw_sources.items()
         if isinstance(key, str)
         and isinstance(value, str)

--- a/vendor/gmaps-scraper/src/gmaps_scraper/scraper.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/scraper.py
@@ -12,6 +12,10 @@ from pathlib import Path
 from typing import Any, Literal, Required, TypedDict
 from urllib.parse import urljoin
 
+from gmaps_scraper.browser_humanization import (
+    BrowserWindowSize,
+    resolve_browser_window_size,
+)
 from gmaps_scraper.models import SavedList
 from gmaps_scraper.parser import JSONValue, ParseError, parse_saved_list_artifacts
 
@@ -92,6 +96,8 @@ class BrowserSessionConfig:
 
     profile_dir: Path | None = None
     proxy: str | BrowserProxyConfig | None = None
+    window_size: BrowserWindowSize = "random"
+    human_mouse: bool = False
 
 
 @dataclass(slots=True, frozen=True)
@@ -325,19 +331,28 @@ def _launch_browser_context(
     except ImportError as exc:  # pragma: no cover - dependency error path
         raise ScrapeError("CloakBrowser is not installed. Run `uv sync`.") from exc
 
+    session = browser_session or BrowserSessionConfig()
     launch_kwargs: dict[str, Any] = {
         "headless": headless,
-        "humanize": True,
+        "humanize": session.human_mouse,
         "locale": "en-US",
         "extra_http_headers": {"Accept-Language": "en-US,en;q=0.9"},
     }
-    if browser_session is not None and browser_session.proxy is not None:
-        launch_kwargs["proxy"] = browser_session.proxy
-    if browser_session is None or browser_session.profile_dir is None:
+    window_size = resolve_browser_window_size(
+        session.window_size,
+        profile_dir=session.profile_dir,
+    )
+    if window_size is not None:
+        width, height = window_size
+        launch_kwargs["args"] = [f"--window-size={width},{height}"]
+        launch_kwargs["viewport"] = {"width": width, "height": height}
+    if session.proxy is not None:
+        launch_kwargs["proxy"] = session.proxy
+    if session.profile_dir is None:
         return launch_context(**launch_kwargs)
 
-    browser_session.profile_dir.mkdir(parents=True, exist_ok=True)
-    return launch_persistent_context(browser_session.profile_dir, **launch_kwargs)
+    session.profile_dir.mkdir(parents=True, exist_ok=True)
+    return launch_persistent_context(session.profile_dir, **launch_kwargs)
 
 
 def _read_resolved_url(page: Any) -> str | None:

--- a/vendor/gmaps-scraper/src/gmaps_scraper/translation_memory.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/translation_memory.py
@@ -218,16 +218,20 @@ def _merge_learned_translation_memory(
     candidates: list[dict[str, object]],
 ) -> None:
     existing = _read_pending_payload(path)
-    entries = existing.setdefault("entries", [])
-    if not isinstance(entries, list):
+    raw_entries = existing.setdefault("entries", [])
+    if isinstance(raw_entries, list):
+        entries: list[object] = raw_entries
+    else:
         entries = []
         existing["entries"] = entries
     index: dict[tuple[object, object, tuple[object, ...]], dict[object, object]] = {}
     for entry in entries:
         if not isinstance(entry, dict):
             continue
-        field_kinds = entry.get("field_kinds")
-        if not isinstance(field_kinds, list):
+        raw_field_kinds = entry.get("field_kinds")
+        if isinstance(raw_field_kinds, list):
+            field_kinds: list[object] = raw_field_kinds
+        else:
             field_kinds = []
         index[(entry.get("source"), entry.get("target"), tuple(field_kinds))] = entry
     for candidate in candidates:
@@ -263,8 +267,10 @@ def _write_json_atomic(path: Path, payload: Mapping[str, object]) -> None:
 
 
 def _memory_entry_key(entry: Mapping[str, object]) -> tuple[object, object, tuple[object, ...]]:
-    field_kinds = entry.get("field_kinds")
-    if not isinstance(field_kinds, list):
+    raw_field_kinds = entry.get("field_kinds")
+    if isinstance(raw_field_kinds, list):
+        field_kinds: list[object] = raw_field_kinds
+    else:
         field_kinds = []
     return (entry.get("source"), entry.get("target"), tuple(field_kinds))
 

--- a/vendor/gmaps-scraper/tests/test_cli.py
+++ b/vendor/gmaps-scraper/tests/test_cli.py
@@ -210,6 +210,42 @@ class CliTests(unittest.TestCase):
             http_session=None,
         )
 
+    def test_forwards_browser_humanization_flags(self) -> None:
+        stdout = io.StringIO()
+        artifacts = _artifacts()
+        parsed_payload = _parsed_payload()
+        result = _result(parsed_payload)
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "gmaps-scraper",
+                    "https://maps.app.goo.gl/TestSavedListShortUrl",
+                    "--human-mouse",
+                    "--disable-random-window-size",
+                ],
+            ),
+            patch(
+                "gmaps_scraper.cli.collect_saved_list_result",
+                return_value=(artifacts, result),
+            ) as collect_saved_list_result,
+            redirect_stdout(stdout),
+        ):
+            exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(json.loads(stdout.getvalue()), parsed_payload)
+        collect_saved_list_result.assert_called_once_with(
+            "https://maps.app.goo.gl/TestSavedListShortUrl",
+            headless=True,
+            timeout_ms=30_000,
+            settle_time_ms=3_000,
+            collection_mode="auto",
+            browser_session=BrowserSessionConfig(window_size=None, human_mouse=True),
+            http_session=None,
+        )
+
     def test_place_kind_calls_place_scraper(self) -> None:
         stdout = io.StringIO()
         details = PlaceDetails(

--- a/vendor/gmaps-scraper/tests/test_llm.py
+++ b/vendor/gmaps-scraper/tests/test_llm.py
@@ -507,10 +507,7 @@ class LLMConfigTests(unittest.TestCase):
         ):
             config = llm_module._langfuse_config_from_env()
 
-        self.assertEqual(
-            config,
-            ("pk-lf-test", "sk-lf-test", "https://us.cloud.langfuse.com", 2, 8, 1.0),
-        )
+        self.assertEqual(config, ("pk-lf-test", "sk-lf-test", "https://us.cloud.langfuse.com"))
 
     def test_langfuse_client_uses_host_fallback_from_env(self) -> None:
         with (
@@ -526,28 +523,7 @@ class LLMConfigTests(unittest.TestCase):
         ):
             config = llm_module._langfuse_config_from_env()
 
-        self.assertEqual(
-            config,
-            ("pk-lf-test", "sk-lf-test", "https://eu.langfuse.com", 2, 8, 1.0),
-        )
-
-    def test_langfuse_client_uses_export_options_from_env(self) -> None:
-        with (
-            patch.dict(
-                "os.environ",
-                {
-                    "LANGFUSE_PUBLIC_KEY": "pk-lf-test",
-                    "LANGFUSE_SECRET_KEY": "sk-lf-test",
-                    "LANGFUSE_TIMEOUT": "4",
-                    "LANGFUSE_FLUSH_AT": "3",
-                    "LANGFUSE_FLUSH_INTERVAL": "0.5",
-                },
-                clear=True,
-            )
-        ):
-            config = llm_module._langfuse_config_from_env()
-
-        self.assertEqual(config, ("pk-lf-test", "sk-lf-test", None, 4, 3, 0.5))
+        self.assertEqual(config, ("pk-lf-test", "sk-lf-test", "https://eu.langfuse.com"))
 
     def test_langfuse_client_does_not_cache_disabled_env(self) -> None:
         class FakeLangfuse:
@@ -578,13 +554,7 @@ class LLMConfigTests(unittest.TestCase):
         self.assertIsInstance(client, FakeLangfuse)
         self.assertEqual(
             client.kwargs,
-            {
-                "public_key": "pk-lf-test",
-                "secret_key": "sk-lf-test",
-                "timeout": 2,
-                "flush_at": 8,
-                "flush_interval": 1.0,
-            },
+            {"public_key": "pk-lf-test", "secret_key": "sk-lf-test"},
         )
 
     def test_local_config_can_define_fireworks_alias(self) -> None:

--- a/vendor/gmaps-scraper/tests/test_place_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_place_scraper.py
@@ -200,7 +200,18 @@ class PlaceScraperTests(unittest.TestCase):
         self.assertIn("about these providers", _PLACE_RESERVATION_DIALOG_JS)
         self.assertIn("hasTrustedProviderRoot", _PLACE_RESERVATION_DIALOG_JS)
         self.assertIn("closeProviderRoot", _PLACE_RESERVATION_DIALOG_JS)
+        self.assertIn(
+            "return (rightRect.width * rightRect.height) - (leftRect.width * leftRect.height);",
+            _PLACE_RESERVATION_DIALOG_JS,
+        )
         self.assertIn("KeyboardEvent", _PLACE_RESERVATION_DIALOG_JS)
+
+    def test_reservation_extractors_match_provider_hosts_with_boundaries(self) -> None:
+        self.assertNotIn("providerHostMatches", _PLACE_JS_EXTRACTOR)
+        self.assertIn("if (!reservationPattern.test(evidence))", _PLACE_JS_EXTRACTOR)
+        self.assertIn("providerHostMatches", _PLACE_RESERVATION_DIALOG_JS)
+        self.assertIn("(^|[.-])(?:opentable|resy|sevenrooms", _PLACE_RESERVATION_DIALOG_JS)
+        self.assertNotIn("providerHostPattern.test(evidence)", _PLACE_RESERVATION_DIALOG_JS)
 
     def test_reservation_extractors_do_not_match_generic_booking_copy(self) -> None:
         for script in (
@@ -249,13 +260,23 @@ class PlaceScraperTests(unittest.TestCase):
             ],
         )
 
-    def test_collect_place_snapshot_wraps_browser_launch_failures(self) -> None:
-        with patch(
-            "gmaps_scraper.place_scraper._launch_browser_context",
-            side_effect=RuntimeError("context launch failed"),
-        ):
-            with self.assertRaisesRegex(ScrapeError, "Failed to launch browser context"):
-                collect_place_snapshot("https://www.google.com/maps/place/Den")
+    def test_merge_reservation_links_stores_normalized_redirect_urls(self) -> None:
+        merged = _merge_reservation_links(
+            {
+                "reservation_links": [
+                    {
+                        "label": "Inline",
+                        "url": "https://www.google.com:443/url?q=https%3A%2F%2Finline.app%2Fbooking%2Ffoo",
+                    }
+                ]
+            },
+            {"reservation_links": []},
+        )
+
+        self.assertEqual(
+            merged["reservation_links"],
+            [{"label": "Inline", "url": "https://inline.app/booking/foo"}],
+        )
 
     def test_scrape_places_reuses_context_and_retries_quality_flags(self) -> None:
         class _FakeContext:
@@ -320,6 +341,8 @@ class PlaceScraperTests(unittest.TestCase):
     def test_scrape_places_parallel_uses_worker_scoped_session_paths(self) -> None:
         seen_profile_dirs: list[Path | None] = []
         seen_cookie_jar_paths: list[Path | None] = []
+        seen_human_mouse: list[bool] = []
+        seen_window_sizes: list[object] = []
 
         def fake_scrape_places_sequential(
             place_urls: list[str],
@@ -330,6 +353,8 @@ class PlaceScraperTests(unittest.TestCase):
             self.assertIsInstance(browser_session, BrowserSessionConfig)
             self.assertIsInstance(http_session, HttpSessionConfig)
             seen_profile_dirs.append(browser_session.profile_dir)
+            seen_human_mouse.append(browser_session.human_mouse)
+            seen_window_sizes.append(browser_session.window_size)
             seen_cookie_jar_paths.append(http_session.cookie_jar_path)
             return [
                 PlaceScrapeResult(source_url=place_url, attempts=1)
@@ -348,7 +373,11 @@ class PlaceScraperTests(unittest.TestCase):
             ):
                 results = scrape_places(
                     ["url-1", "url-2", "url-3"],
-                    browser_session=BrowserSessionConfig(profile_dir=profile_dir),
+                    browser_session=BrowserSessionConfig(
+                        profile_dir=profile_dir,
+                        window_size=None,
+                        human_mouse=True,
+                    ),
                     http_session=HttpSessionConfig(cookie_jar_path=cookie_jar_path),
                     max_concurrency=2,
                     stagger_ms=10,
@@ -367,6 +396,8 @@ class PlaceScraperTests(unittest.TestCase):
                 ]
             ),
         )
+        self.assertEqual(seen_human_mouse, [True, True])
+        self.assertEqual(seen_window_sizes, [None, None])
         self.assertEqual([result.source_url for result in results], ["url-1", "url-2", "url-3"])
 
     def test_scrape_places_parallel_returns_worker_errors_per_url(self) -> None:
@@ -2792,6 +2823,62 @@ class PlaceScraperTests(unittest.TestCase):
                 {"label": "Ikyu", "url": "https://restaurant.ikyu.com/112767/?ikgo=2"},
                 {"label": "AutoReserve", "url": "https://autoreserve.com/restaurants/example"},
                 {"label": "SG Management", "url": "https://sg-management.jp/reserve/"},
+            ],
+        )
+
+    def test_normalize_reservation_links_unwraps_provider_redirects(self) -> None:
+        links = _normalize_reservation_links(
+            [
+                {
+                    "label": "Find a table Inline",
+                    "url": "https://www.google.com:443/url?q=https%3A%2F%2Finline.app%2Fbooking%2Ffoo",
+                }
+            ]
+        )
+
+        self.assertEqual(
+            [link.to_dict() for link in links],
+            [{"label": "Inline", "url": "https://inline.app/booking/foo"}],
+        )
+
+    def test_normalize_reservation_links_drops_google_reserve_cctld(self) -> None:
+        links = _normalize_reservation_links(
+            [
+                {
+                    "label": "Reserve a table",
+                    "url": "https://www.google.com.sg/maps/reserve/v/dine/c/example",
+                },
+                {
+                    "label": "TableCheck",
+                    "url": "https://www.tablecheck.com/example",
+                },
+            ]
+        )
+
+        self.assertEqual(
+            [link.to_dict() for link in links],
+            [{"label": "TableCheck", "url": "https://www.tablecheck.com/example"}],
+        )
+
+    def test_normalize_reservation_links_ignores_google_substring_hosts(self) -> None:
+        links = _normalize_reservation_links(
+            [
+                {
+                    "label": "Reserve",
+                    "url": "https://evilgoogle.com/maps/reserve/v/dine/c/example",
+                },
+                {
+                    "label": "TableCheck",
+                    "url": "https://www.tablecheck.com/example",
+                },
+            ]
+        )
+
+        self.assertEqual(
+            [link.url for link in links],
+            [
+                "https://evilgoogle.com/maps/reserve/v/dine/c/example",
+                "https://www.tablecheck.com/example",
             ],
         )
 

--- a/vendor/gmaps-scraper/tests/test_scraper.py
+++ b/vendor/gmaps-scraper/tests/test_scraper.py
@@ -179,7 +179,13 @@ class ScraperConsentTests(unittest.TestCase):
             launch_persistent_context=lambda *_args, **_kwargs: None,
         )
 
-        with patch.dict("sys.modules", {"cloakbrowser": fake_module}):
+        with (
+            patch.dict("sys.modules", {"cloakbrowser": fake_module}),
+            patch(
+                "gmaps_scraper.scraper.resolve_browser_window_size",
+                return_value=(1366, 768),
+            ),
+        ):
             context = _launch_browser_context(
                 headless=False,
                 browser_session=BrowserSessionConfig(),
@@ -191,9 +197,11 @@ class ScraperConsentTests(unittest.TestCase):
             [
                 {
                     "extra_http_headers": {"Accept-Language": "en-US,en;q=0.9"},
+                    "args": ["--window-size=1366,768"],
                     "headless": False,
-                    "humanize": True,
+                    "humanize": False,
                     "locale": "en-US",
+                    "viewport": {"width": 1366, "height": 768},
                 }
             ],
         )
@@ -213,12 +221,19 @@ class ScraperConsentTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             profile_dir = Path(tmp_dir) / "session"
-            with patch.dict("sys.modules", {"cloakbrowser": fake_module}):
+            with (
+                patch.dict("sys.modules", {"cloakbrowser": fake_module}),
+                patch(
+                    "gmaps_scraper.scraper.resolve_browser_window_size",
+                    return_value=(1536, 864),
+                ),
+            ):
                 context = _launch_browser_context(
                     headless=True,
                     browser_session=BrowserSessionConfig(
                         profile_dir=profile_dir,
                         proxy="http://proxy.example:8080",
+                        human_mouse=True,
                     ),
                 )
             self.assertTrue(profile_dir.is_dir())
@@ -231,10 +246,12 @@ class ScraperConsentTests(unittest.TestCase):
                     profile_dir,
                     {
                         "extra_http_headers": {"Accept-Language": "en-US,en;q=0.9"},
+                        "args": ["--window-size=1536,864"],
                         "headless": True,
                         "humanize": True,
                         "locale": "en-US",
                         "proxy": "http://proxy.example:8080",
+                        "viewport": {"width": 1536, "height": 864},
                     },
                 )
             ],

--- a/vendor/gmaps-scraper/uv.lock
+++ b/vendor/gmaps-scraper/uv.lock
@@ -117,8 +117,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "mypy" },
     { name = "prek" },
+    { name = "pyrefly" },
     { name = "ruff" },
 ]
 
@@ -130,8 +130,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy" },
     { name = "prek" },
+    { name = "pyrefly", specifier = ">=1.0.0,<2.0.0" },
     { name = "ruff" },
 ]
 
@@ -207,40 +207,6 @@ wheels = [
 ]
 
 [[package]]
-name = "librt"
-version = "0.8.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471, upload-time = "2026-02-17T16:13:06.101Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/6a/907ef6800f7bca71b525a05f1839b21f708c09043b1c6aa77b6b827b3996/librt-0.8.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6cfa7fe54fd4d1f47130017351a959fe5804bda7a0bc7e07a2cdbc3fdd28d34f", size = 66081, upload-time = "2026-02-17T16:12:12.766Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/18/25e991cd5640c9fb0f8d91b18797b29066b792f17bf8493da183bf5caabe/librt-0.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:228c2409c079f8c11fb2e5d7b277077f694cb93443eb760e00b3b83cb8b3176c", size = 68309, upload-time = "2026-02-17T16:12:13.756Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/36/46820d03f058cfb5a9de5940640ba03165ed8aded69e0733c417bb04df34/librt-0.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7aae78ab5e3206181780e56912d1b9bb9f90a7249ce12f0e8bf531d0462dd0fc", size = 196804, upload-time = "2026-02-17T16:12:14.818Z" },
-    { url = "https://files.pythonhosted.org/packages/59/18/5dd0d3b87b8ff9c061849fbdb347758d1f724b9a82241aa908e0ec54ccd0/librt-0.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:172d57ec04346b047ca6af181e1ea4858086c80bdf455f61994c4aa6fc3f866c", size = 206907, upload-time = "2026-02-17T16:12:16.513Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/96/ef04902aad1424fd7299b62d1890e803e6ab4018c3044dca5922319c4b97/librt-0.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b1977c4ea97ce5eb7755a78fae68d87e4102e4aaf54985e8b56806849cc06a3", size = 221217, upload-time = "2026-02-17T16:12:17.906Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ff/7e01f2dda84a8f5d280637a2e5827210a8acca9a567a54507ef1c75b342d/librt-0.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10c42e1f6fd06733ef65ae7bebce2872bcafd8d6e6b0a08fe0a05a23b044fb14", size = 214622, upload-time = "2026-02-17T16:12:19.108Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/8c/5b093d08a13946034fed57619742f790faf77058558b14ca36a6e331161e/librt-0.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4c8dfa264b9193c4ee19113c985c95f876fae5e51f731494fc4e0cf594990ba7", size = 221987, upload-time = "2026-02-17T16:12:20.331Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/cc/86b0b3b151d40920ad45a94ce0171dec1aebba8a9d72bb3fa00c73ab25dd/librt-0.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:01170b6729a438f0dedc4a26ed342e3dc4f02d1000b4b19f980e1877f0c297e6", size = 215132, upload-time = "2026-02-17T16:12:21.54Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/be/8588164a46edf1e69858d952654e216a9a91174688eeefb9efbb38a9c799/librt-0.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:7b02679a0d783bdae30d443025b94465d8c3dc512f32f5b5031f93f57ac32071", size = 215195, upload-time = "2026-02-17T16:12:23.073Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/f2/0b9279bea735c734d69344ecfe056c1ba211694a72df10f568745c899c76/librt-0.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:190b109bb69592a3401fe1ffdea41a2e73370ace2ffdc4a0e8e2b39cdea81b78", size = 237946, upload-time = "2026-02-17T16:12:24.275Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/cc/5f2a34fbc8aeb35314a3641f9956fa9051a947424652fad9882be7a97949/librt-0.8.1-cp314-cp314-win32.whl", hash = "sha256:e70a57ecf89a0f64c24e37f38d3fe217a58169d2fe6ed6d70554964042474023", size = 50689, upload-time = "2026-02-17T16:12:25.766Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/76/cd4d010ab2147339ca2b93e959c3686e964edc6de66ddacc935c325883d7/librt-0.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:7e2f3edca35664499fbb36e4770650c4bd4a08abc1f4458eab9df4ec56389730", size = 57875, upload-time = "2026-02-17T16:12:27.465Z" },
-    { url = "https://files.pythonhosted.org/packages/84/0f/2143cb3c3ca48bd3379dcd11817163ca50781927c4537345d608b5045998/librt-0.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:0d2f82168e55ddefd27c01c654ce52379c0750ddc31ee86b4b266bcf4d65f2a3", size = 48058, upload-time = "2026-02-17T16:12:28.556Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/0e/9b23a87e37baf00311c3efe6b48d6b6c168c29902dfc3f04c338372fd7db/librt-0.8.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2c74a2da57a094bd48d03fa5d196da83d2815678385d2978657499063709abe1", size = 68313, upload-time = "2026-02-17T16:12:29.659Z" },
-    { url = "https://files.pythonhosted.org/packages/db/9a/859c41e5a4f1c84200a7d2b92f586aa27133c8243b6cac9926f6e54d01b9/librt-0.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a355d99c4c0d8e5b770313b8b247411ed40949ca44e33e46a4789b9293a907ee", size = 70994, upload-time = "2026-02-17T16:12:31.516Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/28/10605366ee599ed34223ac2bf66404c6fb59399f47108215d16d5ad751a8/librt-0.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2eb345e8b33fb748227409c9f1233d4df354d6e54091f0e8fc53acdb2ffedeb7", size = 220770, upload-time = "2026-02-17T16:12:33.294Z" },
-    { url = "https://files.pythonhosted.org/packages/af/8d/16ed8fd452dafae9c48d17a6bc1ee3e818fd40ef718d149a8eff2c9f4ea2/librt-0.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9be2f15e53ce4e83cc08adc29b26fb5978db62ef2a366fbdf716c8a6c8901040", size = 235409, upload-time = "2026-02-17T16:12:35.443Z" },
-    { url = "https://files.pythonhosted.org/packages/89/1b/7bdf3e49349c134b25db816e4a3db6b94a47ac69d7d46b1e682c2c4949be/librt-0.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:785ae29c1f5c6e7c2cde2c7c0e148147f4503da3abc5d44d482068da5322fd9e", size = 246473, upload-time = "2026-02-17T16:12:36.656Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/8a/91fab8e4fd2a24930a17188c7af5380eb27b203d72101c9cc000dbdfd95a/librt-0.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d3a7da44baf692f0c6aeb5b2a09c5e6fc7a703bca9ffa337ddd2e2da53f7732", size = 238866, upload-time = "2026-02-17T16:12:37.849Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/e0/c45a098843fc7c07e18a7f8a24ca8496aecbf7bdcd54980c6ca1aaa79a8e/librt-0.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5fc48998000cbc39ec0d5311312dda93ecf92b39aaf184c5e817d5d440b29624", size = 250248, upload-time = "2026-02-17T16:12:39.445Z" },
-    { url = "https://files.pythonhosted.org/packages/82/30/07627de23036640c952cce0c1fe78972e77d7d2f8fd54fa5ef4554ff4a56/librt-0.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e96baa6820280077a78244b2e06e416480ed859bbd8e5d641cf5742919d8beb4", size = 240629, upload-time = "2026-02-17T16:12:40.889Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/c1/55bfe1ee3542eba055616f9098eaf6eddb966efb0ca0f44eaa4aba327307/librt-0.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:31362dbfe297b23590530007062c32c6f6176f6099646bb2c95ab1b00a57c382", size = 239615, upload-time = "2026-02-17T16:12:42.446Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/39/191d3d28abc26c9099b19852e6c99f7f6d400b82fa5a4e80291bd3803e19/librt-0.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc3656283d11540ab0ea01978378e73e10002145117055e03722417aeab30994", size = 263001, upload-time = "2026-02-17T16:12:43.627Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -259,45 +225,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
-name = "mypy"
-version = "1.19.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/eb/b83e75f4c820c4247a58580ef86fcd35165028f191e7e1ba57128c52782d/mypy-1.19.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06e6170bd5836770e8104c8fdd58e5e725cfeb309f0a6c681a811f557e97eac1", size = 13199744, upload-time = "2025-12-15T05:03:30.823Z" },
-    { url = "https://files.pythonhosted.org/packages/94/28/52785ab7bfa165f87fcbb61547a93f98bb20e7f82f90f165a1f69bce7b3d/mypy-1.19.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:804bd67b8054a85447c8954215a906d6eff9cabeabe493fb6334b24f4bfff718", size = 12215815, upload-time = "2025-12-15T05:02:42.323Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/c6/bdd60774a0dbfb05122e3e925f2e9e846c009e479dcec4821dad881f5b52/mypy-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21761006a7f497cb0d4de3d8ef4ca70532256688b0523eee02baf9eec895e27b", size = 12740047, upload-time = "2025-12-15T05:03:33.168Z" },
-    { url = "https://files.pythonhosted.org/packages/32/2a/66ba933fe6c76bd40d1fe916a83f04fed253152f451a877520b3c4a5e41e/mypy-1.19.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28902ee51f12e0f19e1e16fbe2f8f06b6637f482c459dd393efddd0ec7f82045", size = 13601998, upload-time = "2025-12-15T05:03:13.056Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/da/5055c63e377c5c2418760411fd6a63ee2b96cf95397259038756c042574f/mypy-1.19.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957", size = 13807476, upload-time = "2025-12-15T05:03:17.977Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/09/4ebd873390a063176f06b0dbf1f7783dd87bd120eae7727fa4ae4179b685/mypy-1.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f", size = 10281872, upload-time = "2025-12-15T05:03:05.549Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", size = 2471239, upload-time = "2025-12-15T05:03:07.248Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "1.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]
@@ -371,6 +298,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyrefly"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/20/976165fa4b1517a1a92f393b3f4d4badabfff1165eff09d4cd4908428183/pyrefly-1.1.1.tar.gz", hash = "sha256:6deda959f8603a7dbdf112c48983e2275b2903cf33c8c739ed65d7e71a4fd520", size = 5880491, upload-time = "2026-06-18T23:45:43.785Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/d6/02ba666018c6a1cb4ddfa2db98ada721adddd374db5c29ba47a0bf2637fa/pyrefly-1.1.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f4b8595f91885bc8b5e3c282ab68d1df21201668a84e6508b1e15f2feec0bb8d", size = 13631867, upload-time = "2026-06-18T23:45:13.923Z" },
+    { url = "https://files.pythonhosted.org/packages/71/47/7a3457dbbddb513a83cf4fe527d5d5ebda5201a1010ad2a6034030e3e358/pyrefly-1.1.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d6b238e1362622d47a6eb5af704fd8b613c94e8c303386efd6350e3da59fecc8", size = 13075304, upload-time = "2026-06-18T23:45:16.865Z" },
+    { url = "https://files.pythonhosted.org/packages/84/df/70f4b3f42d58ed686a80df31e04eca54d88036cea4f9b96195c64ad0b2b5/pyrefly-1.1.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b50d4510e4f8aaea79e2c4b343a4d7a060c9451c0b2aa9bfe10d7ca1ef33d68d", size = 13446966, upload-time = "2026-06-18T23:45:19.644Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/53/12a19bd6c7af985bcbc13c6910d0f9f6684069ead2282a5c08c2bfbb5d03/pyrefly-1.1.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f330cf039ef3da3b910c84f3a7e431f0cf8d0c1d2dad26491d6cadf3c7cd4759", size = 14449222, upload-time = "2026-06-18T23:45:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f0/e55c48a50076fc0f9ecf4bdedec50456db383e01162f5e2121f8468be071/pyrefly-1.1.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a6342d87c52b04f72156da04f554c4d57f3616f2b32d1763969efb22d05a1407", size = 14472947, upload-time = "2026-06-18T23:45:24.858Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e7/30e085b31fed978ecb675bdbb54df566673ab550469e5af2d350f6af0be6/pyrefly-1.1.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c08b814ad03175e9cf47111390537161828b472044c39ab3320252b3ac6b2edd", size = 13975252, upload-time = "2026-06-18T23:45:27.247Z" },
+    { url = "https://files.pythonhosted.org/packages/47/58/49c3e67641133d3fe5d8d9a660dc0826c6c37ca197d86cad05fa7dd8bfd6/pyrefly-1.1.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d50cad97f19fc893b04deff7239626cffff5dd27ffb29b7d303a1b770247b208", size = 13471780, upload-time = "2026-06-18T23:45:29.775Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1e/65a7ba8355e2c39d8331832905fb74dcc85fc122a3f1dfd6dbf2a88907ad/pyrefly-1.1.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2150b450ee6a6bcbe69b2d45d9a4ebc934a609e1abcf65e490433f38eb873d84", size = 13989306, upload-time = "2026-06-18T23:45:32.576Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/b7ee1ab2392c36945738246fba7524439810befa3cfcc03cb6157567fc10/pyrefly-1.1.1-py3-none-win32.whl", hash = "sha256:5ffd8a8ed62fe4e6bf0afe1837d1bad149bb3b9f80e928ef248c96b836db3742", size = 12608469, upload-time = "2026-06-18T23:45:35.419Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9c/a0f5b52934bf80e9c7eff08222e7caf318287b9aef76acb8d9ac5740581b/pyrefly-1.1.1-py3-none-win_amd64.whl", hash = "sha256:4e0430f3ef69c8ac73505fd6584db70ed504665a9f0816fef7f723de510f26cb", size = 13502172, upload-time = "2026-06-18T23:45:38.375Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/4c6bcb3d456835f51445d3662a428f56c3ea5643ec798c577030ae34298c/pyrefly-1.1.1-py3-none-win_arm64.whl", hash = "sha256:83baf0db71e172665db1fca0ced50b8f7773f5192ca57e8ac6773a772b6d2fc5", size = 12895979, upload-time = "2026-06-18T23:45:41.026Z" },
 ]
 
 [[package]]

--- a/vendor/gmaps-scraper/uv.lock
+++ b/vendor/gmaps-scraper/uv.lock
@@ -131,7 +131,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "prek" },
-    { name = "pyrefly", specifier = ">=1.0.0,<2.0.0" },
+    { name = "pyrefly", specifier = ">=1.1.1" },
     { name = "ruff" },
 ]
 


### PR DESCRIPTION
## Summary
- Replace root Python type checking from mypy to Pyrefly, including dev dependencies and Pyrefly config.
- Update CI to run Pyrefly for the root pipeline and vendored scraper configuration.
- Update root pre-commit/prek hooks and docs to use Pyrefly.
- Refresh `vendor/gmaps-scraper` from upstream `508-dev/gmaps-scraper@28daadc`, which includes its own Pyrefly migration, stricter Pyrefly config, supply-chain cooldown settings, browser humanization controls, and reservation-provider scraping updates.
- Refresh the root lockfile metadata for the updated path dependency.

## Validation
- `uv sync --frozen`
- `uv run pyrefly check`
- `uv run pyrefly check --config vendor/gmaps-scraper/pyproject.toml --min-severity warn`
- `uv run python3 -m unittest discover -s tests/python -p 'test_*.py'`\n- `uv run python3 -m unittest discover -s vendor/gmaps-scraper/tests -p 'test_*.py'`\n- `prek run --all-files`\n- `bun run build:data`\n- `bun run check`\n- `bun run build`