### PR TITLE
[codex] Harden refresh automation

### DIFF
--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -66,6 +66,11 @@ jobs:
       GMAPS_SCRAPER_PROXY: ${{ secrets.GMAPS_SCRAPER_PROXY }}
 
     steps:
+      - name: Record job budget start
+        id: budget
+        shell: bash
+        run: echo "started_at_epoch=$(date +%s)" >> "${GITHUB_OUTPUT}"
+
       - name: Check out repository
         uses: actions/checkout@v5
         with:
@@ -181,7 +186,6 @@ jobs:
           kill_after_minutes=5
           post_timeout_buffer_minutes=10
           max_soft_timeout_minutes=$((job_timeout_minutes - pre_refresh_setup_buffer_minutes - kill_after_minutes - post_timeout_buffer_minutes))
-          settings_started_at_epoch="$(date +%s)"
 
           if ! [[ "${soft_timeout_minutes}" =~ ^[0-9]+$ ]] || (( soft_timeout_minutes < 1 )); then
             echo "::error::soft_timeout_minutes must be a positive integer."
@@ -203,7 +207,6 @@ jobs:
             echo "skip_photos=${skip_photos}"
             echo "refresh_workers=${refresh_workers}"
             echo "soft_timeout_minutes=${soft_timeout_minutes}"
-            echo "settings_started_at_epoch=${settings_started_at_epoch}"
             echo "refresh_date=${refresh_date}"
           } >> "${GITHUB_OUTPUT}"
 
@@ -264,9 +267,9 @@ jobs:
           PROFILE: ${{ steps.settings.outputs.profile }}
           REFRESH_LIST: ${{ steps.settings.outputs.refresh_list }}
           REFRESH_FORCE: ${{ steps.settings.outputs.refresh_force }}
+          JOB_BUDGET_STARTED_AT_EPOCH: ${{ steps.budget.outputs.started_at_epoch }}
           REFRESH_LOG_PATH: ${{ runner.temp }}/data-refresh.log
           REFRESH_SUMMARY_PATH: ${{ runner.temp }}/data-refresh-summary.md
-          SETTINGS_STARTED_AT_EPOCH: ${{ steps.settings.outputs.settings_started_at_epoch }}
           SKIP_PHOTOS: ${{ steps.settings.outputs.skip_photos }}
           REFRESH_WORKERS: ${{ steps.settings.outputs.refresh_workers }}
           SOFT_TIMEOUT_MINUTES: ${{ steps.settings.outputs.soft_timeout_minutes }}
@@ -290,7 +293,7 @@ jobs:
           job_timeout_minutes=180
           kill_after_minutes=5
           post_timeout_buffer_minutes=10
-          setup_elapsed_seconds=$(($(date +%s) - SETTINGS_STARTED_AT_EPOCH))
+          setup_elapsed_seconds=$(($(date +%s) - JOB_BUDGET_STARTED_AT_EPOCH))
           setup_elapsed_minutes=$(((setup_elapsed_seconds + 59) / 60))
           max_effective_soft_timeout_minutes=$((job_timeout_minutes - setup_elapsed_minutes - kill_after_minutes - post_timeout_buffer_minutes))
           if (( max_effective_soft_timeout_minutes < 1 )); then
@@ -305,11 +308,7 @@ jobs:
 
           is_soft_timeout_status() {
             local status="$1"
-            local elapsed_seconds="$2"
-            local soft_timeout_seconds=$((effective_soft_timeout_minutes * 60))
-            [[ "${status}" == "124" ]] || {
-              [[ "${status}" == "137" ]] && (( elapsed_seconds >= soft_timeout_seconds ))
-            }
+            [[ "${status}" == "124" ]]
           }
 
           echo "timed_out=false" >> "${GITHUB_OUTPUT}"
@@ -324,7 +323,7 @@ jobs:
           refresh_status="${pipeline_status[0]}"
           tee_status="${pipeline_status[1]}"
           refresh_elapsed_seconds=$((refresh_finished_at - refresh_started_at))
-          if is_soft_timeout_status "${refresh_status}" "${refresh_elapsed_seconds}"; then
+          if is_soft_timeout_status "${refresh_status}"; then
             echo "::warning::Refresh stopped after ${effective_soft_timeout_minutes} minutes so partial progress can be committed."
             {
               echo ""

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -366,14 +366,15 @@ jobs:
               return
             fi
 
+            if [[ "${REFRESH_TIMED_OUT}" == "true" ]]; then
+              echo "::warning::SQLite journal remains after refresh timeout: ${journal_path}. Skipping cache staging for this partial refresh."
+              stage_cache=false
+              return
+            fi
+
             python3 -c 'import sqlite3, sys; db_path = sys.argv[1]; connection = sqlite3.connect(db_path); result = connection.execute("PRAGMA integrity_check").fetchone(); connection.close(); raise SystemExit(0 if result and result[0] == "ok" else f"SQLite integrity check failed for {db_path}: {result}")' "${db_path}"
 
             if [[ -e "${journal_path}" ]]; then
-              if [[ "${REFRESH_TIMED_OUT}" == "true" ]]; then
-                echo "::warning::SQLite journal remains after refresh timeout: ${journal_path}. Skipping cache staging for this partial refresh."
-                stage_cache=false
-                return
-              fi
               echo "::error::SQLite journal remains after recovery attempt: ${journal_path}. Refusing to stage a potentially inconsistent cache."
               exit 1
             fi

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -308,7 +308,12 @@ jobs:
 
           is_soft_timeout_status() {
             local status="$1"
-            [[ "${status}" == "124" ]]
+            local elapsed_seconds="$2"
+            local soft_timeout_seconds=$((effective_soft_timeout_minutes * 60))
+            local kill_after_seconds=$((kill_after_minutes * 60))
+            [[ "${status}" == "124" ]] || {
+              [[ "${status}" == "137" ]] && (( elapsed_seconds >= soft_timeout_seconds + kill_after_seconds ))
+            }
           }
 
           echo "timed_out=false" >> "${GITHUB_OUTPUT}"
@@ -323,7 +328,7 @@ jobs:
           refresh_status="${pipeline_status[0]}"
           tee_status="${pipeline_status[1]}"
           refresh_elapsed_seconds=$((refresh_finished_at - refresh_started_at))
-          if is_soft_timeout_status "${refresh_status}"; then
+          if is_soft_timeout_status "${refresh_status}" "${refresh_elapsed_seconds}"; then
             echo "::warning::Refresh stopped after ${effective_soft_timeout_minutes} minutes so partial progress can be committed."
             {
               echo ""
@@ -387,6 +392,8 @@ jobs:
             if [[ "${REFRESH_TIMED_OUT}" == "true" ]]; then
               echo "::warning::SQLite journal remains after refresh timeout: ${journal_path}. Skipping cache staging for this partial refresh."
               stage_cache=false
+              git restore --worktree -- "${db_path}" 2>/dev/null || true
+              rm -f "${journal_path}"
               return
             fi
 
@@ -411,6 +418,8 @@ jobs:
             if [[ "${REFRESH_TIMED_OUT}" == "true" ]]; then
               echo "::warning::SQLite journal remains after refresh timeout: ${remaining_journal}. Skipping cache staging for this partial refresh."
               stage_cache=false
+              git restore --worktree -- "${site_dir}/data/cache" 2>/dev/null || true
+              find "${site_dir}/data/cache" \( -name "*-journal" -o -name "*.sqlite-journal" \) -delete 2>/dev/null || true
             else
               echo "::error::SQLite journal remains after refresh interruption: ${remaining_journal}. Refusing to stage a potentially inconsistent cache."
               exit 1

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -36,6 +36,11 @@ on:
         required: false
         default: "4"
         type: string
+      soft_timeout_minutes:
+        description: Stop the refresh command after this many minutes so partial changes can still be committed
+        required: false
+        default: "150"
+        type: string
   schedule:
     - cron: "17 3 * * *"
     - cron: "43 5 1 * *"
@@ -50,9 +55,10 @@ concurrency:
 
 jobs:
   refresh:
-    runs-on:
-      - self-hosted
-      - Linux
+    # Upstream default stays generic. Site repos can set the GitHub Actions
+    # repository variable DATA_REFRESH_RUNNER_LABELS to a JSON array such as
+    # ["self-hosted","Linux","residential"] to pin private runner pools.
+    runs-on: ${{ fromJSON(vars.DATA_REFRESH_RUNNER_LABELS || '["self-hosted","Linux"]') }}
     timeout-minutes: 180
     env:
       REFRESH_BRANCH_PREFIX: automation/data-refresh
@@ -74,6 +80,11 @@ jobs:
 
           if ! command -v unzip >/dev/null 2>&1; then
             echo "::error::Missing required runner tool: unzip. Provision it on the self-hosted runner; do not install it inside this workflow."
+            exit 1
+          fi
+
+          if ! command -v timeout >/dev/null 2>&1; then
+            echo "::error::Missing required runner tool: timeout. Provision GNU coreutils on the self-hosted runner; do not install it inside this workflow."
             exit 1
           fi
 
@@ -138,6 +149,7 @@ jobs:
             refresh_force="${{ inputs.refresh_force }}"
             skip_photos="${{ inputs.skip_photos }}"
             refresh_workers="${{ inputs.refresh_workers }}"
+            soft_timeout_minutes="${{ inputs.soft_timeout_minutes }}"
           else
             case "${{ github.event.schedule }}" in
               "43 5 1 * *")
@@ -151,18 +163,36 @@ jobs:
             refresh_force="false"
             skip_photos="false"
             refresh_workers="4"
+            soft_timeout_minutes="150"
+          fi
+
+          job_timeout_minutes=180
+          kill_after_minutes=5
+          post_timeout_buffer_minutes=10
+          max_soft_timeout_minutes=$((job_timeout_minutes - kill_after_minutes - post_timeout_buffer_minutes))
+
+          if ! [[ "${soft_timeout_minutes}" =~ ^[0-9]+$ ]] || (( soft_timeout_minutes < 1 )); then
+            echo "::error::soft_timeout_minutes must be a positive integer."
+            exit 1
+          fi
+          if (( soft_timeout_minutes > max_soft_timeout_minutes )); then
+            echo "::error::soft_timeout_minutes must be <= ${max_soft_timeout_minutes} so the refresh can stop, summarize, commit, and open a PR before the ${job_timeout_minutes}-minute job timeout."
+            exit 1
           fi
 
           refresh_date="$(date -u +%Y-%m-%d)"
           refresh_branch="${REFRESH_BRANCH_PREFIX}-${profile}"
 
-          echo "profile=${profile}" >> "${GITHUB_OUTPUT}"
-          echo "refresh_branch=${refresh_branch}" >> "${GITHUB_OUTPUT}"
-          echo "refresh_list=${refresh_list}" >> "${GITHUB_OUTPUT}"
-          echo "refresh_force=${refresh_force}" >> "${GITHUB_OUTPUT}"
-          echo "skip_photos=${skip_photos}" >> "${GITHUB_OUTPUT}"
-          echo "refresh_workers=${refresh_workers}" >> "${GITHUB_OUTPUT}"
-          echo "refresh_date=${refresh_date}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "profile=${profile}"
+            echo "refresh_branch=${refresh_branch}"
+            echo "refresh_list=${refresh_list}"
+            echo "refresh_force=${refresh_force}"
+            echo "skip_photos=${skip_photos}"
+            echo "refresh_workers=${refresh_workers}"
+            echo "soft_timeout_minutes=${soft_timeout_minutes}"
+            echo "refresh_date=${refresh_date}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -215,6 +245,7 @@ jobs:
           git switch -C "${REFRESH_BRANCH}" origin/main
 
       - name: Run self-hosted refresh
+        id: refresh
         shell: bash
         env:
           PROFILE: ${{ steps.settings.outputs.profile }}
@@ -224,6 +255,7 @@ jobs:
           REFRESH_SUMMARY_PATH: ${{ runner.temp }}/data-refresh-summary.md
           SKIP_PHOTOS: ${{ steps.settings.outputs.skip_photos }}
           REFRESH_WORKERS: ${{ steps.settings.outputs.refresh_workers }}
+          SOFT_TIMEOUT_MINUTES: ${{ steps.settings.outputs.soft_timeout_minutes }}
         run: |
           set -euo pipefail
 
@@ -241,7 +273,34 @@ jobs:
             args+=("--refresh-list" "${REFRESH_LIST}")
           fi
 
-          uv run python3 scripts/refresh_profiles.py "${args[@]}" | tee "${REFRESH_LOG_PATH}"
+          is_soft_timeout_status() {
+            local status="$1"
+            [[ "${status}" == "124" || "${status}" == "137" ]]
+          }
+
+          echo "timed_out=false" >> "${GITHUB_OUTPUT}"
+          set +e
+          timeout --signal=INT --kill-after=5m "${SOFT_TIMEOUT_MINUTES}m" \
+            uv run python3 scripts/refresh_profiles.py "${args[@]}" | tee "${REFRESH_LOG_PATH}"
+          pipeline_status=("${PIPESTATUS[@]}")
+          set -e
+
+          refresh_status="${pipeline_status[0]}"
+          tee_status="${pipeline_status[1]}"
+          if is_soft_timeout_status "${refresh_status}"; then
+            echo "::warning::Refresh stopped after ${SOFT_TIMEOUT_MINUTES} minutes so partial progress can be committed."
+            {
+              echo ""
+              echo "Refresh stopped after ${SOFT_TIMEOUT_MINUTES} minutes so partial progress can be committed."
+            } >> "${REFRESH_LOG_PATH}"
+            echo "timed_out=true" >> "${GITHUB_OUTPUT}"
+          elif (( tee_status != 0 )); then
+            echo "::error::tee failed while writing ${REFRESH_LOG_PATH}."
+            exit "${tee_status}"
+          elif (( refresh_status != 0 )); then
+            exit "${refresh_status}"
+          fi
+
           uv run python3 scripts/refresh_summary.py --log "${REFRESH_LOG_PATH}" --output "${REFRESH_SUMMARY_PATH}"
 
       - name: Create commit if data changed
@@ -250,6 +309,7 @@ jobs:
         env:
           PROFILE: ${{ steps.settings.outputs.profile }}
           REFRESH_BRANCH: ${{ steps.settings.outputs.refresh_branch }}
+          REFRESH_TIMED_OUT: ${{ steps.refresh.outputs.timed_out }}
         run: |
           set -euo pipefail
 
@@ -270,6 +330,44 @@ jobs:
             fi
           }
 
+          cleanup_runtime_artifacts() {
+            local path="$1"
+            if [[ -d "${path}" ]]; then
+              find "${path}" \
+                \( -name "*.tmp" -o -name ".*.tmp" -o -name "*.tmp-journal" -o -name ".*.tmp-journal" \) \
+                -delete
+            fi
+          }
+
+          recover_sqlite_database() {
+            local db_path="$1"
+            local journal_path="${db_path}-journal"
+            if [[ ! -e "${journal_path}" ]]; then
+              return
+            fi
+
+            python3 -c 'import sqlite3, sys; db_path = sys.argv[1]; connection = sqlite3.connect(db_path); result = connection.execute("PRAGMA integrity_check").fetchone(); connection.close(); raise SystemExit(0 if result and result[0] == "ok" else f"SQLite integrity check failed for {db_path}: {result}")' "${db_path}"
+
+            if [[ -e "${journal_path}" ]]; then
+              echo "::error::SQLite journal remains after recovery attempt: ${journal_path}. Refusing to stage a potentially inconsistent cache."
+              exit 1
+            fi
+          }
+
+          recover_sqlite_database "${site_dir}/data/cache/places.sqlite"
+          cleanup_runtime_artifacts "${site_dir}/data/raw"
+          cleanup_runtime_artifacts "${site_dir}/data/cache"
+          cleanup_runtime_artifacts "${site_dir}/public/place-photos"
+          cleanup_runtime_artifacts "${site_dir}/public/author-photos"
+
+          remaining_journal="$(
+            find "${site_dir}/data/cache" \( -name "*-journal" -o -name "*.sqlite-journal" \) -print -quit 2>/dev/null || true
+          )"
+          if [[ -n "${remaining_journal}" ]]; then
+            echo "::error::SQLite journal remains after refresh interruption: ${remaining_journal}. Refusing to stage a potentially inconsistent cache."
+            exit 1
+          fi
+
           git add -A -- \
             "${site_dir}/data/raw" \
             "${site_dir}/data/cache"
@@ -282,7 +380,11 @@ jobs:
             exit 0
           fi
 
-          git commit -m "Refresh place data (${PROFILE})"
+          commit_subject="Refresh place data (${PROFILE})"
+          if [[ "${REFRESH_TIMED_OUT}" == "true" ]]; then
+            commit_subject="${commit_subject} [partial]"
+          fi
+          git commit -m "${commit_subject}"
           git push --force-with-lease origin "${REFRESH_BRANCH}"
 
           echo "changed=true" >> "${GITHUB_OUTPUT}"
@@ -299,6 +401,8 @@ jobs:
           REFRESH_SUMMARY_PATH: ${{ runner.temp }}/data-refresh-summary.md
           SKIP_PHOTOS: ${{ steps.settings.outputs.skip_photos }}
           REFRESH_WORKERS: ${{ steps.settings.outputs.refresh_workers }}
+          SOFT_TIMEOUT_MINUTES: ${{ steps.settings.outputs.soft_timeout_minutes }}
+          REFRESH_TIMED_OUT: ${{ steps.refresh.outputs.timed_out }}
         with:
           github-token: ${{ secrets.GH_AUTOMATION_TOKEN != '' && secrets.GH_AUTOMATION_TOKEN || github.token }}
           script: |
@@ -315,6 +419,7 @@ jobs:
               `- Profile: \`${process.env.PROFILE}\``,
               `- Trigger: \`${context.eventName}\``,
               `- Refresh workers: \`${process.env.REFRESH_WORKERS}\``,
+              `- Soft timeout: \`${process.env.SOFT_TIMEOUT_MINUTES} minutes\``,
             ];
 
             if (process.env.REFRESH_LIST) {
@@ -325,6 +430,9 @@ jobs:
             }
             if (process.env.SKIP_PHOTOS === "true") {
               bodyLines.push("- Photo refresh skipped");
+            }
+            if (process.env.REFRESH_TIMED_OUT === "true") {
+              bodyLines.push("- Partial refresh: stopped at the soft timeout so completed changes could be committed");
             }
             if (manualRun) {
               bodyLines.push(`- Manual run: https://github.com/${owner}/${repo}/actions/runs/${context.runId}`);

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -177,9 +177,10 @@ jobs:
           # refresh step's `timeout --kill-after` value. GitHub Actions does
           # not expose `timeout-minutes` inside a run step.
           job_timeout_minutes=180
+          pre_refresh_setup_buffer_minutes=15
           kill_after_minutes=5
           post_timeout_buffer_minutes=10
-          max_soft_timeout_minutes=$((job_timeout_minutes - kill_after_minutes - post_timeout_buffer_minutes))
+          max_soft_timeout_minutes=$((job_timeout_minutes - pre_refresh_setup_buffer_minutes - kill_after_minutes - post_timeout_buffer_minutes))
 
           if ! [[ "${soft_timeout_minutes}" =~ ^[0-9]+$ ]] || (( soft_timeout_minutes < 1 )); then
             echo "::error::soft_timeout_minutes must be a positive integer."

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -181,6 +181,7 @@ jobs:
           kill_after_minutes=5
           post_timeout_buffer_minutes=10
           max_soft_timeout_minutes=$((job_timeout_minutes - pre_refresh_setup_buffer_minutes - kill_after_minutes - post_timeout_buffer_minutes))
+          settings_started_at_epoch="$(date +%s)"
 
           if ! [[ "${soft_timeout_minutes}" =~ ^[0-9]+$ ]] || (( soft_timeout_minutes < 1 )); then
             echo "::error::soft_timeout_minutes must be a positive integer."
@@ -202,6 +203,7 @@ jobs:
             echo "skip_photos=${skip_photos}"
             echo "refresh_workers=${refresh_workers}"
             echo "soft_timeout_minutes=${soft_timeout_minutes}"
+            echo "settings_started_at_epoch=${settings_started_at_epoch}"
             echo "refresh_date=${refresh_date}"
           } >> "${GITHUB_OUTPUT}"
 
@@ -264,6 +266,7 @@ jobs:
           REFRESH_FORCE: ${{ steps.settings.outputs.refresh_force }}
           REFRESH_LOG_PATH: ${{ runner.temp }}/data-refresh.log
           REFRESH_SUMMARY_PATH: ${{ runner.temp }}/data-refresh-summary.md
+          SETTINGS_STARTED_AT_EPOCH: ${{ steps.settings.outputs.settings_started_at_epoch }}
           SKIP_PHOTOS: ${{ steps.settings.outputs.skip_photos }}
           REFRESH_WORKERS: ${{ steps.settings.outputs.refresh_workers }}
           SOFT_TIMEOUT_MINUTES: ${{ steps.settings.outputs.soft_timeout_minutes }}
@@ -284,10 +287,26 @@ jobs:
             args+=("--refresh-list" "${REFRESH_LIST}")
           fi
 
+          job_timeout_minutes=180
+          kill_after_minutes=5
+          post_timeout_buffer_minutes=10
+          setup_elapsed_seconds=$(($(date +%s) - SETTINGS_STARTED_AT_EPOCH))
+          setup_elapsed_minutes=$(((setup_elapsed_seconds + 59) / 60))
+          max_effective_soft_timeout_minutes=$((job_timeout_minutes - setup_elapsed_minutes - kill_after_minutes - post_timeout_buffer_minutes))
+          if (( max_effective_soft_timeout_minutes < 1 )); then
+            echo "::error::Setup consumed too much of the ${job_timeout_minutes}-minute job timeout to leave room for refresh cleanup."
+            exit 1
+          fi
+          effective_soft_timeout_minutes="${SOFT_TIMEOUT_MINUTES}"
+          if (( effective_soft_timeout_minutes > max_effective_soft_timeout_minutes )); then
+            echo "::warning::Reducing refresh soft timeout from ${SOFT_TIMEOUT_MINUTES} to ${max_effective_soft_timeout_minutes} minutes because setup took ${setup_elapsed_minutes} minutes."
+            effective_soft_timeout_minutes="${max_effective_soft_timeout_minutes}"
+          fi
+
           is_soft_timeout_status() {
             local status="$1"
             local elapsed_seconds="$2"
-            local soft_timeout_seconds=$((SOFT_TIMEOUT_MINUTES * 60))
+            local soft_timeout_seconds=$((effective_soft_timeout_minutes * 60))
             [[ "${status}" == "124" ]] || {
               [[ "${status}" == "137" ]] && (( elapsed_seconds >= soft_timeout_seconds ))
             }
@@ -296,7 +315,7 @@ jobs:
           echo "timed_out=false" >> "${GITHUB_OUTPUT}"
           set +e
           refresh_started_at="$(date +%s)"
-          timeout --signal=INT --kill-after=5m "${SOFT_TIMEOUT_MINUTES}m" \
+          timeout --signal=INT --kill-after=5m "${effective_soft_timeout_minutes}m" \
             uv run python3 scripts/refresh_profiles.py "${args[@]}" | tee "${REFRESH_LOG_PATH}"
           pipeline_status=("${PIPESTATUS[@]}")
           refresh_finished_at="$(date +%s)"
@@ -306,10 +325,10 @@ jobs:
           tee_status="${pipeline_status[1]}"
           refresh_elapsed_seconds=$((refresh_finished_at - refresh_started_at))
           if is_soft_timeout_status "${refresh_status}" "${refresh_elapsed_seconds}"; then
-            echo "::warning::Refresh stopped after ${SOFT_TIMEOUT_MINUTES} minutes so partial progress can be committed."
+            echo "::warning::Refresh stopped after ${effective_soft_timeout_minutes} minutes so partial progress can be committed."
             {
               echo ""
-              echo "Refresh stopped after ${SOFT_TIMEOUT_MINUTES} minutes so partial progress can be committed."
+              echo "Refresh stopped after ${effective_soft_timeout_minutes} minutes so partial progress can be committed."
             } >> "${REFRESH_LOG_PATH}"
             echo "timed_out=true" >> "${GITHUB_OUTPUT}"
           elif (( tee_status != 0 )); then

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -140,16 +140,23 @@ jobs:
       - name: Resolve refresh settings
         id: settings
         shell: bash
+        env:
+          PROFILE_INPUT: ${{ inputs.profile }}
+          REFRESH_LIST_INPUT: ${{ inputs.refresh_list }}
+          REFRESH_FORCE_INPUT: ${{ inputs.refresh_force }}
+          SKIP_PHOTOS_INPUT: ${{ inputs.skip_photos }}
+          REFRESH_WORKERS_INPUT: ${{ inputs.refresh_workers }}
+          SOFT_TIMEOUT_MINUTES_INPUT: ${{ inputs.soft_timeout_minutes }}
         run: |
           set -euo pipefail
 
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            profile="${{ inputs.profile }}"
-            refresh_list="${{ inputs.refresh_list }}"
-            refresh_force="${{ inputs.refresh_force }}"
-            skip_photos="${{ inputs.skip_photos }}"
-            refresh_workers="${{ inputs.refresh_workers }}"
-            soft_timeout_minutes="${{ inputs.soft_timeout_minutes }}"
+            profile="${PROFILE_INPUT}"
+            refresh_list="${REFRESH_LIST_INPUT}"
+            refresh_force="${REFRESH_FORCE_INPUT}"
+            skip_photos="${SKIP_PHOTOS_INPUT}"
+            refresh_workers="${REFRESH_WORKERS_INPUT}"
+            soft_timeout_minutes="${SOFT_TIMEOUT_MINUTES_INPUT}"
           else
             case "${{ github.event.schedule }}" in
               "43 5 1 * *")
@@ -166,6 +173,9 @@ jobs:
             soft_timeout_minutes="150"
           fi
 
+          # Keep these aligned with this job's `timeout-minutes` and the
+          # refresh step's `timeout --kill-after` value. GitHub Actions does
+          # not expose `timeout-minutes` inside a run step.
           job_timeout_minutes=180
           kill_after_minutes=5
           post_timeout_buffer_minutes=10
@@ -275,19 +285,26 @@ jobs:
 
           is_soft_timeout_status() {
             local status="$1"
-            [[ "${status}" == "124" || "${status}" == "137" ]]
+            local elapsed_seconds="$2"
+            local soft_timeout_seconds=$((SOFT_TIMEOUT_MINUTES * 60))
+            [[ "${status}" == "124" ]] || {
+              [[ "${status}" == "137" ]] && (( elapsed_seconds >= soft_timeout_seconds ))
+            }
           }
 
           echo "timed_out=false" >> "${GITHUB_OUTPUT}"
           set +e
+          refresh_started_at="$(date +%s)"
           timeout --signal=INT --kill-after=5m "${SOFT_TIMEOUT_MINUTES}m" \
             uv run python3 scripts/refresh_profiles.py "${args[@]}" | tee "${REFRESH_LOG_PATH}"
           pipeline_status=("${PIPESTATUS[@]}")
+          refresh_finished_at="$(date +%s)"
           set -e
 
           refresh_status="${pipeline_status[0]}"
           tee_status="${pipeline_status[1]}"
-          if is_soft_timeout_status "${refresh_status}"; then
+          refresh_elapsed_seconds=$((refresh_finished_at - refresh_started_at))
+          if is_soft_timeout_status "${refresh_status}" "${refresh_elapsed_seconds}"; then
             echo "::warning::Refresh stopped after ${SOFT_TIMEOUT_MINUTES} minutes so partial progress can be committed."
             {
               echo ""
@@ -339,6 +356,8 @@ jobs:
             fi
           }
 
+          stage_cache=true
+
           recover_sqlite_database() {
             local db_path="$1"
             local journal_path="${db_path}-journal"
@@ -349,6 +368,11 @@ jobs:
             python3 -c 'import sqlite3, sys; db_path = sys.argv[1]; connection = sqlite3.connect(db_path); result = connection.execute("PRAGMA integrity_check").fetchone(); connection.close(); raise SystemExit(0 if result and result[0] == "ok" else f"SQLite integrity check failed for {db_path}: {result}")' "${db_path}"
 
             if [[ -e "${journal_path}" ]]; then
+              if [[ "${REFRESH_TIMED_OUT}" == "true" ]]; then
+                echo "::warning::SQLite journal remains after refresh timeout: ${journal_path}. Skipping cache staging for this partial refresh."
+                stage_cache=false
+                return
+              fi
               echo "::error::SQLite journal remains after recovery attempt: ${journal_path}. Refusing to stage a potentially inconsistent cache."
               exit 1
             fi
@@ -364,13 +388,19 @@ jobs:
             find "${site_dir}/data/cache" \( -name "*-journal" -o -name "*.sqlite-journal" \) -print -quit 2>/dev/null || true
           )"
           if [[ -n "${remaining_journal}" ]]; then
-            echo "::error::SQLite journal remains after refresh interruption: ${remaining_journal}. Refusing to stage a potentially inconsistent cache."
-            exit 1
+            if [[ "${REFRESH_TIMED_OUT}" == "true" ]]; then
+              echo "::warning::SQLite journal remains after refresh timeout: ${remaining_journal}. Skipping cache staging for this partial refresh."
+              stage_cache=false
+            else
+              echo "::error::SQLite journal remains after refresh interruption: ${remaining_journal}. Refusing to stage a potentially inconsistent cache."
+              exit 1
+            fi
           fi
 
-          git add -A -- \
-            "${site_dir}/data/raw" \
-            "${site_dir}/data/cache"
+          git add -A -- "${site_dir}/data/raw"
+          if [[ "${stage_cache}" == "true" ]]; then
+            git add -A -- "${site_dir}/data/cache"
+          fi
 
           stage_optional_path "${site_dir}/public/place-photos"
           stage_optional_path "${site_dir}/public/author-photos"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ The `data-refresh` workflow is intentionally tied to a self-hosted Linux runner.
 
 - Keep upstream runner labels generic. The workflow defaults to `["self-hosted","Linux"]`; site repos can pin private pools with the GitHub Actions repository variable `DATA_REFRESH_RUNNER_LABELS`, for example `["self-hosted","Linux","residential"]`.
 - `unzip` must be present on `PATH` because `oven-sh/setup-bun` downloads a `.zip` release archive.
-- GNU `timeout` must be present on `PATH`; the workflow stops the refresh command after its soft timeout, defaults to 150 minutes, and caps manual values at 165 minutes so the 5-minute kill-after window plus the 10-minute post-timeout buffer still fit before the 180-minute job timeout.
+- GNU `timeout` must be present on `PATH`; the workflow stops the refresh command after its soft timeout, defaults to 150 minutes, and caps manual values at 150 minutes so setup, the 5-minute kill-after window, and the 10-minute post-timeout buffer still fit before the 180-minute job timeout.
 - `cloakbrowser` downloads its own Chromium binary, but the host still needs Playwright/Chromium system libraries installed.
 - Provision the runner with the equivalent of Playwright's Chromium Linux dependencies, for example the packages behind `playwright install-deps chromium`, instead of trying to `apt install` during the workflow run.
 - The workflow includes a preflight check for `unzip` and a small set of required shared libraries (`libnspr4`, `libnss3`, GTK, GBM, X11, and related browser deps) so runner drift fails fast with a clear error.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,9 @@
 
 The `data-refresh` workflow is intentionally tied to a self-hosted Linux runner. Treat the runner image or host provisioning as the contract for OS-level tools and browser libraries; do not install them ad hoc inside the workflow.
 
+- Keep upstream runner labels generic. The workflow defaults to `["self-hosted","Linux"]`; site repos can pin private pools with the GitHub Actions repository variable `DATA_REFRESH_RUNNER_LABELS`, for example `["self-hosted","Linux","residential"]`.
 - `unzip` must be present on `PATH` because `oven-sh/setup-bun` downloads a `.zip` release archive.
+- GNU `timeout` must be present on `PATH`; the workflow stops the refresh command after its soft timeout, defaults to 150 minutes, caps manual values below the 180-minute job timeout, then commits any completed partial data changes.
 - `cloakbrowser` downloads its own Chromium binary, but the host still needs Playwright/Chromium system libraries installed.
 - Provision the runner with the equivalent of Playwright's Chromium Linux dependencies, for example the packages behind `playwright install-deps chromium`, instead of trying to `apt install` during the workflow run.
 - The workflow includes a preflight check for `unzip` and a small set of required shared libraries (`libnspr4`, `libnss3`, GTK, GBM, X11, and related browser deps) so runner drift fails fast with a clear error.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ The `data-refresh` workflow is intentionally tied to a self-hosted Linux runner.
 
 - Keep upstream runner labels generic. The workflow defaults to `["self-hosted","Linux"]`; site repos can pin private pools with the GitHub Actions repository variable `DATA_REFRESH_RUNNER_LABELS`, for example `["self-hosted","Linux","residential"]`.
 - `unzip` must be present on `PATH` because `oven-sh/setup-bun` downloads a `.zip` release archive.
-- GNU `timeout` must be present on `PATH`; the workflow stops the refresh command after its soft timeout, defaults to 150 minutes, and caps manual values at 150 minutes so setup, the 5-minute kill-after window, and the 10-minute post-timeout buffer still fit before the 180-minute job timeout.
+- GNU `timeout` must be present on `PATH`; the workflow stops the refresh command after its soft timeout, defaults to 150 minutes, caps manual values at 150 minutes, and shortens the effective timeout after setup when needed so the 5-minute kill-after window and 10-minute post-timeout buffer still fit before the 180-minute job timeout.
 - `cloakbrowser` downloads its own Chromium binary, but the host still needs Playwright/Chromium system libraries installed.
 - Provision the runner with the equivalent of Playwright's Chromium Linux dependencies, for example the packages behind `playwright install-deps chromium`, instead of trying to `apt install` during the workflow run.
 - The workflow includes a preflight check for `unzip` and a small set of required shared libraries (`libnspr4`, `libnss3`, GTK, GBM, X11, and related browser deps) so runner drift fails fast with a clear error.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ The `data-refresh` workflow is intentionally tied to a self-hosted Linux runner.
 
 - Keep upstream runner labels generic. The workflow defaults to `["self-hosted","Linux"]`; site repos can pin private pools with the GitHub Actions repository variable `DATA_REFRESH_RUNNER_LABELS`, for example `["self-hosted","Linux","residential"]`.
 - `unzip` must be present on `PATH` because `oven-sh/setup-bun` downloads a `.zip` release archive.
-- GNU `timeout` must be present on `PATH`; the workflow stops the refresh command after its soft timeout, defaults to 150 minutes, caps manual values below the 180-minute job timeout, then commits any completed partial data changes.
+- GNU `timeout` must be present on `PATH`; the workflow stops the refresh command after its soft timeout, defaults to 150 minutes, and caps manual values at 165 minutes so the 5-minute kill-after window plus the 10-minute post-timeout buffer still fit before the 180-minute job timeout.
 - `cloakbrowser` downloads its own Chromium binary, but the host still needs Playwright/Chromium system libraries installed.
 - Provision the runner with the equivalent of Playwright's Chromium Linux dependencies, for example the packages behind `playwright install-deps chromium`, instead of trying to `apt install` during the workflow run.
 - The workflow includes a preflight check for `unzip` and a small set of required shared libraries (`libnspr4`, `libnss3`, GTK, GBM, X11, and related browser deps) so runner drift fails fast with a clear error.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -168,6 +168,22 @@ GitHub Actions schedules use UTC.
 
 The repo includes `.github/workflows/data-refresh.yml` for refresh automation on a self-hosted Linux runner.
 
+The workflow intentionally keeps the upstream runner selection generic. It defaults to:
+
+```json
+["self-hosted", "Linux"]
+```
+
+Site repos that need a specific private runner pool should set the GitHub Actions repository variable `DATA_REFRESH_RUNNER_LABELS` to a JSON array, for example:
+
+```json
+["self-hosted", "Linux", "residential"]
+```
+
+Use repository variables for installation-specific runner labels instead of committing private labels to the upstream template.
+
+The Actions job has a 180-minute hard timeout and runs the refresh command with a shorter soft timeout. The default soft timeout is 150 minutes, and manual dispatch values are capped so the 5-minute kill-after window plus summary, commit, and PR steps still fit under the job timeout. When the soft timeout expires, the workflow interrupts the refresh command, writes a partial summary, and continues to the commit and PR steps so completed raw snapshots, enrichment cache rows, and downloaded photos are not lost.
+
 Recommended boundary:
 
 - Do not run Google Maps list scraping or enrichment refreshes on GitHub-hosted runners.
@@ -190,6 +206,7 @@ Minimum `GH_AUTOMATION_TOKEN` permissions:
 Runner provisioning:
 
 - `unzip` must be present on `PATH` for `oven-sh/setup-bun`.
+- GNU `timeout` must be present on `PATH` for the soft-timeout partial commit path.
 - `cloakbrowser` downloads Chromium, but the host still needs Chromium system libraries.
 - Prefer provisioning the full Playwright Chromium dependency set:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -182,7 +182,7 @@ Site repos that need a specific private runner pool should set the GitHub Action
 
 Use repository variables for installation-specific runner labels instead of committing private labels to the upstream template.
 
-The Actions job has a 180-minute hard timeout and runs the refresh command with a shorter soft timeout. The default soft timeout is 150 minutes, and manual dispatch values are capped so the 5-minute kill-after window plus summary, commit, and PR steps still fit under the job timeout. When the soft timeout expires, the workflow interrupts the refresh command, writes a partial summary, and continues to the commit and PR steps so completed raw snapshots, enrichment cache rows, and downloaded photos are not lost.
+The Actions job has a 180-minute hard timeout and runs the refresh command with a shorter soft timeout. The default soft timeout is 150 minutes, and manual dispatch values are capped at 150 minutes so setup, the 5-minute kill-after window, and summary, commit, and PR steps still fit under the job timeout. When the soft timeout expires, the workflow interrupts the refresh command, writes a partial summary, and continues to the commit and PR steps so completed raw snapshots, enrichment cache rows, and downloaded photos are not lost.
 
 Recommended boundary:
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -2081,6 +2081,7 @@ def refresh_raw_sources(
     failures: list[str] = []
 
     executor = ThreadPoolExecutor(max_workers=max_workers)
+    interrupted = False
     try:
         future_map = {
             executor.submit(
@@ -2111,11 +2112,13 @@ def refresh_raw_sources(
             )
             write_json(raw_path, payload)
     except KeyboardInterrupt:
+        interrupted = True
         print("Interrupt received; terminating refresh workers.", flush=True)
         terminate_executor(executor)
         raise
     finally:
-        executor.shutdown(wait=True, cancel_futures=True)
+        if not interrupted:
+            executor.shutdown(wait=True, cancel_futures=True)
 
     if failures:
         failure_text = "\n".join(failures)
@@ -4269,6 +4272,7 @@ def enrich_raw_sources(
 
     print(f"Running {len(enrich_jobs)} enrichment jobs with {max_workers} workers")
     executor = ThreadPoolExecutor(max_workers=max_workers)
+    interrupted = False
     try:
         future_map = {
             executor.submit(
@@ -4291,11 +4295,13 @@ def enrich_raw_sources(
             cache_payloads[slug][place_id] = future.result()
             save_places_cache(slug, cache_payloads[slug])
     except KeyboardInterrupt:
+        interrupted = True
         print("Interrupt received; terminating enrichment workers.", flush=True)
         terminate_executor(executor)
         raise
     finally:
-        executor.shutdown(wait=True, cancel_futures=True)
+        if not interrupted:
+            executor.shutdown(wait=True, cancel_futures=True)
 
 
 def enrichment_source_refresh_lists(place_selectors: Sequence[str] | None) -> list[str]:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6440,6 +6440,8 @@ def preserve_existing_raw_place(
     *,
     existing_place: RawPlace,
     refreshed_place: RawPlace,
+    blocked_google_ids: set[str] | None = None,
+    blocked_maps_place_tokens: set[str] | None = None,
 ) -> tuple[RawPlace, list[str]]:
     preserved_fields: list[str] = []
     updates: dict[str, Any] = {}
@@ -6454,13 +6456,28 @@ def preserve_existing_raw_place(
     ):
         updates["address"] = existing_place.address
         preserved_fields.append("address")
-    if names_compatible and not refreshed_place.google_id and existing_place.google_id:
+    existing_google_id = raw_place_google_id_identity(existing_place)
+    if (
+        names_compatible
+        and not refreshed_place.google_id
+        and existing_place.google_id
+        and (blocked_google_ids is None or existing_google_id not in blocked_google_ids)
+    ):
         updates["google_id"] = existing_place.google_id
         preserved_fields.append("google_id")
     if names_compatible and not refreshed_place.cid and existing_place.cid:
         updates["cid"] = existing_place.cid
         preserved_fields.append("cid")
-    if names_compatible and not refreshed_place.maps_place_token and existing_place.maps_place_token:
+    existing_maps_place_token = raw_place_maps_place_token_identity(existing_place)
+    if (
+        names_compatible
+        and not refreshed_place.maps_place_token
+        and existing_place.maps_place_token
+        and (
+            blocked_maps_place_tokens is None
+            or existing_maps_place_token not in blocked_maps_place_tokens
+        )
+    ):
         updates["maps_place_token"] = existing_place.maps_place_token
         preserved_fields.append("maps_place_token")
     if names_compatible and not refreshed_place.is_favorite and existing_place.is_favorite:
@@ -6526,6 +6543,14 @@ def raw_place_cid_identity(place: RawPlace) -> str | None:
     return as_string(place.cid) or extract_maps_cid(place.maps_url)
 
 
+def raw_place_google_id_identity(place: RawPlace) -> str | None:
+    return as_string(place.google_id)
+
+
+def raw_place_maps_place_token_identity(place: RawPlace) -> str | None:
+    return as_string(place.maps_place_token) or extract_maps_place_token(place.maps_url)
+
+
 def score_duplicate_raw_place_cid_candidate(
     place: RawPlace,
     *,
@@ -6586,12 +6611,13 @@ def strip_duplicate_raw_place_cid(
     place: RawPlace,
     *,
     cid: str,
+    shared_google_ids: set[str] | None = None,
     shared_maps_place_tokens: set[str] | None = None,
 ) -> RawPlace:
     updates: dict[str, Any] = {}
     if as_string(place.cid) == cid:
         updates["cid"] = None
-    maps_place_token = extract_maps_place_token(place.maps_url)
+    maps_place_token = raw_place_maps_place_token_identity(place)
     if (
         extract_maps_cid(place.maps_url) == cid
         or (
@@ -6609,8 +6635,16 @@ def strip_duplicate_raw_place_cid(
         )
     if not updates:
         return place
-    updates["google_id"] = None
-    updates["maps_place_token"] = None
+    google_id = raw_place_google_id_identity(place)
+    if google_id and shared_google_ids is not None and google_id in shared_google_ids:
+        updates["google_id"] = None
+    if (
+        as_string(place.maps_place_token)
+        and maps_place_token
+        and shared_maps_place_tokens is not None
+        and maps_place_token in shared_maps_place_tokens
+    ):
+        updates["maps_place_token"] = None
     return place.model_copy(update=updates)
 
 
@@ -6642,12 +6676,15 @@ def clear_duplicate_raw_place_cids(
     updated_places = list(payload.places)
     for cid, indexes in duplicate_indexes_by_cid.items():
         prior_places = prior_places_by_cid.get(cid, [])
+        google_id_counts = Counter(
+            google_id
+            for google_id in (raw_place_google_id_identity(updated_places[index]) for index in indexes)
+            if google_id is not None
+        )
+        shared_google_ids = {google_id for google_id, count in google_id_counts.items() if count > 1}
         maps_place_token_counts = Counter(
             token
-            for token in (
-                extract_maps_place_token(updated_places[index].maps_url)
-                for index in indexes
-            )
+            for token in (raw_place_maps_place_token_identity(updated_places[index]) for index in indexes)
             if token is not None
         )
         shared_maps_place_tokens = {
@@ -6672,6 +6709,7 @@ def clear_duplicate_raw_place_cids(
             updated_place = strip_duplicate_raw_place_cid(
                 original_place,
                 cid=cid,
+                shared_google_ids=shared_google_ids,
                 shared_maps_place_tokens=shared_maps_place_tokens,
             )
             if updated_place != original_place:
@@ -6727,6 +6765,16 @@ def preserve_existing_raw_saved_list(
         existing_payload=existing_payload,
     )
     existing_index = build_raw_place_preservation_index(existing_payload, source_type=source_type)
+    google_ids_in_refreshed = {
+        google_id
+        for google_id in (raw_place_google_id_identity(place) for place in refreshed_payload.places)
+        if google_id is not None
+    }
+    maps_place_tokens_in_refreshed = {
+        token
+        for token in (raw_place_maps_place_token_identity(place) for place in refreshed_payload.places)
+        if token is not None
+    }
     updated_places: list[RawPlace] = []
 
     for refreshed_place in refreshed_payload.places:
@@ -6743,6 +6791,8 @@ def preserve_existing_raw_saved_list(
         merged_place, preserved_fields = preserve_existing_raw_place(
             existing_place=existing_place,
             refreshed_place=refreshed_place,
+            blocked_google_ids=google_ids_in_refreshed,
+            blocked_maps_place_tokens=maps_place_tokens_in_refreshed,
         )
         if preserved_fields:
             place_id = stable_place_id(merged_place, source_type=source_type)

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6592,6 +6592,8 @@ def strip_duplicate_raw_place_cid(place: RawPlace, *, cid: str) -> RawPlace:
         )
     if not updates:
         return place
+    updates["google_id"] = None
+    updates["maps_place_token"] = None
     return place.model_copy(update=updates)
 
 
@@ -6673,7 +6675,7 @@ def preserve_existing_raw_saved_list(
             return clear_duplicate_raw_place_cids(
                 slug=slug,
                 payload=refreshed_payload,
-                existing_payload=None,
+                existing_payload=existing_payload,
             )
     elif (
         existing_payload.source_signature
@@ -6683,7 +6685,7 @@ def preserve_existing_raw_saved_list(
         return clear_duplicate_raw_place_cids(
             slug=slug,
             payload=refreshed_payload,
-            existing_payload=None,
+            existing_payload=existing_payload,
         )
 
     source_type = refreshed_payload.configured_source_type or existing_payload.configured_source_type

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -2584,7 +2584,11 @@ def refresh_google_export_csv(
     print(f"{action} {source.slug} from {csv_path}")
     payload = import_saved_list_csv(source)
     stamp_raw_saved_list(payload, source, source_signature=source_signature)
-    return payload
+    return clear_duplicate_raw_place_cids(
+        slug=source.slug,
+        payload=payload,
+        existing_payload=existing_payload,
+    )
 
 
 def metadata_datetime_or_none(value: str | None) -> datetime | None:
@@ -6689,6 +6693,11 @@ def preserve_existing_raw_saved_list(
         )
 
     source_type = refreshed_payload.configured_source_type or existing_payload.configured_source_type
+    refreshed_payload = clear_duplicate_raw_place_cids(
+        slug=slug,
+        payload=refreshed_payload,
+        existing_payload=existing_payload,
+    )
     existing_index = build_raw_place_preservation_index(existing_payload, source_type=source_type)
     updated_places: list[RawPlace] = []
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6440,8 +6440,6 @@ def preserve_existing_raw_place(
     *,
     existing_place: RawPlace,
     refreshed_place: RawPlace,
-    blocked_google_ids: set[str] | None = None,
-    blocked_maps_place_tokens: set[str] | None = None,
 ) -> tuple[RawPlace, list[str]]:
     preserved_fields: list[str] = []
     updates: dict[str, Any] = {}
@@ -6456,28 +6454,13 @@ def preserve_existing_raw_place(
     ):
         updates["address"] = existing_place.address
         preserved_fields.append("address")
-    existing_google_id = raw_place_google_id_identity(existing_place)
-    if (
-        names_compatible
-        and not refreshed_place.google_id
-        and existing_place.google_id
-        and (blocked_google_ids is None or existing_google_id not in blocked_google_ids)
-    ):
+    if names_compatible and not refreshed_place.google_id and existing_place.google_id:
         updates["google_id"] = existing_place.google_id
         preserved_fields.append("google_id")
     if names_compatible and not refreshed_place.cid and existing_place.cid:
         updates["cid"] = existing_place.cid
         preserved_fields.append("cid")
-    existing_maps_place_token = raw_place_maps_place_token_identity(existing_place)
-    if (
-        names_compatible
-        and not refreshed_place.maps_place_token
-        and existing_place.maps_place_token
-        and (
-            blocked_maps_place_tokens is None
-            or existing_maps_place_token not in blocked_maps_place_tokens
-        )
-    ):
+    if names_compatible and not refreshed_place.maps_place_token and existing_place.maps_place_token:
         updates["maps_place_token"] = existing_place.maps_place_token
         preserved_fields.append("maps_place_token")
     if names_compatible and not refreshed_place.is_favorite and existing_place.is_favorite:
@@ -6614,6 +6597,8 @@ def strip_duplicate_raw_place_cid(
     shared_google_ids: set[str] | None = None,
     shared_maps_place_tokens: set[str] | None = None,
     shared_maps_url_place_tokens: set[str] | None = None,
+    protected_google_ids: set[str] | None = None,
+    protected_maps_place_tokens: set[str] | None = None,
 ) -> RawPlace:
     updates: dict[str, Any] = {}
     if as_string(place.cid) == cid:
@@ -6638,13 +6623,18 @@ def strip_duplicate_raw_place_cid(
     if not updates:
         return place
     google_id = raw_place_google_id_identity(place)
-    if google_id and shared_google_ids is not None and google_id in shared_google_ids:
+    if google_id and (
+        (shared_google_ids is not None and google_id in shared_google_ids)
+        or (protected_google_ids is not None and google_id in protected_google_ids)
+    ):
         updates["google_id"] = None
     if (
         as_string(place.maps_place_token)
         and maps_place_token
-        and shared_maps_place_tokens is not None
-        and maps_place_token in shared_maps_place_tokens
+        and (
+            (shared_maps_place_tokens is not None and maps_place_token in shared_maps_place_tokens)
+            or (protected_maps_place_tokens is not None and maps_place_token in protected_maps_place_tokens)
+        )
     ):
         updates["maps_place_token"] = None
     return place.model_copy(update=updates)
@@ -6711,6 +6701,21 @@ def clear_duplicate_raw_place_cids(
                 -index,
             ),
         )
+        kept_place = updated_places[keep_index]
+        protected_google_ids = {
+            google_id
+            for prior_place in prior_places
+            if raw_place_names_are_compatible(as_string(prior_place.name), as_string(kept_place.name))
+            for google_id in [raw_place_google_id_identity(prior_place)]
+            if google_id is not None
+        }
+        protected_maps_place_tokens = {
+            token
+            for prior_place in prior_places
+            if raw_place_names_are_compatible(as_string(prior_place.name), as_string(kept_place.name))
+            for token in [raw_place_maps_place_token_identity(prior_place)]
+            if token is not None
+        }
         cleared_names: list[str] = []
         for index in indexes:
             if index == keep_index:
@@ -6722,6 +6727,8 @@ def clear_duplicate_raw_place_cids(
                 shared_google_ids=shared_google_ids,
                 shared_maps_place_tokens=shared_maps_place_tokens,
                 shared_maps_url_place_tokens=shared_maps_url_place_tokens,
+                protected_google_ids=protected_google_ids,
+                protected_maps_place_tokens=protected_maps_place_tokens,
             )
             if updated_place != original_place:
                 updated_places[index] = updated_place
@@ -6738,6 +6745,153 @@ def clear_duplicate_raw_place_cids(
     return payload.model_copy(update={"places": updated_places})
 
 
+def score_duplicate_raw_place_google_identity_candidate(
+    place: RawPlace,
+    *,
+    prior_places: Sequence[RawPlace],
+) -> int:
+    score = 50 if raw_place_cid_identity(place) else 0
+    best_prior_score = 0
+    for prior_place in prior_places:
+        prior_score = 0
+        if raw_place_names_are_compatible(as_string(prior_place.name), as_string(place.name)):
+            prior_score += 80
+
+        prior_address = normalize_text(prior_place.address)
+        place_address = normalize_text(place.address)
+        if prior_address and place_address:
+            if prior_address == place_address:
+                prior_score += 50
+            else:
+                prior_score += token_overlap_score(prior_address, place_address)
+
+        if (
+            prior_place.lat is not None
+            and prior_place.lng is not None
+            and place.lat is not None
+            and place.lng is not None
+        ):
+            distance_m = haversine_meters(
+                prior_place.lat,
+                prior_place.lng,
+                place.lat,
+                place.lng,
+            )
+            if distance_m <= 100:
+                prior_score += 60
+            elif distance_m <= 400:
+                prior_score += 40
+            elif distance_m <= 1200:
+                prior_score += 10
+
+        best_prior_score = max(best_prior_score, prior_score)
+
+    return score + best_prior_score
+
+
+def strip_duplicate_raw_place_google_identity(
+    place: RawPlace,
+    *,
+    google_id: str | None = None,
+    maps_place_token: str | None = None,
+) -> RawPlace:
+    updates: dict[str, Any] = {}
+    if google_id is not None and raw_place_google_id_identity(place) == google_id:
+        updates["google_id"] = None
+    if maps_place_token is not None:
+        if as_string(place.maps_place_token) == maps_place_token:
+            updates["maps_place_token"] = None
+        if extract_maps_place_token(place.maps_url) == maps_place_token:
+            updates["maps_url"] = build_public_google_maps_url(
+                name=place.name,
+                address=place.address,
+                lat=place.lat,
+                lng=place.lng,
+                raw_maps_url=None,
+            )
+    if not updates:
+        return place
+    return place.model_copy(update=updates)
+
+
+def clear_duplicate_raw_place_google_identities(
+    *,
+    slug: str,
+    payload: RawSavedList,
+    existing_payload: RawSavedList | None,
+) -> RawSavedList:
+    updated_places = list(payload.places)
+    duplicate_groups: list[tuple[str, str, list[int]]] = []
+    for identity_name, identity_getter in (
+        ("google_id", raw_place_google_id_identity),
+        ("maps_place_token", raw_place_maps_place_token_identity),
+    ):
+        indexes_by_identity: dict[str, list[int]] = {}
+        for index, place in enumerate(updated_places):
+            identity = identity_getter(place)
+            if identity:
+                indexes_by_identity.setdefault(identity, []).append(index)
+        duplicate_groups.extend(
+            (identity_name, identity, indexes)
+            for identity, indexes in indexes_by_identity.items()
+            if len(indexes) > 1
+        )
+
+    if not duplicate_groups:
+        return payload
+
+    prior_places_by_google_id: dict[str, list[RawPlace]] = {}
+    prior_places_by_maps_place_token: dict[str, list[RawPlace]] = {}
+    if existing_payload is not None:
+        for prior_place in existing_payload.places:
+            google_id = raw_place_google_id_identity(prior_place)
+            if google_id:
+                prior_places_by_google_id.setdefault(google_id, []).append(prior_place)
+            maps_place_token = raw_place_maps_place_token_identity(prior_place)
+            if maps_place_token:
+                prior_places_by_maps_place_token.setdefault(maps_place_token, []).append(prior_place)
+
+    for identity_name, identity, indexes in duplicate_groups:
+        prior_places = (
+            prior_places_by_google_id.get(identity, [])
+            if identity_name == "google_id"
+            else prior_places_by_maps_place_token.get(identity, [])
+        )
+        keep_index = max(
+            indexes,
+            key=lambda index: (
+                score_duplicate_raw_place_google_identity_candidate(
+                    updated_places[index],
+                    prior_places=prior_places,
+                ),
+                -index,
+            ),
+        )
+        cleared_names: list[str] = []
+        for index in indexes:
+            if index == keep_index:
+                continue
+            original_place = updated_places[index]
+            updated_place = strip_duplicate_raw_place_google_identity(
+                original_place,
+                google_id=identity if identity_name == "google_id" else None,
+                maps_place_token=identity if identity_name == "maps_place_token" else None,
+            )
+            if updated_place != original_place:
+                updated_places[index] = updated_place
+                cleared_names.append(updated_place.name or f"place #{index + 1}")
+
+        if cleared_names:
+            kept_name = updated_places[keep_index].name or f"place #{keep_index + 1}"
+            print(
+                f"WARNING: Clearing duplicate raw {identity_name} {identity} in {slug}: "
+                f"kept [{kept_name}], cleared [{', '.join(cleared_names)}].",
+                flush=True,
+            )
+
+    return payload.model_copy(update={"places": updated_places})
+
+
 def preserve_existing_raw_saved_list(
     *,
     source: SourceConfig | None = None,
@@ -6746,16 +6900,26 @@ def preserve_existing_raw_saved_list(
     refreshed_payload: RawSavedList,
 ) -> RawSavedList:
     if existing_payload is None:
-        return clear_duplicate_raw_place_cids(
+        deduped_payload = clear_duplicate_raw_place_cids(
             slug=slug,
             payload=refreshed_payload,
             existing_payload=None,
         )
+        return clear_duplicate_raw_place_google_identities(
+            slug=slug,
+            payload=deduped_payload,
+            existing_payload=None,
+        )
     if source is not None:
         if not raw_source_signature_matches(source, existing_payload.source_signature):
-            return clear_duplicate_raw_place_cids(
+            deduped_payload = clear_duplicate_raw_place_cids(
                 slug=slug,
                 payload=refreshed_payload,
+                existing_payload=existing_payload,
+            )
+            return clear_duplicate_raw_place_google_identities(
+                slug=slug,
+                payload=deduped_payload,
                 existing_payload=existing_payload,
             )
     elif (
@@ -6763,9 +6927,14 @@ def preserve_existing_raw_saved_list(
         and refreshed_payload.source_signature
         and existing_payload.source_signature != refreshed_payload.source_signature
     ):
-        return clear_duplicate_raw_place_cids(
+        deduped_payload = clear_duplicate_raw_place_cids(
             slug=slug,
             payload=refreshed_payload,
+            existing_payload=existing_payload,
+        )
+        return clear_duplicate_raw_place_google_identities(
+            slug=slug,
+            payload=deduped_payload,
             existing_payload=existing_payload,
         )
 
@@ -6776,16 +6945,6 @@ def preserve_existing_raw_saved_list(
         existing_payload=existing_payload,
     )
     existing_index = build_raw_place_preservation_index(existing_payload, source_type=source_type)
-    google_ids_in_refreshed = {
-        google_id
-        for google_id in (raw_place_google_id_identity(place) for place in refreshed_payload.places)
-        if google_id is not None
-    }
-    maps_place_tokens_in_refreshed = {
-        token
-        for token in (raw_place_maps_place_token_identity(place) for place in refreshed_payload.places)
-        if token is not None
-    }
     updated_places: list[RawPlace] = []
 
     for refreshed_place in refreshed_payload.places:
@@ -6802,8 +6961,6 @@ def preserve_existing_raw_saved_list(
         merged_place, preserved_fields = preserve_existing_raw_place(
             existing_place=existing_place,
             refreshed_place=refreshed_place,
-            blocked_google_ids=google_ids_in_refreshed,
-            blocked_maps_place_tokens=maps_place_tokens_in_refreshed,
         )
         if preserved_fields:
             place_id = stable_place_id(merged_place, source_type=source_type)
@@ -6814,9 +6971,14 @@ def preserve_existing_raw_saved_list(
             )
         updated_places.append(merged_place)
 
-    return clear_duplicate_raw_place_cids(
+    deduped_payload = clear_duplicate_raw_place_cids(
         slug=slug,
         payload=refreshed_payload.model_copy(update={"places": updated_places}),
+        existing_payload=existing_payload,
+    )
+    return clear_duplicate_raw_place_google_identities(
+        slug=slug,
+        payload=deduped_payload,
         existing_payload=existing_payload,
     )
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6512,6 +6512,143 @@ def raw_place_address_is_preservable(existing_place: RawPlace, refreshed_place: 
     )
 
 
+def raw_place_cid_identity(place: RawPlace) -> str | None:
+    return as_string(place.cid) or extract_maps_cid(place.maps_url)
+
+
+def score_duplicate_raw_place_cid_candidate(
+    place: RawPlace,
+    *,
+    cid: str,
+    prior_places: Sequence[RawPlace],
+) -> int:
+    score = 0
+    if as_string(place.cid) == cid:
+        score += 20
+    if extract_maps_cid(place.maps_url) == cid:
+        score += 25
+
+    best_prior_score = 0
+    for prior_place in prior_places:
+        prior_score = 0
+        if raw_place_names_are_compatible(as_string(prior_place.name), as_string(place.name)):
+            prior_score += 80
+
+        if (
+            as_string(prior_place.google_id)
+            and as_string(prior_place.google_id) == as_string(place.google_id)
+        ):
+            prior_score += 60
+
+        prior_address = normalize_text(prior_place.address)
+        place_address = normalize_text(place.address)
+        if prior_address and place_address:
+            if prior_address == place_address:
+                prior_score += 50
+            else:
+                prior_score += token_overlap_score(prior_address, place_address)
+
+        if (
+            prior_place.lat is not None
+            and prior_place.lng is not None
+            and place.lat is not None
+            and place.lng is not None
+        ):
+            distance_m = haversine_meters(
+                prior_place.lat,
+                prior_place.lng,
+                place.lat,
+                place.lng,
+            )
+            if distance_m <= 100:
+                prior_score += 60
+            elif distance_m <= 400:
+                prior_score += 40
+            elif distance_m <= 1200:
+                prior_score += 10
+
+        best_prior_score = max(best_prior_score, prior_score)
+
+    return score + best_prior_score
+
+
+def strip_duplicate_raw_place_cid(place: RawPlace, *, cid: str) -> RawPlace:
+    updates: dict[str, Any] = {}
+    if as_string(place.cid) == cid:
+        updates["cid"] = None
+    if extract_maps_cid(place.maps_url) == cid:
+        updates["maps_url"] = build_public_google_maps_url(
+            name=place.name,
+            address=place.address,
+            lat=place.lat,
+            lng=place.lng,
+            raw_maps_url=None,
+        )
+    if not updates:
+        return place
+    return place.model_copy(update=updates)
+
+
+def clear_duplicate_raw_place_cids(
+    *,
+    slug: str,
+    payload: RawSavedList,
+    existing_payload: RawSavedList | None,
+) -> RawSavedList:
+    indexes_by_cid: dict[str, list[int]] = {}
+    for index, place in enumerate(payload.places):
+        cid = raw_place_cid_identity(place)
+        if cid:
+            indexes_by_cid.setdefault(cid, []).append(index)
+
+    duplicate_indexes_by_cid = {
+        cid: indexes for cid, indexes in indexes_by_cid.items() if len(indexes) > 1
+    }
+    if not duplicate_indexes_by_cid:
+        return payload
+
+    prior_places_by_cid: dict[str, list[RawPlace]] = {}
+    if existing_payload is not None:
+        for prior_place in existing_payload.places:
+            cid = raw_place_cid_identity(prior_place)
+            if cid:
+                prior_places_by_cid.setdefault(cid, []).append(prior_place)
+
+    updated_places = list(payload.places)
+    for cid, indexes in duplicate_indexes_by_cid.items():
+        prior_places = prior_places_by_cid.get(cid, [])
+        keep_index = max(
+            indexes,
+            key=lambda index: (
+                score_duplicate_raw_place_cid_candidate(
+                    updated_places[index],
+                    cid=cid,
+                    prior_places=prior_places,
+                ),
+                -index,
+            ),
+        )
+        cleared_names: list[str] = []
+        for index in indexes:
+            if index == keep_index:
+                continue
+            original_place = updated_places[index]
+            updated_place = strip_duplicate_raw_place_cid(original_place, cid=cid)
+            if updated_place != original_place:
+                updated_places[index] = updated_place
+                cleared_names.append(updated_place.name or f"place #{index + 1}")
+
+        if cleared_names:
+            kept_name = updated_places[keep_index].name or f"place #{keep_index + 1}"
+            print(
+                f"WARNING: Clearing duplicate raw CID {cid} in {slug}: "
+                f"kept [{kept_name}], cleared [{', '.join(cleared_names)}].",
+                flush=True,
+            )
+
+    return payload.model_copy(update={"places": updated_places})
+
+
 def preserve_existing_raw_saved_list(
     *,
     source: SourceConfig | None = None,
@@ -6520,16 +6657,28 @@ def preserve_existing_raw_saved_list(
     refreshed_payload: RawSavedList,
 ) -> RawSavedList:
     if existing_payload is None:
-        return refreshed_payload
+        return clear_duplicate_raw_place_cids(
+            slug=slug,
+            payload=refreshed_payload,
+            existing_payload=None,
+        )
     if source is not None:
         if not raw_source_signature_matches(source, existing_payload.source_signature):
-            return refreshed_payload
+            return clear_duplicate_raw_place_cids(
+                slug=slug,
+                payload=refreshed_payload,
+                existing_payload=None,
+            )
     elif (
         existing_payload.source_signature
         and refreshed_payload.source_signature
         and existing_payload.source_signature != refreshed_payload.source_signature
     ):
-        return refreshed_payload
+        return clear_duplicate_raw_place_cids(
+            slug=slug,
+            payload=refreshed_payload,
+            existing_payload=None,
+        )
 
     source_type = refreshed_payload.configured_source_type or existing_payload.configured_source_type
     existing_index = build_raw_place_preservation_index(existing_payload, source_type=source_type)
@@ -6559,7 +6708,11 @@ def preserve_existing_raw_saved_list(
             )
         updated_places.append(merged_place)
 
-    return refreshed_payload.model_copy(update={"places": updated_places})
+    return clear_duplicate_raw_place_cids(
+        slug=slug,
+        payload=refreshed_payload.model_copy(update={"places": updated_places}),
+        existing_payload=existing_payload,
+    )
 
 
 def raw_source_refresh_after(fetched_at: datetime, source: SourceConfig, *, source_signature: str) -> datetime:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6883,7 +6883,11 @@ def clear_duplicate_raw_place_google_identities(
             updated_place = strip_duplicate_raw_place_google_identity(
                 original_place,
                 google_id=identity if identity_name == "google_id" else None,
-                maps_place_token=identity if identity_name == "maps_place_token" else None,
+                maps_place_token=(
+                    identity
+                    if identity_name == "maps_place_token"
+                    else raw_place_maps_place_token_identity(updated_places[keep_index])
+                ),
             )
             if updated_place != original_place:
                 updated_places[index] = updated_place

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6527,7 +6527,10 @@ def raw_place_cid_identity(place: RawPlace) -> str | None:
 
 
 def raw_place_google_id_identity(place: RawPlace) -> str | None:
-    return as_string(place.google_id)
+    google_id = as_string(place.google_id)
+    if not google_id:
+        return None
+    return google_id.strip("/").replace("/", "-")
 
 
 def raw_place_maps_place_token_identity(place: RawPlace) -> str | None:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6612,6 +6612,11 @@ def strip_duplicate_raw_place_cid(
             and shared_maps_url_place_tokens is not None
             and maps_url_place_token in shared_maps_url_place_tokens
         )
+        or (
+            maps_url_place_token is not None
+            and protected_maps_place_tokens is not None
+            and maps_url_place_token in protected_maps_place_tokens
+        )
     ):
         updates["maps_url"] = build_public_google_maps_url(
             name=place.name,

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6613,17 +6613,19 @@ def strip_duplicate_raw_place_cid(
     cid: str,
     shared_google_ids: set[str] | None = None,
     shared_maps_place_tokens: set[str] | None = None,
+    shared_maps_url_place_tokens: set[str] | None = None,
 ) -> RawPlace:
     updates: dict[str, Any] = {}
     if as_string(place.cid) == cid:
         updates["cid"] = None
+    maps_url_place_token = extract_maps_place_token(place.maps_url)
     maps_place_token = raw_place_maps_place_token_identity(place)
     if (
         extract_maps_cid(place.maps_url) == cid
         or (
-            maps_place_token is not None
-            and shared_maps_place_tokens is not None
-            and maps_place_token in shared_maps_place_tokens
+            maps_url_place_token is not None
+            and shared_maps_url_place_tokens is not None
+            and maps_url_place_token in shared_maps_url_place_tokens
         )
     ):
         updates["maps_url"] = build_public_google_maps_url(
@@ -6690,6 +6692,14 @@ def clear_duplicate_raw_place_cids(
         shared_maps_place_tokens = {
             token for token, count in maps_place_token_counts.items() if count > 1
         }
+        maps_url_place_token_counts = Counter(
+            token
+            for token in (extract_maps_place_token(updated_places[index].maps_url) for index in indexes)
+            if token is not None
+        )
+        shared_maps_url_place_tokens = {
+            token for token, count in maps_url_place_token_counts.items() if count > 1
+        }
         keep_index = max(
             indexes,
             key=lambda index: (
@@ -6711,6 +6721,7 @@ def clear_duplicate_raw_place_cids(
                 cid=cid,
                 shared_google_ids=shared_google_ids,
                 shared_maps_place_tokens=shared_maps_place_tokens,
+                shared_maps_url_place_tokens=shared_maps_url_place_tokens,
             )
             if updated_place != original_place:
                 updated_places[index] = updated_place

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6582,11 +6582,24 @@ def score_duplicate_raw_place_cid_candidate(
     return score + best_prior_score
 
 
-def strip_duplicate_raw_place_cid(place: RawPlace, *, cid: str) -> RawPlace:
+def strip_duplicate_raw_place_cid(
+    place: RawPlace,
+    *,
+    cid: str,
+    shared_maps_place_tokens: set[str] | None = None,
+) -> RawPlace:
     updates: dict[str, Any] = {}
     if as_string(place.cid) == cid:
         updates["cid"] = None
-    if extract_maps_cid(place.maps_url) == cid:
+    maps_place_token = extract_maps_place_token(place.maps_url)
+    if (
+        extract_maps_cid(place.maps_url) == cid
+        or (
+            maps_place_token is not None
+            and shared_maps_place_tokens is not None
+            and maps_place_token in shared_maps_place_tokens
+        )
+    ):
         updates["maps_url"] = build_public_google_maps_url(
             name=place.name,
             address=place.address,
@@ -6629,6 +6642,17 @@ def clear_duplicate_raw_place_cids(
     updated_places = list(payload.places)
     for cid, indexes in duplicate_indexes_by_cid.items():
         prior_places = prior_places_by_cid.get(cid, [])
+        maps_place_token_counts = Counter(
+            token
+            for token in (
+                extract_maps_place_token(updated_places[index].maps_url)
+                for index in indexes
+            )
+            if token is not None
+        )
+        shared_maps_place_tokens = {
+            token for token, count in maps_place_token_counts.items() if count > 1
+        }
         keep_index = max(
             indexes,
             key=lambda index: (
@@ -6645,7 +6669,11 @@ def clear_duplicate_raw_place_cids(
             if index == keep_index:
                 continue
             original_place = updated_places[index]
-            updated_place = strip_duplicate_raw_place_cid(original_place, cid=cid)
+            updated_place = strip_duplicate_raw_place_cid(
+                original_place,
+                cid=cid,
+                shared_maps_place_tokens=shared_maps_place_tokens,
+            )
             if updated_place != original_place:
                 updated_places[index] = updated_place
                 cleared_names.append(updated_place.name or f"place #{index + 1}")

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1583,8 +1583,8 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertEqual(merged.places[0].cid, duplicate_cid)
         self.assertIsNone(merged.places[1].cid)
-        self.assertIsNone(merged.places[1].google_id)
-        self.assertIsNone(merged.places[1].maps_place_token)
+        self.assertEqual(merged.places[1].google_id, "/g/11belem")
+        self.assertEqual(merged.places[1].maps_place_token, "0xd2:0x2")
         self.assertNotEqual(
             build_data.stable_place_id(merged.places[0], source_type=merged.configured_source_type),
             build_data.stable_place_id(merged.places[1], source_type=merged.configured_source_type),
@@ -1650,6 +1650,69 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertIsNone(merged.places[0].cid)
         self.assertEqual(merged.places[1].cid, duplicate_cid)
+
+    def test_preserve_existing_raw_saved_list_clears_duplicate_cid_before_preserving_fields(
+        self,
+    ) -> None:
+        duplicate_cid = "555123"
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    added_by=ListAuthor(name="Alice"),
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url="https://maps.google.com/?cid=555123",
+                    cid=duplicate_cid,
+                ),
+                RawPlace(
+                    name="Wrong Cafe",
+                    address=None,
+                    added_by=None,
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Wrong+Cafe",
+                    cid=None,
+                ),
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="",
+                    address=None,
+                    added_by=None,
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url="https://maps.google.com/?cid=555123",
+                    cid=duplicate_cid,
+                ),
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    added_by=None,
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url="https://maps.google.com/?cid=555123",
+                    cid=duplicate_cid,
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertIsNone(merged.places[0].cid)
+        self.assertIsNone(merged.places[0].address)
+        self.assertIsNone(merged.places[0].added_by)
+        self.assertEqual(merged.places[1].cid, duplicate_cid)
+        self.assertEqual(merged.places[1].added_by, ListAuthor(name="Alice"))
 
     def test_build_place_page_candidate_urls_prefers_search_for_cid_inputs(self) -> None:
         place = RawPlace(
@@ -10154,6 +10217,42 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(second_place.name, "Fallback Name")
         self.assertTrue(
             build_data.stable_place_id(second_place, source_type="google_export_csv").startswith("url:")
+        )
+
+    def test_refresh_google_export_csv_clears_duplicate_cids(self) -> None:
+        duplicate_cid = "444555666"
+        with TemporaryDirectory() as tmpdir:
+            csv_path = Path(tmpdir) / "alishan.csv"
+            csv_path.write_text(
+                "\n".join(
+                    [
+                        "Title,Note,URL",
+                        f"Tea House,,https://maps.google.com/?cid={duplicate_cid}",
+                        f"Mountain Cafe,,https://maps.google.com/?cid={duplicate_cid}",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            source = SourceConfig(
+                slug="alishan-taiwan",
+                type="google_export_csv",
+                path=str(csv_path),
+                title="Alishan, Taiwan",
+            )
+
+            saved_list = build_data.refresh_google_export_csv(
+                source,
+                existing_payload=None,
+                force_refresh=True,
+            )
+
+        self.assertIsNotNone(saved_list)
+        assert saved_list is not None
+        self.assertEqual(build_data.extract_maps_cid(saved_list.places[0].maps_url), duplicate_cid)
+        self.assertIsNone(build_data.extract_maps_cid(saved_list.places[1].maps_url))
+        self.assertNotEqual(
+            build_data.stable_place_id(saved_list.places[0], source_type="google_export_csv"),
+            build_data.stable_place_id(saved_list.places[1], source_type="google_export_csv"),
         )
 
     def test_normalize_guide_prefers_enrichment_name_for_csv_sources_and_tracks_provenance(self) -> None:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1533,6 +1533,8 @@ class BuildDataTests(unittest.TestCase):
                         "Jer%C3%B3nimos+Monastery%2C+Pra%C3%A7a+do+Imp%C3%A9rio"
                     ),
                     cid=duplicate_cid,
+                    google_id="/g/11jeronimos",
+                    maps_place_token="0xd1:0x1",
                 ),
                 RawPlace(
                     name="Belém Tower",
@@ -1541,6 +1543,8 @@ class BuildDataTests(unittest.TestCase):
                     lng=-9.2159773,
                     maps_url="https://www.google.com/maps/search/?api=1&query=Bel%C3%A9m+Tower",
                     cid=None,
+                    google_id="/g/11belem",
+                    maps_place_token="0xd2:0x2",
                 ),
             ],
         )
@@ -1565,6 +1569,8 @@ class BuildDataTests(unittest.TestCase):
                     lng=-9.2159773,
                     maps_url="https://www.google.com/maps/search/?api=1&query=Bel%C3%A9m+Tower",
                     cid=duplicate_cid,
+                    google_id=None,
+                    maps_place_token=None,
                 ),
             ],
         )
@@ -1577,10 +1583,73 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertEqual(merged.places[0].cid, duplicate_cid)
         self.assertIsNone(merged.places[1].cid)
+        self.assertIsNone(merged.places[1].google_id)
+        self.assertIsNone(merged.places[1].maps_place_token)
         self.assertNotEqual(
             build_data.stable_place_id(merged.places[0], source_type=merged.configured_source_type),
             build_data.stable_place_id(merged.places[1], source_type=merged.configured_source_type),
         )
+
+    def test_preserve_existing_raw_saved_list_uses_prior_anchor_for_changed_source_duplicate_cid(
+        self,
+    ) -> None:
+        duplicate_cid = "123456789"
+        previous_source = SourceConfig(slug="taipei-taiwan", url="https://maps.app.goo.gl/old")
+        current_source = SourceConfig(slug="taipei-taiwan", url="https://maps.app.goo.gl/new")
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            source_signature=build_data.raw_source_signature(previous_source),
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url="https://maps.google.com/?cid=123456789",
+                    cid=duplicate_cid,
+                ),
+                RawPlace(
+                    name="Wrong Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Wrong+Cafe",
+                    cid=None,
+                ),
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            source_signature=build_data.raw_source_signature(current_source),
+            places=[
+                RawPlace(
+                    name="Wrong Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url="https://maps.google.com/?cid=123456789",
+                    cid=duplicate_cid,
+                ),
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url="https://maps.google.com/?cid=123456789",
+                    cid=duplicate_cid,
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            source=current_source,
+            slug="taipei-taiwan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertIsNone(merged.places[0].cid)
+        self.assertEqual(merged.places[1].cid, duplicate_cid)
 
     def test_build_place_page_candidate_urls_prefers_search_for_cid_inputs(self) -> None:
         place = RawPlace(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1518,6 +1518,70 @@ class BuildDataTests(unittest.TestCase):
         self.assertIsNone(merged.places[0].maps_place_token)
         self.assertFalse(merged.places[0].is_favorite)
 
+    def test_preserve_existing_raw_saved_list_clears_new_duplicate_cid(self) -> None:
+        duplicate_cid = "945416459406974027"
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Jerónimos Monastery",
+                    address="Praça do Império 1400-206 Lisboa, Portugal",
+                    lat=38.6978909,
+                    lng=-9.2067039,
+                    maps_url=(
+                        "https://www.google.com/maps/search/?api=1&query="
+                        "Jer%C3%B3nimos+Monastery%2C+Pra%C3%A7a+do+Imp%C3%A9rio"
+                    ),
+                    cid=duplicate_cid,
+                ),
+                RawPlace(
+                    name="Belém Tower",
+                    address=None,
+                    lat=38.6915837,
+                    lng=-9.2159773,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Bel%C3%A9m+Tower",
+                    cid=None,
+                ),
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Jerónimos Monastery",
+                    address="Praça do Império 1400-206 Lisboa, Portugal",
+                    lat=38.6978909,
+                    lng=-9.2067039,
+                    maps_url=(
+                        "https://www.google.com/maps/search/?api=1&query="
+                        "Jer%C3%B3nimos+Monastery%2C+Pra%C3%A7a+do+Imp%C3%A9rio"
+                    ),
+                    cid=duplicate_cid,
+                ),
+                RawPlace(
+                    name="Belém Tower",
+                    address=None,
+                    lat=38.6915837,
+                    lng=-9.2159773,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Bel%C3%A9m+Tower",
+                    cid=duplicate_cid,
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="lisbon-portugal",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].cid, duplicate_cid)
+        self.assertIsNone(merged.places[1].cid)
+        self.assertNotEqual(
+            build_data.stable_place_id(merged.places[0], source_type=merged.configured_source_type),
+            build_data.stable_place_id(merged.places[1], source_type=merged.configured_source_type),
+        )
+
     def test_build_place_page_candidate_urls_prefers_search_for_cid_inputs(self) -> None:
         place = RawPlace(
             name="Sister Midnight",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1805,6 +1805,52 @@ class BuildDataTests(unittest.TestCase):
             "gid:g-independent-cafe",
         )
 
+    def test_preserve_existing_raw_saved_list_strips_shared_url_token_but_keeps_independent_field_token(
+        self,
+    ) -> None:
+        duplicate_cid = "888456"
+        duplicate_url_token = "0xabc123:0xdef456"
+        maps_url = f"https://www.google.com/maps/place/data=!4m2!3m1!1s{duplicate_url_token}"
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=maps_url,
+                    cid=duplicate_cid,
+                    maps_place_token="0xabc123:0x111111",
+                ),
+                RawPlace(
+                    name="Independent Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url=maps_url,
+                    cid=duplicate_cid,
+                    maps_place_token="0xabc123:0x222222",
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=None,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].cid, duplicate_cid)
+        self.assertEqual(build_data.extract_maps_place_token(merged.places[0].maps_url), duplicate_url_token)
+        self.assertIsNone(merged.places[1].cid)
+        self.assertIsNone(build_data.extract_maps_place_token(merged.places[1].maps_url))
+        self.assertEqual(merged.places[1].maps_place_token, "0xabc123:0x222222")
+        self.assertEqual(
+            build_data.stable_place_id(merged.places[1], source_type=merged.configured_source_type),
+            "gms:0xabc123:0x222222",
+        )
+
     def test_preserve_existing_raw_saved_list_does_not_restore_stripped_duplicate_identity(
         self,
     ) -> None:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2110,6 +2110,44 @@ class BuildDataTests(unittest.TestCase):
         self.assertIsNone(merged.places[1].cid)
         self.assertIsNone(merged.places[1].google_id)
 
+    def test_preserve_existing_raw_saved_list_clears_normalized_duplicate_google_id(
+        self,
+    ) -> None:
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Correct+Cafe",
+                    google_id="/g/correct-cafe",
+                ),
+                RawPlace(
+                    name="Wrong Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Wrong+Cafe",
+                    google_id="g/correct-cafe",
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=None,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].google_id, "/g/correct-cafe")
+        self.assertIsNone(merged.places[1].google_id)
+        self.assertNotEqual(
+            build_data.stable_place_id(merged.places[0], source_type=merged.configured_source_type),
+            build_data.stable_place_id(merged.places[1], source_type=merged.configured_source_type),
+        )
+
     def test_build_place_page_candidate_urls_prefers_search_for_cid_inputs(self) -> None:
         place = RawPlace(
             name="Sister Midnight",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2148,6 +2148,51 @@ class BuildDataTests(unittest.TestCase):
             build_data.stable_place_id(merged.places[1], source_type=merged.configured_source_type),
         )
 
+    def test_preserve_existing_raw_saved_list_strips_keeper_url_token_from_duplicate_google_id_loser(
+        self,
+    ) -> None:
+        keeper_token = "0xabc123:0x111111"
+        independent_token = "0xabc123:0x222222"
+        keeper_maps_url = f"https://www.google.com/maps/place/data=!4m2!3m1!1s{keeper_token}"
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=keeper_maps_url,
+                    google_id="/g/correct-cafe",
+                ),
+                RawPlace(
+                    name="Wrong Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url=keeper_maps_url,
+                    google_id="g/correct-cafe",
+                    maps_place_token=independent_token,
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=None,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].google_id, "/g/correct-cafe")
+        self.assertEqual(build_data.extract_maps_place_token(merged.places[0].maps_url), keeper_token)
+        self.assertIsNone(merged.places[1].google_id)
+        self.assertIsNone(build_data.extract_maps_place_token(merged.places[1].maps_url))
+        self.assertEqual(merged.places[1].maps_place_token, independent_token)
+        self.assertEqual(
+            build_data.stable_place_id(merged.places[1], source_type=merged.configured_source_type),
+            f"gms:{independent_token}",
+        )
+
     def test_build_place_page_candidate_urls_prefers_search_for_cid_inputs(self) -> None:
         place = RawPlace(
             name="Sister Midnight",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1714,6 +1714,51 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(merged.places[1].cid, duplicate_cid)
         self.assertEqual(merged.places[1].added_by, ListAuthor(name="Alice"))
 
+    def test_preserve_existing_raw_saved_list_clears_shared_maps_place_token_for_duplicate_cid(
+        self,
+    ) -> None:
+        duplicate_cid = "777123"
+        duplicate_token = "0xabc123:0xdef456"
+        maps_url = f"https://www.google.com/maps/place/data=!4m2!3m1!1s{duplicate_token}"
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=maps_url,
+                    cid=duplicate_cid,
+                ),
+                RawPlace(
+                    name="Wrong Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url=maps_url,
+                    cid=duplicate_cid,
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=None,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].cid, duplicate_cid)
+        self.assertEqual(build_data.extract_maps_place_token(merged.places[0].maps_url), duplicate_token)
+        self.assertIsNone(merged.places[1].cid)
+        self.assertIsNone(build_data.extract_maps_place_token(merged.places[1].maps_url))
+        self.assertIsNone(merged.places[1].google_id)
+        self.assertIsNone(merged.places[1].maps_place_token)
+        self.assertNotEqual(
+            build_data.stable_place_id(merged.places[0], source_type=merged.configured_source_type),
+            build_data.stable_place_id(merged.places[1], source_type=merged.configured_source_type),
+        )
+
     def test_build_place_page_candidate_urls_prefers_search_for_cid_inputs(self) -> None:
         place = RawPlace(
             name="Sister Midnight",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1759,6 +1759,123 @@ class BuildDataTests(unittest.TestCase):
             build_data.stable_place_id(merged.places[1], source_type=merged.configured_source_type),
         )
 
+    def test_preserve_existing_raw_saved_list_keeps_independent_google_ids_for_duplicate_cid(
+        self,
+    ) -> None:
+        duplicate_cid = "888123"
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=f"https://maps.google.com/?cid={duplicate_cid}",
+                    cid=duplicate_cid,
+                    google_id="/g/correct-cafe",
+                    maps_place_token="0xabc123:0xcorrect",
+                ),
+                RawPlace(
+                    name="Independent Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url=f"https://maps.google.com/?cid={duplicate_cid}",
+                    cid=duplicate_cid,
+                    google_id="/g/independent-cafe",
+                    maps_place_token="0xabc123:0xindependent",
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=None,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].cid, duplicate_cid)
+        self.assertIsNone(merged.places[1].cid)
+        self.assertIsNone(build_data.extract_maps_cid(merged.places[1].maps_url))
+        self.assertEqual(merged.places[1].google_id, "/g/independent-cafe")
+        self.assertEqual(merged.places[1].maps_place_token, "0xabc123:0xindependent")
+        self.assertEqual(
+            build_data.stable_place_id(merged.places[1], source_type=merged.configured_source_type),
+            "gid:g-independent-cafe",
+        )
+
+    def test_preserve_existing_raw_saved_list_does_not_restore_stripped_duplicate_identity(
+        self,
+    ) -> None:
+        duplicate_cid = "999123"
+        duplicate_token = "0xabc123:0xdef456"
+        maps_url = f"https://www.google.com/maps/place/data=!4m2!3m1!1s{duplicate_token}"
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=maps_url,
+                    cid=duplicate_cid,
+                    google_id="/g/correct-cafe",
+                    maps_place_token=duplicate_token,
+                ),
+                RawPlace(
+                    name="Wrong Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Wrong+Cafe",
+                    google_id="/g/correct-cafe",
+                    maps_place_token=duplicate_token,
+                ),
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=maps_url,
+                    cid=duplicate_cid,
+                    google_id="/g/correct-cafe",
+                ),
+                RawPlace(
+                    name="Wrong Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url=maps_url,
+                    cid=duplicate_cid,
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].cid, duplicate_cid)
+        self.assertEqual(merged.places[0].google_id, "/g/correct-cafe")
+        self.assertEqual(build_data.extract_maps_place_token(merged.places[0].maps_url), duplicate_token)
+        self.assertIsNone(merged.places[1].cid)
+        self.assertIsNone(merged.places[1].google_id)
+        self.assertIsNone(merged.places[1].maps_place_token)
+        self.assertIsNone(build_data.extract_maps_place_token(merged.places[1].maps_url))
+        self.assertNotEqual(
+            build_data.stable_place_id(merged.places[0], source_type=merged.configured_source_type),
+            build_data.stable_place_id(merged.places[1], source_type=merged.configured_source_type),
+        )
+
     def test_build_place_page_candidate_urls_prefers_search_for_cid_inputs(self) -> None:
         place = RawPlace(
             name="Sister Midnight",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1922,6 +1922,124 @@ class BuildDataTests(unittest.TestCase):
             build_data.stable_place_id(merged.places[1], source_type=merged.configured_source_type),
         )
 
+    def test_preserve_existing_raw_saved_list_restores_keeper_identity_from_wrong_row(
+        self,
+    ) -> None:
+        duplicate_cid = "999456"
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=f"https://maps.google.com/?cid={duplicate_cid}",
+                    cid=duplicate_cid,
+                    google_id="/g/correct-cafe",
+                ),
+                RawPlace(
+                    name="Wrong Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Wrong+Cafe",
+                ),
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=f"https://maps.google.com/?cid={duplicate_cid}",
+                    cid=duplicate_cid,
+                ),
+                RawPlace(
+                    name="Wrong Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url=f"https://maps.google.com/?cid={duplicate_cid}",
+                    cid=duplicate_cid,
+                    google_id="/g/correct-cafe",
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].cid, duplicate_cid)
+        self.assertEqual(merged.places[0].google_id, "/g/correct-cafe")
+        self.assertIsNone(merged.places[1].cid)
+        self.assertIsNone(merged.places[1].google_id)
+
+    def test_preserve_existing_raw_saved_list_clears_duplicate_identity_after_preservation(
+        self,
+    ) -> None:
+        duplicate_cid = "999789"
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=f"https://maps.google.com/?cid={duplicate_cid}",
+                    cid=duplicate_cid,
+                    google_id="/g/correct-cafe",
+                ),
+                RawPlace(
+                    name="Wrong Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Wrong+Cafe",
+                    google_id="/g/correct-cafe",
+                ),
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=f"https://maps.google.com/?cid={duplicate_cid}",
+                    cid=duplicate_cid,
+                ),
+                RawPlace(
+                    name="Wrong Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url=f"https://maps.google.com/?cid={duplicate_cid}",
+                    cid=duplicate_cid,
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].cid, duplicate_cid)
+        self.assertEqual(merged.places[0].google_id, "/g/correct-cafe")
+        self.assertIsNone(merged.places[1].cid)
+        self.assertIsNone(merged.places[1].google_id)
+
     def test_build_place_page_candidate_urls_prefers_search_for_cid_inputs(self) -> None:
         place = RawPlace(
             name="Sister Midnight",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1851,6 +1851,76 @@ class BuildDataTests(unittest.TestCase):
             "gms:0xabc123:0x222222",
         )
 
+    def test_preserve_existing_raw_saved_list_strips_protected_url_token_but_keeps_independent_field_token(
+        self,
+    ) -> None:
+        duplicate_cid = "888789"
+        protected_token = "0xabc123:0x111111"
+        independent_token = "0xabc123:0x222222"
+        protected_maps_url = (
+            f"https://www.google.com/maps/place/data=!4m2!3m1!1s{protected_token}"
+        )
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=protected_maps_url,
+                    cid=duplicate_cid,
+                    maps_place_token=protected_token,
+                ),
+                RawPlace(
+                    name="Independent Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Independent+Cafe",
+                    maps_place_token=independent_token,
+                ),
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=protected_maps_url,
+                    cid=duplicate_cid,
+                ),
+                RawPlace(
+                    name="Independent Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url=protected_maps_url,
+                    cid=duplicate_cid,
+                    maps_place_token=independent_token,
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].cid, duplicate_cid)
+        self.assertEqual(build_data.extract_maps_place_token(merged.places[0].maps_url), protected_token)
+        self.assertIsNone(merged.places[1].cid)
+        self.assertIsNone(build_data.extract_maps_place_token(merged.places[1].maps_url))
+        self.assertEqual(merged.places[1].maps_place_token, independent_token)
+        self.assertEqual(
+            build_data.stable_place_id(merged.places[1], source_type=merged.configured_source_type),
+            f"gms:{independent_token}",
+        )
+
     def test_preserve_existing_raw_saved_list_does_not_restore_stripped_duplicate_identity(
         self,
     ) -> None:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -11049,7 +11049,7 @@ class BuildDataTests(unittest.TestCase):
         executor = executor_holder["executor"]
         assert isinstance(executor, FakeExecutor)
         self.assertTrue(executor.terminated)
-        self.assertIn((True, True), executor.shutdown_calls)
+        self.assertEqual([], executor.shutdown_calls)
 
     def test_refresh_retries_transient_scrape_failure(self) -> None:
         source = SourceConfig(
@@ -13396,7 +13396,7 @@ class BuildDataTests(unittest.TestCase):
         executor = executor_holder["executor"]
         assert isinstance(executor, FakeExecutor)
         self.assertTrue(executor.terminated)
-        self.assertIn((True, True), executor.shutdown_calls)
+        self.assertEqual([], executor.shutdown_calls)
 
     def test_enrich_place_job_logs_when_worker_starts(self) -> None:
         entry = EnrichmentCacheEntry(


### PR DESCRIPTION
## Summary

- Guard raw source refreshes against duplicate Google Maps CIDs so one duplicate cannot overwrite another place's stable identity fields.
- Make the self-hosted data refresh runner labels configurable through `DATA_REFRESH_RUNNER_LABELS`.
- Document the runner-label contract and token requirements for downstream site repos.

## Why

Downstream site repos may need to pin refresh jobs to a private runner pool without editing the upstream workflow. The raw refresh guard also prevents scraper output with duplicate CIDs from corrupting existing raw snapshots by preserving known-good fields and clearing duplicate CIDs deterministically.

## Validation

- `bun run test:python`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches automation commit paths and enrichment cache staging on timeout; incorrect journal/SQLite handling could omit cache or ship bad state, while dedup heuristics could strip IDs from legitimately ambiguous scraper rows.
> 
> **Overview**
> Hardens the **self-hosted data-refresh** workflow so long runs can stop gracefully and still land useful work, while the Python pipeline **deduplicates conflicting Google Maps identities** in raw snapshots.
> 
> **Workflow:** Adds a `soft_timeout_minutes` dispatch input (default 150) and wraps `refresh_profiles.py` in GNU `timeout` with INT + 5m kill-after, treating exit 124/137 as a partial run (`timed_out`, `[partial]` commits, PR body note). Runner selection uses `DATA_REFRESH_RUNNER_LABELS` (JSON array repo variable) instead of hard-coded labels; preflight now requires `timeout`. Commit staging cleans temp artifacts, runs SQLite integrity recovery, and **skips cache staging** when journals remain after a soft timeout. Setup time can shrink the effective soft timeout so summary/commit/PR still fit the 180-minute job cap.
> 
> **Data pipeline:** New logic in `build_data.py` clears duplicate **CIDs**, **google_id**, and **maps_place_token** within a raw list (scored keepers vs losers, including CSV import path). `preserve_existing_raw_saved_list` runs dedup before/after field preservation so duplicates cannot re-merge stable IDs. Raw refresh and enrichment thread pools skip `shutdown(wait=True)` after `KeyboardInterrupt` once workers are terminated.
> 
> **Docs:** `AGENTS.md` and `docs/ARCHITECTURE.md` document runner labels, soft timeout, and `timeout` on the runner image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c660558d4dbb9afec4f14f011885021f82d93c5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable soft timeout for refresh runs, allowing partial commits/PR updates with `[partial]` indicators and PR notes.
  * Improved self-hosted runner selection with a configurable JSON label list and updated runner guidance.
* **Bug Fixes**
  * Added safer cache staging by validating SQLite integrity and refusing staging with inconsistent journal remnants; skips cache staging on soft-timeout.
  * Improved interrupt handling to avoid unintended shutdown behavior.
  * Enhanced deduplication by clearing duplicate raw place CIDs (including imported exports).
* **Documentation**
  * Updated runner/timeout guidance in AGENTS.md and architecture documentation.
* **Tests**
  * Added coverage for duplicate-CID merging and interrupt scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->