### PR TITLE
[codex] Spread enrichment refresh load

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -151,7 +151,7 @@ bun run refresh:backfill
 bun run refresh:sweep
 ```
 
-- `refresh:balanced`: refreshes raw sources so saved-list changes are pulled in promptly, then runs normal incremental enrichment. Missing places and raw-place changes go first; stale cache entries are refreshed afterward according to their TTLs.
+- `refresh:balanced`: refreshes URL-backed raw sources so saved-list changes are pulled in promptly, keeps CSV sources on content-signature skips, then runs normal incremental enrichment. Missing places and raw-place changes go first; stale cache entries are refreshed afterward according to their TTLs.
 - `refresh:backfill`: refreshes due raw sources, then fills only missing enrichment and missing photos.
 - `refresh:sweep`: refreshes due raw sources, then force-refreshes every enrichment entry as a periodic consistency sweep.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -151,7 +151,7 @@ bun run refresh:backfill
 bun run refresh:sweep
 ```
 
-- `refresh:balanced`: refreshes due raw sources, then runs normal incremental enrichment. Missing places and raw-place changes go first; stale cache entries are refreshed afterward according to their TTLs.
+- `refresh:balanced`: refreshes raw sources so saved-list changes are pulled in promptly, then runs normal incremental enrichment. Missing places and raw-place changes go first; stale cache entries are refreshed afterward according to their TTLs.
 - `refresh:backfill`: refreshes due raw sources, then fills only missing enrichment and missing photos.
 - `refresh:sweep`: refreshes due raw sources, then force-refreshes every enrichment entry as a periodic consistency sweep.
 
@@ -183,6 +183,8 @@ Site repos that need a specific private runner pool should set the GitHub Action
 Use repository variables for installation-specific runner labels instead of committing private labels to the upstream template.
 
 The Actions job has a 180-minute hard timeout and runs the refresh command with a shorter soft timeout. The default soft timeout is 150 minutes, and manual dispatch values are capped at 150 minutes so setup, the 5-minute kill-after window, and summary, commit, and PR steps still fit under the job timeout. When the soft timeout expires, the workflow interrupts the refresh command, writes a partial summary, and continues to the commit and PR steps so completed raw snapshots, enrichment cache rows, and downloaded photos are not lost.
+
+Rating-bearing place enrichment uses longer TTLs than raw saved-list snapshots because small review-count and rating movements usually do not change the guide experience. Normal rating-bearing places refresh after 15 days; places with at least 1,000 reviews refresh after 30 days. Non-operational, error, low-confidence, unmatched, and missing-photo retry entries keep shorter retry windows.
 
 Recommended boundary:
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -2011,7 +2011,7 @@ def refresh_raw_sources(
             payload = refresh_google_export_csv(
                 source,
                 existing_payload=existing_payload,
-                force_refresh=force_refresh or bool(selected_sources),
+                force_refresh=bool(selected_sources),
             )
             if payload is not None:
                 write_json(raw_path, payload)
@@ -7119,9 +7119,17 @@ def cache_refresh_reason(
     if cache_entry.input_signature != expected_signature:
         return "raw-place-changed"
 
+    fetched_at_dt: datetime | None = None
+
+    def parsed_fetched_at() -> datetime:
+        nonlocal fetched_at_dt
+        if fetched_at_dt is None:
+            fetched_at_dt = parse_metadata_datetime(cache_entry.fetched_at)
+        return fetched_at_dt
+
     if cache_entry_needs_photo_url_retry(cache_entry):
         try:
-            fetched_at_dt = parse_metadata_datetime(cache_entry.fetched_at)
+            fetched_at_dt = parsed_fetched_at()
         except ValueError:
             return "invalid-fetched-at"
         if datetime.now(UTC) - fetched_at_dt >= PHOTOLESS_REAL_PLACE_CACHE_TTL:
@@ -7133,7 +7141,7 @@ def cache_refresh_reason(
         except ValueError:
             return "invalid-refresh-after"
         try:
-            fetched_at_dt = parse_metadata_datetime(cache_entry.fetched_at)
+            fetched_at_dt = parsed_fetched_at()
         except ValueError:
             return "invalid-fetched-at"
         policy_refresh_after_dt = fetched_at_dt + cache_refresh_ttl(cache_entry)
@@ -7142,7 +7150,7 @@ def cache_refresh_reason(
         return None
 
     try:
-        fetched_at_dt = parse_metadata_datetime(cache_entry.fetched_at)
+        fetched_at_dt = parsed_fetched_at()
     except ValueError:
         return "invalid-fetched-at"
     if datetime.now(UTC) - fetched_at_dt > OPERATIONAL_CACHE_TTL:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -151,7 +151,9 @@ SCRAPER_SESSION_MAX_AGE = timedelta(days=14)
 ERROR_CACHE_TTL = timedelta(days=1)
 UNMATCHED_CACHE_TTL = timedelta(days=3)
 LOW_CONFIDENCE_CACHE_TTL = timedelta(days=3)
-RATINGS_CACHE_TTL = timedelta(days=7)
+RATINGS_CACHE_TTL = timedelta(days=15)
+HIGH_REVIEW_COUNT_CACHE_TTL = timedelta(days=30)
+HIGH_REVIEW_COUNT_THRESHOLD = 1_000
 NON_OPERATIONAL_CACHE_TTL = timedelta(days=3)
 OPERATIONAL_CACHE_TTL = timedelta(days=14)
 PHOTOLESS_REAL_PLACE_CACHE_TTL = timedelta(days=1)
@@ -7130,7 +7132,12 @@ def cache_refresh_reason(
             refresh_after_dt = parse_metadata_datetime(cache_entry.refresh_after)
         except ValueError:
             return "invalid-refresh-after"
-        if datetime.now(UTC) >= refresh_after_dt:
+        try:
+            fetched_at_dt = parse_metadata_datetime(cache_entry.fetched_at)
+        except ValueError:
+            return "invalid-fetched-at"
+        policy_refresh_after_dt = fetched_at_dt + cache_refresh_ttl(cache_entry)
+        if datetime.now(UTC) >= max(refresh_after_dt, policy_refresh_after_dt):
             return "refresh-window-expired"
         return None
 
@@ -7268,6 +7275,11 @@ def cache_refresh_ttl(cache_entry: EnrichmentCacheEntry) -> timedelta:
         return PHOTOLESS_REAL_PLACE_CACHE_TTL
     if place.business_status and place.business_status != "OPERATIONAL":
         return NON_OPERATIONAL_CACHE_TTL
+    if (
+        place.user_rating_count is not None
+        and place.user_rating_count >= HIGH_REVIEW_COUNT_THRESHOLD
+    ):
+        return HIGH_REVIEW_COUNT_CACHE_TTL
     if place.rating is not None or place.user_rating_count is not None:
         return RATINGS_CACHE_TTL
     return OPERATIONAL_CACHE_TTL

--- a/scripts/refresh_profiles.py
+++ b/scripts/refresh_profiles.py
@@ -25,7 +25,8 @@ class RefreshProfile:
 REFRESH_PROFILES: dict[str, RefreshProfile] = {
     "balanced": RefreshProfile(
         description=(
-            "Refresh raw sources to pull in fresh list changes, then run incremental enrichment. "
+            "Refresh URL-backed raw sources to pull in fresh list changes, then run incremental enrichment. "
+            "CSV sources still use content signatures to skip unchanged imports. "
             "Missing and changed places go first; stale entries are refreshed by TTL afterward."
         ),
         force_raw_refresh=True,

--- a/scripts/refresh_profiles.py
+++ b/scripts/refresh_profiles.py
@@ -16,6 +16,7 @@ else:
 @dataclass(frozen=True)
 class RefreshProfile:
     description: str
+    force_raw_refresh: bool = False
     enrich_force_refresh: bool = False
     enrich_missing_only: bool = False
     refresh_photos: bool = True
@@ -24,9 +25,10 @@ class RefreshProfile:
 REFRESH_PROFILES: dict[str, RefreshProfile] = {
     "balanced": RefreshProfile(
         description=(
-            "Refresh due raw sources, then run the normal incremental enrichment pass. "
+            "Refresh raw sources to pull in fresh list changes, then run incremental enrichment. "
             "Missing and changed places go first; stale entries are refreshed by TTL afterward."
-        )
+        ),
+        force_raw_refresh=True,
     ),
     "backfill": RefreshProfile(
         description=(
@@ -111,10 +113,13 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Selected source filter(s): {', '.join(args.refresh_list)}")
     if args.refresh_force:
         print("Raw source refreshes are forced for this run.")
+    raw_force_refresh = args.refresh_force or profile.force_raw_refresh
+    if profile.force_raw_refresh and not args.refresh_force:
+        print("Profile forces raw source refreshes so list changes are discovered promptly.")
 
     build_data.refresh_raw_sources(
         headed=args.headed,
-        force_refresh=args.refresh_force,
+        force_refresh=raw_force_refresh,
         refresh_lists=args.refresh_list,
         refresh_workers=args.refresh_workers,
         refresh_retries=args.refresh_retries,

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -13020,6 +13020,92 @@ class BuildDataTests(unittest.TestCase):
             build_data.PHOTOLESS_REAL_PLACE_CACHE_TTL,
         )
 
+    def test_cache_refresh_ttl_uses_fifteen_days_for_rating_places(self) -> None:
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at=datetime.now(UTC).isoformat(),
+            source="google_maps_page",
+            query="Neighborhood Cafe",
+            matched=True,
+            score=build_data.STRONG_MATCH_SCORE,
+            place=EnrichmentPlace(
+                display_name="Neighborhood Cafe",
+                rating=4.6,
+                user_rating_count=124,
+            ),
+        )
+
+        self.assertEqual(build_data.cache_refresh_ttl(cache_entry), timedelta(days=15))
+
+    def test_cache_refresh_ttl_uses_longer_ttl_for_high_review_count_places(self) -> None:
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at=datetime.now(UTC).isoformat(),
+            source="google_maps_page",
+            query="Popular Cafe",
+            matched=True,
+            score=build_data.STRONG_MATCH_SCORE,
+            place=EnrichmentPlace(
+                display_name="Popular Cafe",
+                rating=4.6,
+                user_rating_count=build_data.HIGH_REVIEW_COUNT_THRESHOLD,
+            ),
+        )
+
+        self.assertEqual(
+            build_data.cache_refresh_ttl(cache_entry),
+            build_data.HIGH_REVIEW_COUNT_CACHE_TTL,
+        )
+
+    def test_cache_refresh_reason_applies_current_ttl_when_stored_refresh_after_is_older(self) -> None:
+        place = RawPlace(
+            name="Neighborhood Cafe",
+            maps_url="https://maps.google.com/?cid=111",
+            cid="111",
+        )
+        now = datetime.now(UTC)
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at=(now - timedelta(days=8)).isoformat(),
+            refresh_after=(now - timedelta(days=1)).isoformat(),
+            source="google_maps_page",
+            query="Neighborhood Cafe",
+            input_signature=build_data.enrichment_input_signature(place),
+            matched=True,
+            score=build_data.STRONG_MATCH_SCORE,
+            place=EnrichmentPlace(
+                display_name="Neighborhood Cafe",
+                rating=4.6,
+                user_rating_count=124,
+            ),
+        )
+
+        self.assertIsNone(build_data.cache_refresh_reason(place, cache_entry))
+
+    def test_cache_refresh_reason_expires_after_current_ttl_window(self) -> None:
+        place = RawPlace(
+            name="Neighborhood Cafe",
+            maps_url="https://maps.google.com/?cid=111",
+            cid="111",
+        )
+        now = datetime.now(UTC)
+        cache_entry = EnrichmentCacheEntry(
+            fetched_at=(now - timedelta(days=16)).isoformat(),
+            refresh_after=(now - timedelta(days=9)).isoformat(),
+            source="google_maps_page",
+            query="Neighborhood Cafe",
+            input_signature=build_data.enrichment_input_signature(place),
+            matched=True,
+            score=build_data.STRONG_MATCH_SCORE,
+            place=EnrichmentPlace(
+                display_name="Neighborhood Cafe",
+                rating=4.6,
+                user_rating_count=124,
+            ),
+        )
+
+        self.assertEqual(
+            build_data.cache_refresh_reason(place, cache_entry),
+            "refresh-window-expired",
+        )
+
     def test_build_places_sqlite_signature_changes_when_version_or_schema_changes(self) -> None:
         raw = RawSavedList(
             configured_source_type="google_list_url",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -11022,6 +11022,93 @@ class BuildDataTests(unittest.TestCase):
 
         scrape.assert_called_once_with(source, headed=False)
 
+    def test_refresh_raw_sources_force_keeps_unchanged_csv_signature_skip(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            raw_dir = tmpdir_path / "raw"
+            raw_dir.mkdir()
+            csv_path = tmpdir_path / "alishan.csv"
+            csv_path.write_text("Title,URL\nTea House,https://maps.google.com/?cid=111\n", encoding="utf-8")
+            source = SourceConfig(
+                slug="alishan-taiwan",
+                type="google_export_csv",
+                path=str(csv_path),
+                title="Alishan, Taiwan",
+            )
+            raw_path = raw_dir / "alishan-taiwan.json"
+            build_data.write_json(
+                raw_path,
+                RawSavedList(
+                    title="Alishan, Taiwan",
+                    fetched_at=datetime.now(UTC).isoformat(),
+                    refresh_after=(datetime.now(UTC) + timedelta(days=1)).isoformat(),
+                    source_signature=build_data.raw_source_signature(source),
+                    places=[],
+                ),
+            )
+
+            with (
+                patch.object(build_data, "RAW_DIR", raw_dir),
+                patch.object(build_data, "load_sources", return_value=[source]),
+                patch.object(build_data, "import_saved_list_csv") as import_csv,
+            ):
+                build_data.refresh_raw_sources(
+                    headed=False,
+                    force_refresh=True,
+                    refresh_lists=[],
+                    refresh_workers=1,
+                    refresh_startup_jitter_seconds=0,
+                )
+
+        import_csv.assert_not_called()
+
+    def test_refresh_raw_sources_selected_csv_reimports_even_when_signature_unchanged(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            raw_dir = tmpdir_path / "raw"
+            raw_dir.mkdir()
+            csv_path = tmpdir_path / "alishan.csv"
+            csv_path.write_text("Title,URL\nTea House,https://maps.google.com/?cid=111\n", encoding="utf-8")
+            source = SourceConfig(
+                slug="alishan-taiwan",
+                type="google_export_csv",
+                path=str(csv_path),
+                title="Alishan, Taiwan",
+            )
+            raw_path = raw_dir / "alishan-taiwan.json"
+            build_data.write_json(
+                raw_path,
+                RawSavedList(
+                    title="Old Alishan",
+                    fetched_at=datetime.now(UTC).isoformat(),
+                    refresh_after=(datetime.now(UTC) + timedelta(days=1)).isoformat(),
+                    source_signature=build_data.raw_source_signature(source),
+                    places=[],
+                ),
+            )
+
+            with (
+                patch.object(build_data, "RAW_DIR", raw_dir),
+                patch.object(build_data, "load_sources", return_value=[source]),
+                patch.object(
+                    build_data,
+                    "import_saved_list_csv",
+                    return_value=RawSavedList(title="Fresh Alishan", places=[]),
+                ) as import_csv,
+            ):
+                build_data.refresh_raw_sources(
+                    headed=False,
+                    force_refresh=False,
+                    refresh_lists=["alishan-taiwan"],
+                    refresh_workers=1,
+                    refresh_startup_jitter_seconds=0,
+                )
+
+            payload = RawSavedList.model_validate_json(raw_path.read_text(encoding="utf-8"))
+
+        import_csv.assert_called_once_with(source)
+        self.assertEqual(payload.title, "Fresh Alishan")
+
     def test_scraper_session_identity_key_changes_with_proxy(self) -> None:
         self.assertEqual(build_data.scraper_session_identity_key(None), "direct")
         self.assertNotEqual(

--- a/tests/python/test_refresh_profiles.py
+++ b/tests/python/test_refresh_profiles.py
@@ -27,7 +27,7 @@ class SelfHostedRefreshTests(unittest.TestCase):
         self.assertEqual(result, 0)
         refresh_raw_sources.assert_called_once_with(
             headed=False,
-            force_refresh=False,
+            force_refresh=True,
             refresh_lists=[],
             refresh_workers=build_data.DEFAULT_REFRESH_WORKERS,
             refresh_retries=build_data.DEFAULT_REFRESH_RETRIES,


### PR DESCRIPTION
## Summary

- force the balanced refresh profile to refresh raw saved-list sources first so newly added places are pulled in promptly
- extend rating-bearing enrichment TTLs from 7 days to 15 days
- give places with at least 1,000 reviews a 30-day enrichment TTL because small rating/review deltas are lower signal
- apply the current TTL policy when evaluating older stored refresh_after values so old 7-day cache rows do not immediately re-expire
- document the refresh profile and TTL behavior

## Impact

This keeps the 150-minute workflow soft timeout as the runtime budget instead of adding a per-run TTL cap. On the demflyers cache used to evaluate this change, the estimated immediate enrichment queue dropped from about 4,195 jobs to about 2,302 jobs, and estimated steady-state TTL work dropped from about 1,095/day to about 491/day.

## Validation

- `uv run python3 -m unittest tests.python.test_refresh_profiles tests.python.test_build_data`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core refresh scheduling and raw-source vs enrichment freshness tradeoffs; mis-tuned TTL or raw-force behavior could delay updates or overload self-hosted refresh jobs, but changes are incremental with unit test coverage.
> 
> **Overview**
> Reduces steady-state enrichment churn by **stretching rating-bearing cache TTLs** (7→15 days; **30 days** when review count ≥ 1,000) and by evaluating expiry against **`max(stored refresh_after, fetched_at + current policy TTL)`**, so rows stamped under the old 7-day policy are not immediately queued after deploy.
> 
> **`refresh:balanced`** now passes **`force_raw_refresh`** into raw sync so **URL-backed** saved lists are scraped every run for new places; **Google Takeout CSV** sources still skip when the content signature is unchanged unless that source is explicitly selected via `--refresh-list`. Global `force_refresh` alone no longer re-imports unchanged CSVs.
> 
> Architecture docs describe the balanced raw behavior and the new rating TTL tiers. Tests cover CSV skip/selected re-import, TTL helpers, and the refresh-window logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e97a75307d9a5514367d799fd5e24234f22e060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The balanced refresh option now more reliably updates raw sources so saved-list changes appear sooner.
  * Places with many reviews now use a longer cache lifetime, reducing unnecessary refreshes for stable results.

* **Bug Fixes**
  * Refresh timing now respects the current cache policy, preventing outdated refresh windows from keeping stale data around longer than intended.

* **Documentation**
  * Clarified refresh behavior and cache timing guidance in the architecture documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->