### PR TITLE
[codex] Honor explicit CSV refresh force

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -151,7 +151,7 @@ bun run refresh:backfill
 bun run refresh:sweep
 ```
 
-- `refresh:balanced`: refreshes URL-backed raw sources so saved-list changes are pulled in promptly, keeps CSV sources on content-signature skips, then runs normal incremental enrichment. Missing places and raw-place changes go first; stale cache entries are refreshed afterward according to their TTLs.
+- `refresh:balanced`: refreshes URL-backed raw sources so saved-list changes are pulled in promptly, keeps CSV sources on content-signature skips unless explicitly selected or force-refreshed, then runs normal incremental enrichment. Missing places and raw-place changes go first; stale cache entries are refreshed afterward according to their TTLs.
 - `refresh:backfill`: refreshes due raw sources, then fills only missing enrichment and missing photos.
 - `refresh:sweep`: refreshes due raw sources, then force-refreshes every enrichment entry as a periodic consistency sweep.
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -1990,6 +1990,7 @@ def refresh_raw_sources(
     force_refresh: bool,
     refresh_lists: list[str],
     refresh_workers: int,
+    force_url_refresh: bool = False,
     refresh_retries: int = DEFAULT_REFRESH_RETRIES,
     refresh_retry_backoff_seconds: float = DEFAULT_REFRESH_RETRY_BACKOFF_SECONDS,
     refresh_startup_jitter_seconds: float = DEFAULT_REFRESH_STARTUP_JITTER_SECONDS,
@@ -2011,7 +2012,7 @@ def refresh_raw_sources(
             payload = refresh_google_export_csv(
                 source,
                 existing_payload=existing_payload,
-                force_refresh=bool(selected_sources),
+                force_refresh=force_refresh or bool(selected_sources),
             )
             if payload is not None:
                 write_json(raw_path, payload)
@@ -2021,16 +2022,17 @@ def refresh_raw_sources(
         if not source_url:
             raise RuntimeError(f"Configured source {source.slug} is missing a URL.")
 
+        url_force_refresh = force_refresh or force_url_refresh
         refresh_reason = (
             None
-            if force_refresh or bool(selected_sources)
+            if url_force_refresh or bool(selected_sources)
             else raw_source_refresh_reason(source, existing_payload)
         )
-        if not force_refresh and not bool(selected_sources) and refresh_reason is None:
+        if not url_force_refresh and not bool(selected_sources) and refresh_reason is None:
             print(f"Skipping {source.slug} (raw snapshot fresh)")
             continue
 
-        if force_refresh:
+        if url_force_refresh:
             print(f"Refreshing {source.slug} from {source_url} (forced)")
         elif selected_sources:
             print(f"Refreshing {source.slug} from {source_url} (selected)")

--- a/scripts/refresh_profiles.py
+++ b/scripts/refresh_profiles.py
@@ -114,15 +114,15 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Selected source filter(s): {', '.join(args.refresh_list)}")
     if args.refresh_force:
         print("Raw source refreshes are forced for this run.")
-    raw_force_refresh = args.refresh_force or profile.force_raw_refresh
     if profile.force_raw_refresh and not args.refresh_force:
         print("Profile forces raw source refreshes so list changes are discovered promptly.")
 
     build_data.refresh_raw_sources(
         headed=args.headed,
-        force_refresh=raw_force_refresh,
+        force_refresh=args.refresh_force,
         refresh_lists=args.refresh_list,
         refresh_workers=args.refresh_workers,
+        force_url_refresh=profile.force_raw_refresh,
         refresh_retries=args.refresh_retries,
         refresh_retry_backoff_seconds=args.refresh_retry_backoff_seconds,
         refresh_startup_jitter_seconds=args.refresh_startup_jitter_seconds,

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -11022,7 +11022,7 @@ class BuildDataTests(unittest.TestCase):
 
         scrape.assert_called_once_with(source, headed=False)
 
-    def test_refresh_raw_sources_force_keeps_unchanged_csv_signature_skip(self) -> None:
+    def test_refresh_raw_sources_url_force_keeps_unchanged_csv_signature_skip(self) -> None:
         with TemporaryDirectory() as tmpdir:
             tmpdir_path = Path(tmpdir)
             raw_dir = tmpdir_path / "raw"
@@ -11054,13 +11054,61 @@ class BuildDataTests(unittest.TestCase):
             ):
                 build_data.refresh_raw_sources(
                     headed=False,
-                    force_refresh=True,
+                    force_refresh=False,
+                    force_url_refresh=True,
                     refresh_lists=[],
                     refresh_workers=1,
                     refresh_startup_jitter_seconds=0,
                 )
 
         import_csv.assert_not_called()
+
+    def test_refresh_raw_sources_explicit_force_reimports_csv_even_when_signature_unchanged(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            raw_dir = tmpdir_path / "raw"
+            raw_dir.mkdir()
+            csv_path = tmpdir_path / "alishan.csv"
+            csv_path.write_text("Title,URL\nTea House,https://maps.google.com/?cid=111\n", encoding="utf-8")
+            source = SourceConfig(
+                slug="alishan-taiwan",
+                type="google_export_csv",
+                path=str(csv_path),
+                title="Alishan, Taiwan",
+            )
+            raw_path = raw_dir / "alishan-taiwan.json"
+            build_data.write_json(
+                raw_path,
+                RawSavedList(
+                    title="Old Alishan",
+                    fetched_at=datetime.now(UTC).isoformat(),
+                    refresh_after=(datetime.now(UTC) + timedelta(days=1)).isoformat(),
+                    source_signature=build_data.raw_source_signature(source),
+                    places=[],
+                ),
+            )
+
+            with (
+                patch.object(build_data, "RAW_DIR", raw_dir),
+                patch.object(build_data, "load_sources", return_value=[source]),
+                patch.object(
+                    build_data,
+                    "import_saved_list_csv",
+                    return_value=RawSavedList(title="Forced Alishan", places=[]),
+                ) as import_csv,
+            ):
+                build_data.refresh_raw_sources(
+                    headed=False,
+                    force_refresh=True,
+                    refresh_lists=[],
+                    refresh_workers=1,
+                    refresh_startup_jitter_seconds=0,
+                )
+
+            payload = RawSavedList.model_validate_json(raw_path.read_text(encoding="utf-8"))
+
+        import_csv.assert_called_once_with(source)
+        self.assertEqual(payload.title, "Forced Alishan")
 
     def test_refresh_raw_sources_selected_csv_reimports_even_when_signature_unchanged(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/tests/python/test_refresh_profiles.py
+++ b/tests/python/test_refresh_profiles.py
@@ -27,9 +27,10 @@ class SelfHostedRefreshTests(unittest.TestCase):
         self.assertEqual(result, 0)
         refresh_raw_sources.assert_called_once_with(
             headed=False,
-            force_refresh=True,
+            force_refresh=False,
             refresh_lists=[],
             refresh_workers=build_data.DEFAULT_REFRESH_WORKERS,
+            force_url_refresh=True,
             refresh_retries=build_data.DEFAULT_REFRESH_RETRIES,
             refresh_retry_backoff_seconds=build_data.DEFAULT_REFRESH_RETRY_BACKOFF_SECONDS,
             refresh_startup_jitter_seconds=build_data.DEFAULT_REFRESH_STARTUP_JITTER_SECONDS,
@@ -85,6 +86,7 @@ class SelfHostedRefreshTests(unittest.TestCase):
             force_refresh=True,
             refresh_lists=["tokyo-japan"],
             refresh_workers=build_data.DEFAULT_REFRESH_WORKERS,
+            force_url_refresh=False,
             refresh_retries=build_data.DEFAULT_REFRESH_RETRIES,
             refresh_retry_backoff_seconds=build_data.DEFAULT_REFRESH_RETRY_BACKOFF_SECONDS,
             refresh_startup_jitter_seconds=build_data.DEFAULT_REFRESH_STARTUP_JITTER_SECONDS,


### PR DESCRIPTION
## Summary

- split profile-level URL refresh force from explicit raw-source `--refresh-force`
- keep balanced runs from reimporting unchanged CSV sources by signature
- preserve explicit force/selected behavior for CSV imports
- update docs and regression tests for URL-only force vs explicit CSV force

## Context

This follows up on #132 after downstream automated review noticed that preserving CSV signature skips also accidentally weakened explicit `--refresh-force` for CSV imports.

## Validation

- `uv run python3 -m unittest tests.python.test_refresh_profiles tests.python.test_build_data.BuildDataTests.test_refresh_raw_sources_url_force_keeps_unchanged_csv_signature_skip tests.python.test_build_data.BuildDataTests.test_refresh_raw_sources_explicit_force_reimports_csv_even_when_signature_unchanged tests.python.test_build_data.BuildDataTests.test_refresh_raw_sources_selected_csv_reimports_even_when_signature_unchanged`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scheduled `refresh:balanced` raw-source behavior and CSV import skip logic; wrong wiring could skip needed CSV updates or cause extra scrapes on URL sources.
> 
> **Overview**
> **Refresh raw sources** now takes a separate `force_url_refresh` flag for profile behavior (e.g. `refresh:balanced` still forces URL-backed list scrapes) while `force_refresh` is reserved for explicit `--refresh-force` and selected-source CSV reimports.
> 
> **CSV `google_export_csv` sources** only honor full force via `force_refresh`, not profile URL force—unchanged content signatures are skipped on balanced runs again. Explicit `--refresh-force` and list selection continue to reimport CSV even when the signature is unchanged.
> 
> Docs and unit tests were updated to document and lock in URL-only force vs explicit CSV force.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7495ce16ec164357e424a89d48edd91cdcb4f7af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->