### PR TITLE
[codex] Update gmaps-scraper CID parsing

### DIFF
--- a/vendor/gmaps-scraper/src/gmaps_scraper/parser.py
+++ b/vendor/gmaps-scraper/src/gmaps_scraper/parser.py
@@ -587,11 +587,11 @@ def _looks_like_address(value: str | None) -> bool:
 def _find_cid(node: list[JSONValue] | None) -> str | None:
     if node is None:
         return None
-    structured = _find_cid_in_value(_safe_index(node, 6))
+    structured = _find_cid_in_structured_slot(_safe_index(node, 6))
     if structured is not None:
         return structured
     for value in node:
-        candidate = _find_cid_in_value(value)
+        candidate = _find_cid_in_fallback_value(value)
         if candidate is not None:
             return candidate
     return None
@@ -637,7 +637,7 @@ def _metadata_matches_coordinate(
     )
 
 
-def _find_cid_in_value(value: JSONValue | None) -> str | None:
+def _find_cid_in_structured_slot(value: JSONValue | None) -> str | None:
     if isinstance(value, int):
         return _normalize_cid_token(str(value))
     if isinstance(value, str):
@@ -655,12 +655,36 @@ def _find_cid_in_value(value: JSONValue | None) -> str | None:
     ]
     if not numeric_texts:
         return None
-    for text in numeric_texts:
-        if not text.startswith("-"):
-            return _normalize_cid_token(text)
     if len(numeric_texts) >= 2:
         return _normalize_cid_token(numeric_texts[1])
     return _normalize_cid_token(numeric_texts[0])
+
+
+def _find_cid_in_fallback_value(value: JSONValue | None) -> str | None:
+    if isinstance(value, int | str):
+        return _normalize_fallback_cid_token(value)
+    if not isinstance(value, list):
+        return None
+    owner = _parse_list_owner(value)
+    if owner is not None and (owner.photo_url is not None or owner.profile_id is not None):
+        return None
+    numeric_texts = [
+        text
+        for text in (_clean_text(item) for item in value)
+        if text is not None and _LONG_INTEGER_PATTERN.fullmatch(text) is not None
+    ]
+    if len(numeric_texts) == 1:
+        return _normalize_fallback_cid_token(numeric_texts[0])
+    return None
+
+
+def _normalize_fallback_cid_token(value: JSONValue | None) -> str | None:
+    text = str(value) if isinstance(value, int) else _clean_text(value)
+    if text is None or _LONG_INTEGER_PATTERN.fullmatch(text) is None:
+        return None
+    if len(text.removeprefix("-")) < 15:
+        return None
+    return _normalize_cid_token(text)
 
 
 def _normalize_cid_token(value: JSONValue | None) -> str | None:

--- a/vendor/gmaps-scraper/tests/test_parser.py
+++ b/vendor/gmaps-scraper/tests/test_parser.py
@@ -15,6 +15,10 @@ _REDIRECT_URL = (
     "https://www.google.com/maps/@30.5370705,125.4120472,6z/"
     "data=!4m3!11m2!2sTESTLISTABC123456789!3e3?entry=ttu"
 )
+_NORTHWIND_CELL_ID = "7451636382641713350"
+_NORTHWIND_CID = "9055794338847426964"
+_HARBOR_CELL_ID = "1234567890123456789"
+_HARBOR_CID = "5678901234567890123"
 _LIST_NODE = [
     ["TESTLISTABC123456789", 1, None, 1, 1],
     4,
@@ -38,7 +42,7 @@ _LIST_NODE = [
                 None,
                 "Example District",
                 [None, None, 35.6501307, 139.6868459],
-                ["7451636382641713350", "aux"],
+                [_NORTHWIND_CELL_ID, _NORTHWIND_CID],
                 "/g/11northwind",
             ],
             "Northwind Cafe",
@@ -47,7 +51,7 @@ _LIST_NODE = [
             None,
             None,
             [[[[3, None, "104356373423434804635", "❤️", [1776133481, 81561000]]]]],
-            [[1], ["7451636382641713350", "aux"]],
+            [[1], [_NORTHWIND_CELL_ID, _NORTHWIND_CID]],
             [1776063335, 302383000],
             [1776132745, 850748000],
             None,
@@ -66,7 +70,7 @@ _LIST_NODE = [
                 None,
                 "Market Square",
                 [None, None, 35.6915776, 139.7836109],
-                ["1234567890123456789"],
+                [_HARBOR_CELL_ID, _HARBOR_CID],
                 "/g/11harborbakery",
             ],
             "Harbor Bakery",
@@ -75,7 +79,7 @@ _LIST_NODE = [
             None,
             None,
             [],
-            [[1], ["1234567890123456789", "aux-2"]],
+            [[1], [_HARBOR_CELL_ID, _HARBOR_CID]],
             [1776063335, 302383000],
             [1776132745, 850748000],
             None,
@@ -180,7 +184,7 @@ class ParserTests(unittest.TestCase):
                 },
             ],
         )
-        self.assertEqual(parsed.places[0].cid, "7451636382641713350")
+        self.assertEqual(parsed.places[0].cid, _NORTHWIND_CID)
         self.assertEqual(
             parsed.places[0].maps_url,
             "https://www.google.com/maps/search/?api=1&query=Northwind+Cafe%2C+Example+District",
@@ -245,6 +249,35 @@ class ParserTests(unittest.TestCase):
             "https://www.google.com/maps/search/?api=1&query=Northwind+Cafe%2C+Example+District",
         )
 
+    def test_uses_fingerprint_not_positive_s2_cell_from_slot_6(self) -> None:
+        runtime_state = copy.deepcopy(["noise", _LIST_NODE])
+
+        parsed = parse_saved_list_artifacts(_LIST_URL, runtime_state=runtime_state)
+
+        self.assertEqual(parsed.places[0].cid, _NORTHWIND_CID)
+        self.assertNotEqual(parsed.places[0].cid, _NORTHWIND_CELL_ID)
+
+    def test_normalizes_negative_slot_6_fingerprint(self) -> None:
+        runtime_state = copy.deepcopy(["noise", _LIST_NODE])
+        place_metadata = runtime_state[1][8][0][1]
+        assert isinstance(place_metadata, list)
+        place_metadata[6] = ["3765761194353288769", "-782808945063765017"]
+
+        parsed = parse_saved_list_artifacts(_LIST_URL, runtime_state=runtime_state)
+
+        self.assertEqual(parsed.places[0].cid, "17663935128645786599")
+
+    def test_ignores_timestamp_like_fallback_values_when_cid_is_missing(self) -> None:
+        runtime_state = copy.deepcopy(["noise", _LIST_NODE])
+        place_metadata = runtime_state[1][8][0][1]
+        assert isinstance(place_metadata, list)
+        place_metadata[6] = [None]
+        place_metadata.append(1776063335)
+
+        parsed = parse_saved_list_artifacts(_LIST_URL, runtime_state=runtime_state)
+
+        self.assertEqual(parsed.places[0].cid, None)
+
     def test_builds_coordinate_query_url_only_when_no_name_or_address_exist(self) -> None:
         runtime_state = [
             "noise",
@@ -296,8 +329,8 @@ class ParserTests(unittest.TestCase):
         parsed = parse_saved_list_artifacts(_LIST_URL, runtime_state=runtime_state)
 
         self.assertEqual(len(parsed.places), 2)
-        self.assertEqual(parsed.places[0].cid, "7451636382641713350")
-        self.assertEqual(parsed.places[1].cid, "1234567890123456789")
+        self.assertEqual(parsed.places[0].cid, _NORTHWIND_CID)
+        self.assertEqual(parsed.places[1].cid, _HARBOR_CID)
 
     def test_keeps_distinct_places_that_share_a_cid(self) -> None:
         runtime_state = copy.deepcopy(["noise", _LIST_NODE])
@@ -307,14 +340,14 @@ class ParserTests(unittest.TestCase):
         assert isinstance(second_metadata, list)
 
         second_metadata[5] = [None, None, 35.7000000, 139.7800000]
-        second_metadata[6] = ["7451636382641713350", "-2234567890123456789"]
+        second_metadata[6] = ["7451636382641713350", _NORTHWIND_CID]
         second_metadata[7] = None
 
         parsed = parse_saved_list_artifacts(_LIST_URL, runtime_state=runtime_state)
 
         self.assertEqual(len(parsed.places), 2)
-        self.assertEqual(parsed.places[0].cid, "7451636382641713350")
-        self.assertEqual(parsed.places[1].cid, "7451636382641713350")
+        self.assertEqual(parsed.places[0].cid, _NORTHWIND_CID)
+        self.assertEqual(parsed.places[1].cid, _NORTHWIND_CID)
         self.assertEqual(parsed.places[1].lat, 35.7)
 
     def test_does_not_use_owner_profile_id_as_place_cid(self) -> None:


### PR DESCRIPTION
## Summary

- Sync the vendored `gmaps-scraper` CID parsing fix from upstream commit `dfa440f`.
- Prefer the structured saved-list fingerprint over S2 cell IDs when extracting place CIDs.
- Narrow fallback numeric CID detection so timestamp-like values are not treated as CIDs.
- Add/update upstream parser regression tests for the CID cases.

## Validation

- `uv run python3 -m unittest tests.test_parser` from `vendor/gmaps-scraper`
- `uv run python3 -m unittest tests.python.test_build_data.BuildDataTests.test_preserve_existing_raw_saved_list_clears_new_duplicate_cid tests.python.test_build_data.BuildDataTests.test_preserve_existing_raw_saved_list_uses_prior_anchor_for_changed_source_duplicate_cid tests.python.test_build_data.BuildDataTests.test_preserve_existing_raw_saved_list_clears_duplicate_cid_before_preserving_fields tests.python.test_build_data.BuildDataTests.test_preserve_existing_raw_saved_list_clears_shared_maps_place_token_for_duplicate_cid tests.python.test_build_data.BuildDataTests.test_preserve_existing_raw_saved_list_keeps_independent_google_ids_for_duplicate_cid`
- Commit hooks: vendored `ruff` and `pyrefly`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how place CIDs are derived for saved lists, which can affect deduplication and downstream merge logic, but scope is limited to parser heuristics with added regression tests.
> 
> **Overview**
> Syncs vendored **gmaps-scraper** CID extraction so saved-list places get the correct Google place fingerprint instead of an S2 cell ID or spurious long integers.
> 
> **Structured metadata (slot 6):** when that slot is a list with two or more long integer strings, the parser now takes the **second** value as the CID (fingerprint) rather than the first non-negative number (often the cell ID). A single value in that slot still normalizes as before.
> 
> **Fallback scan:** tree-wide CID lookup is split from the structured path. Fallback candidates must be a lone long integer with at least 15 digits (after optional sign), so values like Unix timestamps are not treated as CIDs. Lists with multiple numeric strings no longer pick a CID from fallback.
> 
> Parser tests are updated with explicit cell vs CID fixtures and cover fingerprint preference, negative fingerprint uint64 normalization, and missing-CID cases with timestamp-like noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22ba22fc0e505856accf425044d0f855700e84ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->