### PR TITLE
Preserve rich enrichment on refresh regressions

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7480,6 +7480,9 @@ def merge_page_place_into_api_entry(
     if not api_place.about_sections:
         api_place.about_sections = page_place.about_sections
 
+    if page_place.limited_view is True:
+        api_place.limited_view = True
+
     if google_maps_uri_strength(page_place.google_maps_uri) > google_maps_uri_strength(api_place.google_maps_uri):
         api_place.google_maps_uri = page_place.google_maps_uri
 
@@ -7540,7 +7543,7 @@ def preserve_existing_enrichment(
         and refreshed_place.limited_view is True
     ):
         return (
-            existing_entry,
+            cache_entry_with_refreshed_metadata(existing_entry, refreshed_entry),
             f"WARNING: Preserving previous enrichment for {slug}:{place_id} [{place_name}] "
             "because refresh returned degraded result (limited view).",
         )
@@ -7559,77 +7562,78 @@ def preserve_existing_enrichment(
 
     preserved_fields: list[str] = []
 
-    if refreshed_place.rating is None and previous_place.rating is not None:
-        refreshed_place.rating = previous_place.rating
-        append_unique_reason(preserved_fields, "rating")
-    if refreshed_place.user_rating_count is None and previous_place.user_rating_count is not None:
-        refreshed_place.user_rating_count = previous_place.user_rating_count
-        append_unique_reason(preserved_fields, "user_rating_count")
-    if not refreshed_place.formatted_address and previous_place.formatted_address:
-        refreshed_place.formatted_address = previous_place.formatted_address
-        append_unique_reason(preserved_fields, "address")
-    if not refreshed_place.address_display_en and previous_place.address_display_en:
-        refreshed_place.address_display_en = previous_place.address_display_en
-        refreshed_place.address_display_en_source = previous_place.address_display_en_source
-        refreshed_place.address_display_en_confidence = previous_place.address_display_en_confidence
-
-    if not refreshed_place.primary_type_display_name and previous_place.primary_type_display_name:
-        refreshed_place.primary_type_display_name = previous_place.primary_type_display_name
-        if not refreshed_place.primary_type and previous_place.primary_type:
-            refreshed_place.primary_type = previous_place.primary_type
-        if not refreshed_place.types and previous_place.types:
-            refreshed_place.types = previous_place.types[:]
-        append_unique_reason(preserved_fields, "primary_category")
-    elif (
-        refreshed_place.primary_type_display_name == previous_place.primary_type_display_name
-        and not refreshed_place.primary_type
-        and previous_place.primary_type
-    ):
-        refreshed_place.primary_type = previous_place.primary_type
-        if not refreshed_place.types and previous_place.types:
-            refreshed_place.types = previous_place.types[:]
-
-    if not refreshed_place.primary_type_display_name_localized and previous_place.primary_type_display_name_localized:
-        refreshed_place.primary_type_display_name_localized = previous_place.primary_type_display_name_localized
-    if not refreshed_place.category_display_en and previous_place.category_display_en:
-        refreshed_place.category_display_en = previous_place.category_display_en
-        refreshed_place.category_display_en_source = previous_place.category_display_en_source
-        refreshed_place.category_display_en_confidence = previous_place.category_display_en_confidence
-
-    if not refreshed_place.business_status and previous_place.business_status:
-        refreshed_place.business_status = previous_place.business_status
-        append_unique_reason(preserved_fields, "status")
-
-    if can_preserve_previous_identity and price_range_regressed_from_symbolic_tier(previous_place, refreshed_place):
-        preserve_previous_symbolic_price_range(previous_place, refreshed_place)
-        append_unique_reason(preserved_fields, "price_range")
-
-    if (
-        can_preserve_previous_identity
-        and google_maps_uri_strength(refreshed_place.google_maps_uri)
-        < google_maps_uri_strength(previous_place.google_maps_uri)
-        and google_maps_uri_is_compatible_for_preservation(previous_place, refreshed_place)
-    ):
-        refreshed_place.google_maps_uri = previous_place.google_maps_uri
-        if not refreshed_place.google_place_id and previous_place.google_place_id:
-            refreshed_place.google_place_id = previous_place.google_place_id
-        if not refreshed_place.google_place_resource_name and previous_place.google_place_resource_name:
-            refreshed_place.google_place_resource_name = previous_place.google_place_resource_name
-        append_unique_reason(preserved_fields, "maps_url")
-    elif can_preserve_previous_identity and google_maps_uri_is_compatible_for_preservation(previous_place, refreshed_place):
-        if not refreshed_place.google_place_id and previous_place.google_place_id:
-            refreshed_place.google_place_id = previous_place.google_place_id
-        if not refreshed_place.google_place_resource_name and previous_place.google_place_resource_name:
-            refreshed_place.google_place_resource_name = previous_place.google_place_resource_name
-
-    if not refreshed_place.main_photo_url and previous_place.main_photo_url:
-        refreshed_place.main_photo_url = previous_place.main_photo_url
-        append_unique_reason(preserved_fields, "photo_url")
-    if not refreshed_place.photo_url and previous_place.photo_url:
-        refreshed_place.photo_url = previous_place.photo_url
-        append_unique_reason(preserved_fields, "photo_url")
-
     if can_preserve_previous_identity:
+        if refreshed_place.rating is None and previous_place.rating is not None:
+            refreshed_place.rating = previous_place.rating
+            append_unique_reason(preserved_fields, "rating")
+        if refreshed_place.user_rating_count is None and previous_place.user_rating_count is not None:
+            refreshed_place.user_rating_count = previous_place.user_rating_count
+            append_unique_reason(preserved_fields, "user_rating_count")
+        if not refreshed_place.formatted_address and previous_place.formatted_address:
+            refreshed_place.formatted_address = previous_place.formatted_address
+            append_unique_reason(preserved_fields, "address")
+        if not refreshed_place.address_display_en and previous_place.address_display_en:
+            refreshed_place.address_display_en = previous_place.address_display_en
+            refreshed_place.address_display_en_source = previous_place.address_display_en_source
+            refreshed_place.address_display_en_confidence = previous_place.address_display_en_confidence
+
+        if not refreshed_place.primary_type_display_name and previous_place.primary_type_display_name:
+            refreshed_place.primary_type_display_name = previous_place.primary_type_display_name
+            if not refreshed_place.primary_type and previous_place.primary_type:
+                refreshed_place.primary_type = previous_place.primary_type
+            if not refreshed_place.types and previous_place.types:
+                refreshed_place.types = previous_place.types[:]
+            append_unique_reason(preserved_fields, "primary_category")
+        elif (
+            refreshed_place.primary_type_display_name == previous_place.primary_type_display_name
+            and not refreshed_place.primary_type
+            and previous_place.primary_type
+        ):
+            refreshed_place.primary_type = previous_place.primary_type
+            if not refreshed_place.types and previous_place.types:
+                refreshed_place.types = previous_place.types[:]
+
+        if (
+            not refreshed_place.primary_type_display_name_localized
+            and previous_place.primary_type_display_name_localized
+        ):
+            refreshed_place.primary_type_display_name_localized = previous_place.primary_type_display_name_localized
+        if not refreshed_place.category_display_en and previous_place.category_display_en:
+            refreshed_place.category_display_en = previous_place.category_display_en
+            refreshed_place.category_display_en_source = previous_place.category_display_en_source
+            refreshed_place.category_display_en_confidence = previous_place.category_display_en_confidence
+
+        if not refreshed_place.business_status and previous_place.business_status:
+            refreshed_place.business_status = previous_place.business_status
+            append_unique_reason(preserved_fields, "status")
+
+        if price_range_regressed_from_symbolic_tier(previous_place, refreshed_place):
+            preserve_previous_symbolic_price_range(previous_place, refreshed_place)
+            append_unique_reason(preserved_fields, "price_range")
+
+        if (
+            google_maps_uri_strength(refreshed_place.google_maps_uri)
+            < google_maps_uri_strength(previous_place.google_maps_uri)
+            and google_maps_uri_is_compatible_for_preservation(previous_place, refreshed_place)
+        ):
+            refreshed_place.google_maps_uri = previous_place.google_maps_uri
+            if not refreshed_place.google_place_id and previous_place.google_place_id:
+                refreshed_place.google_place_id = previous_place.google_place_id
+            if not refreshed_place.google_place_resource_name and previous_place.google_place_resource_name:
+                refreshed_place.google_place_resource_name = previous_place.google_place_resource_name
+            append_unique_reason(preserved_fields, "maps_url")
+        elif google_maps_uri_is_compatible_for_preservation(previous_place, refreshed_place):
+            if not refreshed_place.google_place_id and previous_place.google_place_id:
+                refreshed_place.google_place_id = previous_place.google_place_id
+            if not refreshed_place.google_place_resource_name and previous_place.google_place_resource_name:
+                refreshed_place.google_place_resource_name = previous_place.google_place_resource_name
+
+        if not refreshed_place.main_photo_url and previous_place.main_photo_url:
+            refreshed_place.main_photo_url = previous_place.main_photo_url
+            append_unique_reason(preserved_fields, "photo_url")
+        if not refreshed_place.photo_url and previous_place.photo_url:
+            refreshed_place.photo_url = previous_place.photo_url
+            append_unique_reason(preserved_fields, "photo_url")
         if not refreshed_place.review_topics and previous_place.review_topics:
             refreshed_place.review_topics = previous_place.review_topics[:]
             append_unique_reason(preserved_fields, "review_topics")
@@ -7677,6 +7681,20 @@ def semantic_description_for_preservation(
         city_name=None,
         country_name=None,
     )
+
+
+def cache_entry_with_refreshed_metadata(
+    existing_entry: EnrichmentCacheEntry,
+    refreshed_entry: EnrichmentCacheEntry,
+) -> EnrichmentCacheEntry:
+    updates: dict[str, Any] = {}
+    for field_name in ("fetched_at", "refresh_after", "input_signature"):
+        value = getattr(refreshed_entry, field_name)
+        if value is not None:
+            updates[field_name] = value
+    if not updates:
+        return existing_entry
+    return existing_entry.model_copy(update=updates)
 
 
 def google_maps_uri_is_compatible_for_preservation(
@@ -7733,6 +7751,10 @@ def preserve_previous_symbolic_price_range(
     previous_place: EnrichmentPlace,
     refreshed_place: EnrichmentPlace,
 ) -> None:
+    numeric_price = as_string(refreshed_place.price_range)
+    for field_name in ("admission_price", "room_price"):
+        if numeric_price is not None and as_string(getattr(refreshed_place, field_name)) == numeric_price:
+            setattr(refreshed_place, field_name, None)
     refreshed_place.price_range = previous_place.price_range
     reset_semantic_description_after_price_preservation(refreshed_place)
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7563,8 +7563,7 @@ def preserve_existing_enrichment(
         append_unique_reason(preserved_fields, "status")
 
     if price_range_regressed_from_symbolic_tier(previous_place, refreshed_place):
-        refreshed_place.price_range = previous_place.price_range
-        reset_semantic_description_after_price_preservation(refreshed_place)
+        preserve_previous_symbolic_price_range(previous_place, refreshed_place)
         append_unique_reason(preserved_fields, "price_range")
 
     if (
@@ -7675,6 +7674,14 @@ def reset_semantic_description_after_price_preservation(place: EnrichmentPlace) 
     place.semantic_description_signature = None
     if not semantic_enrichment_state_is_populated(semantic_enrichment_state(place)):
         place.semantic_source = None
+
+
+def preserve_previous_symbolic_price_range(
+    previous_place: EnrichmentPlace,
+    refreshed_place: EnrichmentPlace,
+) -> None:
+    refreshed_place.price_range = previous_place.price_range
+    reset_semantic_description_after_price_preservation(refreshed_place)
 
 
 def enrichment_google_identity_shift_conflicts_with_raw(

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -3046,6 +3046,9 @@ def google_maps_url_identity(maps_url: str | None) -> str | None:
     cid = extract_maps_cid(maps_url)
     if cid is not None:
         return f"cid:{cid}"
+    maps_place_token = extract_maps_place_token(maps_url)
+    if maps_place_token is not None:
+        return f"gms:{maps_place_token}"
     normalized_url = as_string(maps_url)
     if normalized_url is None or not resolved_google_maps_url_is_place_page(normalized_url):
         return None
@@ -7498,6 +7501,10 @@ def merged_enrichment_sources(*entries: EnrichmentCacheEntry) -> list[Literal["g
     return sources
 
 
+def cache_entry_includes_google_places_api(entry: EnrichmentCacheEntry) -> bool:
+    return entry.source == "google_places_api" or "google_places_api" in entry.merged_sources
+
+
 def preserve_existing_enrichment(
     *,
     slug: str,
@@ -7541,6 +7548,7 @@ def preserve_existing_enrichment(
         can_preserve_previous_identity
         and previous_place.limited_view is False
         and refreshed_place.limited_view is True
+        and not cache_entry_includes_google_places_api(refreshed_entry)
     ):
         return (
             cache_entry_with_refreshed_metadata(existing_entry, refreshed_entry),
@@ -7823,6 +7831,10 @@ def address_texts_conflict(left: str | None, right: str | None) -> bool:
     right_text = normalize_text(right)
     if not left_text or not right_text or left_text == right_text:
         return False
+    left_street_numbers = address_street_numbers(as_string(left) or "")
+    right_street_numbers = address_street_numbers(as_string(right) or "")
+    if left_street_numbers and right_street_numbers and not left_street_numbers & right_street_numbers:
+        return True
     left_numbers = set(re.findall(r"\d+", left_text))
     right_numbers = set(re.findall(r"\d+", right_text))
     if left_numbers and right_numbers and not left_numbers & right_numbers:
@@ -7839,9 +7851,39 @@ ADDRESS_TOKEN_STOPWORDS = {
     "province",
     "region",
     "state",
+    "street",
+    "st",
     "the",
     "united",
+    "avenue",
+    "ave",
+    "road",
+    "rd",
+    "boulevard",
+    "blvd",
+    "lane",
+    "ln",
+    "drive",
+    "dr",
+    "way",
+    "place",
+    "pl",
+    "court",
+    "ct",
+    "square",
+    "sq",
 }
+
+
+def address_street_numbers(text: str) -> set[str]:
+    parts = [part.strip() for part in re.split(r"[,、]", text) if part.strip()]
+    if not parts:
+        parts = [text]
+    for part in parts:
+        numbers = set(re.findall(r"\d+", part))
+        if numbers:
+            return numbers
+    return set()
 
 
 def address_identity_tokens(text: str) -> set[str]:
@@ -7857,7 +7899,7 @@ def address_identity_tokens(text: str) -> set[str]:
         token
         for part in streetish_parts
         for token in re.findall(r"[\w]+", part.casefold())
-        if len(token) > 2 and token not in ADDRESS_TOKEN_STOPWORDS
+        if len(token) > 2 and not token.isdigit() and token not in ADDRESS_TOKEN_STOPWORDS
     }
     return tokens
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -3021,6 +3021,39 @@ def extract_maps_place_token(maps_url: str | None) -> str | None:
     return match.group(1).lower()
 
 
+def extract_maps_query_place_id(maps_url: str | None) -> str | None:
+    normalized_url = as_string(maps_url)
+    if normalized_url is None:
+        return None
+    parsed = urlsplit(normalized_url)
+    for key, value in parse_qsl(parsed.query, keep_blank_values=False):
+        if key == "query_place_id" and value:
+            return value
+    return None
+
+
+def normalized_google_place_resource_identity(value: str | None) -> str | None:
+    normalized = as_string(value)
+    if normalized is None:
+        return None
+    return normalized.removeprefix("places/")
+
+
+def google_maps_url_identity(maps_url: str | None) -> str | None:
+    query_place_id = extract_maps_query_place_id(maps_url)
+    if query_place_id is not None:
+        return f"google_place_id:{query_place_id}"
+    cid = extract_maps_cid(maps_url)
+    if cid is not None:
+        return f"cid:{cid}"
+    normalized_url = as_string(maps_url)
+    if normalized_url is None or not resolved_google_maps_url_is_place_page(normalized_url):
+        return None
+    parsed = urlsplit(normalized_url)
+    path = unquote(parsed.path).rstrip("/")
+    return f"google_maps_uri:{parsed.netloc.lower()}{path}"
+
+
 def expand_location_tag_aliases(tags: set[str]) -> set[str]:
     expanded = set(tags)
     for tag in list(tags):
@@ -7493,8 +7526,13 @@ def preserve_existing_enrichment(
     can_preserve_previous_identity = (
         allow_identity_mismatch
         or raw_place is None
-        or enrichment_identity_is_compatible_with_raw(raw_place, previous_place)
+        or (
+            enrichment_identity_is_compatible_with_raw(raw_place, previous_place)
+            and enrichment_address_is_compatible_with_raw(raw_place, previous_place)
+        )
     )
+    if not can_preserve_previous_identity and refreshed_place.limited_view is True:
+        return refreshed_entry, None
 
     if (
         can_preserve_previous_identity
@@ -7562,7 +7600,7 @@ def preserve_existing_enrichment(
         refreshed_place.business_status = previous_place.business_status
         append_unique_reason(preserved_fields, "status")
 
-    if price_range_regressed_from_symbolic_tier(previous_place, refreshed_place):
+    if can_preserve_previous_identity and price_range_regressed_from_symbolic_tier(previous_place, refreshed_place):
         preserve_previous_symbolic_price_range(previous_place, refreshed_place)
         append_unique_reason(preserved_fields, "price_range")
 
@@ -7652,6 +7690,21 @@ def google_maps_uri_is_compatible_for_preservation(
     return True
 
 
+def enrichment_address_is_compatible_with_raw(
+    raw_place: RawPlace | None,
+    enrichment_place: EnrichmentPlace,
+) -> bool:
+    if raw_place is None:
+        return True
+    raw_address = as_string(raw_place.address)
+    if raw_address is None:
+        return True
+    enrichment_address = as_string(enrichment_place.formatted_address)
+    if enrichment_address is None:
+        return False
+    return not address_texts_conflict(raw_address, enrichment_address)
+
+
 def price_range_regressed_from_symbolic_tier(
     previous_place: EnrichmentPlace,
     refreshed_place: EnrichmentPlace,
@@ -7714,11 +7767,12 @@ def enrichment_google_identity_for_shift_detection(place: EnrichmentPlace) -> st
     google_place_id = as_string(place.google_place_id)
     if google_place_id is not None:
         return f"google_place_id:{google_place_id}"
-    google_place_resource_name = as_string(place.google_place_resource_name)
+    google_place_resource_name = normalized_google_place_resource_identity(place.google_place_resource_name)
     if google_place_resource_name is not None:
-        return f"google_place_resource_name:{google_place_resource_name}"
-    if resolved_google_maps_url_is_place_page(place.google_maps_uri):
-        return f"google_maps_uri:{place.google_maps_uri}"
+        return f"google_place_id:{google_place_resource_name}"
+    google_maps_identity = google_maps_url_identity(place.google_maps_uri)
+    if google_maps_identity is not None:
+        return google_maps_identity
     return None
 
 
@@ -7746,7 +7800,47 @@ def address_texts_conflict(left: str | None, right: str | None) -> bool:
     right_numbers = set(re.findall(r"\d+", right_text))
     if left_numbers and right_numbers and not left_numbers & right_numbers:
         return True
-    return token_overlap_score(left_text, right_text) <= 10
+    return address_token_overlap_score(left_text, right_text) == 0
+
+
+ADDRESS_TOKEN_STOPWORDS = {
+    "city",
+    "country",
+    "county",
+    "district",
+    "prefecture",
+    "province",
+    "region",
+    "state",
+    "the",
+    "united",
+}
+
+
+def address_identity_tokens(text: str) -> set[str]:
+    parts = [part.strip() for part in re.split(r"[,、]", text) if part.strip()]
+    if not parts:
+        parts = [text]
+    streetish_parts = [
+        part
+        for index, part in enumerate(parts)
+        if index == 0 or re.search(r"\d", part)
+    ]
+    tokens = {
+        token
+        for part in streetish_parts
+        for token in re.findall(r"[\w]+", part.casefold())
+        if len(token) > 2 and token not in ADDRESS_TOKEN_STOPWORDS
+    }
+    return tokens
+
+
+def address_token_overlap_score(left: str, right: str) -> int:
+    left_tokens = address_identity_tokens(left)
+    right_tokens = address_identity_tokens(right)
+    if not left_tokens or not right_tokens:
+        return 0
+    return len(left_tokens & right_tokens) * 5
 
 
 def load_places_cache(slug: str) -> dict[str, EnrichmentCacheEntry]:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7701,7 +7701,7 @@ def enrichment_address_is_compatible_with_raw(
         return True
     enrichment_address = as_string(enrichment_place.formatted_address)
     if enrichment_address is None:
-        return False
+        return True
     return not address_texts_conflict(raw_address, enrichment_address)
 
 
@@ -7748,6 +7748,10 @@ def enrichment_google_identity_shift_conflicts_with_raw(
         return False
     if not enrichment_identity_is_compatible_with_raw(raw_place, previous_place):
         return False
+    previous_identity = enrichment_google_identity_for_shift_detection(previous_place)
+    refreshed_identity = enrichment_google_identity_for_shift_detection(refreshed_place)
+    if previous_identity is not None and refreshed_identity is not None and previous_identity == refreshed_identity:
+        return False
     if not enrichment_identity_is_compatible_with_raw(raw_place, refreshed_place):
         return True
     if not enrichment_address_conflicts_with_raw_or_previous(
@@ -7756,9 +7760,7 @@ def enrichment_google_identity_shift_conflicts_with_raw(
         raw_place=raw_place,
     ):
         return False
-    previous_identity = enrichment_google_identity_for_shift_detection(previous_place)
-    refreshed_identity = enrichment_google_identity_for_shift_detection(refreshed_place)
-    if previous_identity is None or refreshed_identity is None or previous_identity == refreshed_identity:
+    if previous_identity is None or refreshed_identity is None:
         return False
     return True
 
@@ -7773,6 +7775,9 @@ def enrichment_google_identity_for_shift_detection(place: EnrichmentPlace) -> st
     google_maps_identity = google_maps_url_identity(place.google_maps_uri)
     if google_maps_identity is not None:
         return google_maps_identity
+    search_result_identity = google_maps_url_identity(place.search_result_url)
+    if search_result_identity is not None:
+        return search_result_identity
     return None
 
 
@@ -7800,7 +7805,7 @@ def address_texts_conflict(left: str | None, right: str | None) -> bool:
     right_numbers = set(re.findall(r"\d+", right_text))
     if left_numbers and right_numbers and not left_numbers & right_numbers:
         return True
-    return address_token_overlap_score(left_text, right_text) == 0
+    return address_token_overlap_score(as_string(left) or "", as_string(right) or "") == 0
 
 
 ADDRESS_TOKEN_STOPWORDS = {

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7496,7 +7496,11 @@ def preserve_existing_enrichment(
         or enrichment_identity_is_compatible_with_raw(raw_place, previous_place)
     )
 
-    if previous_place.limited_view is False and refreshed_place.limited_view is True:
+    if (
+        can_preserve_previous_identity
+        and previous_place.limited_view is False
+        and refreshed_place.limited_view is True
+    ):
         return (
             existing_entry,
             f"WARNING: Preserving previous enrichment for {slug}:{place_id} [{place_name}] "
@@ -7560,6 +7564,7 @@ def preserve_existing_enrichment(
 
     if price_range_regressed_from_symbolic_tier(previous_place, refreshed_place):
         refreshed_place.price_range = previous_place.price_range
+        reset_semantic_description_after_price_preservation(refreshed_place)
         append_unique_reason(preserved_fields, "price_range")
 
     if (
@@ -7663,6 +7668,15 @@ def price_range_regressed_from_symbolic_tier(
     )
 
 
+def reset_semantic_description_after_price_preservation(place: EnrichmentPlace) -> None:
+    if not place.semantic_description and not place.semantic_description_signature:
+        return
+    place.semantic_description = None
+    place.semantic_description_signature = None
+    if not semantic_enrichment_state_is_populated(semantic_enrichment_state(place)):
+        place.semantic_source = None
+
+
 def enrichment_google_identity_shift_conflicts_with_raw(
     previous_place: EnrichmentPlace,
     refreshed_place: EnrichmentPlace,
@@ -7672,23 +7686,33 @@ def enrichment_google_identity_shift_conflicts_with_raw(
 ) -> bool:
     if allow_identity_mismatch or raw_place is None:
         return False
-    previous_google_place_id = as_string(previous_place.google_place_id)
-    refreshed_google_place_id = as_string(refreshed_place.google_place_id)
-    if (
-        previous_google_place_id is None
-        or refreshed_google_place_id is None
-        or previous_google_place_id == refreshed_google_place_id
-    ):
-        return False
     if not enrichment_identity_is_compatible_with_raw(raw_place, previous_place):
         return False
     if not enrichment_identity_is_compatible_with_raw(raw_place, refreshed_place):
         return True
-    return enrichment_address_conflicts_with_raw_or_previous(
+    if not enrichment_address_conflicts_with_raw_or_previous(
         previous_place,
         refreshed_place,
         raw_place=raw_place,
-    )
+    ):
+        return False
+    previous_identity = enrichment_google_identity_for_shift_detection(previous_place)
+    refreshed_identity = enrichment_google_identity_for_shift_detection(refreshed_place)
+    if previous_identity is None or refreshed_identity is None or previous_identity == refreshed_identity:
+        return False
+    return True
+
+
+def enrichment_google_identity_for_shift_detection(place: EnrichmentPlace) -> str | None:
+    google_place_id = as_string(place.google_place_id)
+    if google_place_id is not None:
+        return f"google_place_id:{google_place_id}"
+    google_place_resource_name = as_string(place.google_place_resource_name)
+    if google_place_resource_name is not None:
+        return f"google_place_resource_name:{google_place_resource_name}"
+    if resolved_google_maps_url_is_place_page(place.google_maps_uri):
+        return f"google_maps_uri:{place.google_maps_uri}"
+    return None
 
 
 def enrichment_address_conflicts_with_raw_or_previous(
@@ -7711,7 +7735,11 @@ def address_texts_conflict(left: str | None, right: str | None) -> bool:
     right_text = normalize_text(right)
     if not left_text or not right_text or left_text == right_text:
         return False
-    return token_overlap_score(left_text, right_text) <= 5
+    left_numbers = set(re.findall(r"\d+", left_text))
+    right_numbers = set(re.findall(r"\d+", right_text))
+    if left_numbers and right_numbers and not left_numbers & right_numbers:
+        return True
+    return token_overlap_score(left_text, right_text) <= 10
 
 
 def load_places_cache(slug: str) -> dict[str, EnrichmentCacheEntry]:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7496,6 +7496,25 @@ def preserve_existing_enrichment(
         or enrichment_identity_is_compatible_with_raw(raw_place, previous_place)
     )
 
+    if previous_place.limited_view is False and refreshed_place.limited_view is True:
+        return (
+            existing_entry,
+            f"WARNING: Preserving previous enrichment for {slug}:{place_id} [{place_name}] "
+            "because refresh returned degraded result (limited view).",
+        )
+
+    if enrichment_google_identity_shift_conflicts_with_raw(
+        previous_place,
+        refreshed_place,
+        raw_place=raw_place,
+        allow_identity_mismatch=allow_identity_mismatch,
+    ):
+        return (
+            existing_entry,
+            f"WARNING: Preserving previous enrichment for {slug}:{place_id} [{place_name}] "
+            "because refresh changed Google place identity to a conflicting location.",
+        )
+
     preserved_fields: list[str] = []
 
     if refreshed_place.rating is None and previous_place.rating is not None:
@@ -7538,6 +7557,10 @@ def preserve_existing_enrichment(
     if not refreshed_place.business_status and previous_place.business_status:
         refreshed_place.business_status = previous_place.business_status
         append_unique_reason(preserved_fields, "status")
+
+    if price_range_regressed_from_symbolic_tier(previous_place, refreshed_place):
+        refreshed_place.price_range = previous_place.price_range
+        append_unique_reason(preserved_fields, "price_range")
 
     if (
         can_preserve_previous_identity
@@ -7623,6 +7646,72 @@ def google_maps_uri_is_compatible_for_preservation(
     if previous_address and refreshed_address and token_overlap_score(previous_address, refreshed_address) == 0:
         return False
     return True
+
+
+def price_range_regressed_from_symbolic_tier(
+    previous_place: EnrichmentPlace,
+    refreshed_place: EnrichmentPlace,
+) -> bool:
+    previous_price = as_string(previous_place.price_range)
+    refreshed_price = as_string(refreshed_place.price_range)
+    if previous_price is None or refreshed_price is None:
+        return False
+    return (
+        symbolic_price_tier(previous_price) is not None
+        and symbolic_price_tier(refreshed_price) is None
+        and parse_price_text(refreshed_price) is not None
+    )
+
+
+def enrichment_google_identity_shift_conflicts_with_raw(
+    previous_place: EnrichmentPlace,
+    refreshed_place: EnrichmentPlace,
+    *,
+    raw_place: RawPlace | None,
+    allow_identity_mismatch: bool,
+) -> bool:
+    if allow_identity_mismatch or raw_place is None:
+        return False
+    previous_google_place_id = as_string(previous_place.google_place_id)
+    refreshed_google_place_id = as_string(refreshed_place.google_place_id)
+    if (
+        previous_google_place_id is None
+        or refreshed_google_place_id is None
+        or previous_google_place_id == refreshed_google_place_id
+    ):
+        return False
+    if not enrichment_identity_is_compatible_with_raw(raw_place, previous_place):
+        return False
+    if not enrichment_identity_is_compatible_with_raw(raw_place, refreshed_place):
+        return True
+    return enrichment_address_conflicts_with_raw_or_previous(
+        previous_place,
+        refreshed_place,
+        raw_place=raw_place,
+    )
+
+
+def enrichment_address_conflicts_with_raw_or_previous(
+    previous_place: EnrichmentPlace,
+    refreshed_place: EnrichmentPlace,
+    *,
+    raw_place: RawPlace,
+) -> bool:
+    refreshed_address = refreshed_place.formatted_address
+    if refreshed_address is None:
+        return False
+    return address_texts_conflict(raw_place.address, refreshed_address) or address_texts_conflict(
+        previous_place.formatted_address,
+        refreshed_address,
+    )
+
+
+def address_texts_conflict(left: str | None, right: str | None) -> bool:
+    left_text = normalize_text(left)
+    right_text = normalize_text(right)
+    if not left_text or not right_text or left_text == right_text:
+        return False
+    return token_overlap_score(left_text, right_text) <= 5
 
 
 def load_places_cache(slug: str) -> dict[str, EnrichmentCacheEntry]:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -3953,6 +3953,148 @@ class BuildDataTests(unittest.TestCase):
         self.assertIn("about", warning or "")
         self.assertIn("semantic_description", warning or "")
 
+    def test_preserve_existing_enrichment_keeps_rich_row_when_refresh_is_limited_view(self) -> None:
+        existing_entry = EnrichmentCacheEntry(
+            fetched_at="2026-07-06T00:00:00+00:00",
+            source="google_maps_page",
+            query="Tanta de Miraflores, Lima",
+            matched=True,
+            place=EnrichmentPlace(
+                google_place_id="ChIJcRZpcB3IBZERnslL022_dbs",
+                display_name="Tanta de Miraflores",
+                formatted_address="Av. Vasco Núñez de Balboa 660, Miraflores 15074, Peru",
+                rating=4.4,
+                review_topics=[{"label": "ceviche", "count": 11}],
+                about_sections=[
+                    {
+                        "title": "Accessibility",
+                        "items": [{"label": "Wheelchair accessible entrance"}],
+                    }
+                ],
+                limited_view=False,
+            ),
+        )
+        refreshed_entry = EnrichmentCacheEntry(
+            fetched_at="2026-07-08T00:00:00+00:00",
+            source="google_maps_page",
+            query="Tanta de Miraflores, Lima",
+            matched=True,
+            place=EnrichmentPlace(
+                google_place_id="ChIJcRZpcB3IBZERnslL022_dbs",
+                display_name="Tanta de Miraflores",
+                formatted_address="Av. Vasco Núñez de Balboa 660, Miraflores 15074, Peru",
+                rating=4.4,
+                review_topics=[{"label": "Photo of Christina", "count": 1010}],
+                about_sections=[{"title": "Accessibility"}],
+                limited_view=True,
+            ),
+        )
+
+        merged, warning = build_data.preserve_existing_enrichment(
+            slug="lima-peru",
+            place_id="gid:g-1hd_kmn5v",
+            place_name="Tanta de Miraflores",
+            existing_entry=existing_entry,
+            refreshed_entry=refreshed_entry,
+        )
+
+        self.assertIs(merged, existing_entry)
+        self.assertIn("limited view", warning or "")
+
+    def test_preserve_existing_enrichment_keeps_symbolic_price_tier(self) -> None:
+        existing_entry = EnrichmentCacheEntry(
+            fetched_at="2026-06-11T00:00:00+00:00",
+            source="google_maps_page",
+            query="Mount Desert Island Ice Cream, Bar Harbor",
+            matched=True,
+            place=EnrichmentPlace(
+                google_place_id="ChIJHfztTmO_rkwRFQ1uTa_aXd4",
+                display_name="Mount Desert Island Ice Cream",
+                formatted_address="7 Firefly Ln, Bar Harbor, ME 04609",
+                price_range="$$",
+                primary_type="ice_cream_shop",
+                primary_type_display_name="Ice cream shop",
+                types=["bakery", "ice_cream_shop"],
+            ),
+        )
+        refreshed_entry = EnrichmentCacheEntry(
+            fetched_at="2026-07-08T00:00:00+00:00",
+            source="google_maps_page",
+            query="Mount Desert Island Ice Cream, Bar Harbor",
+            matched=True,
+            place=EnrichmentPlace(
+                google_place_id="ChIJHfztTmO_rkwRFQ1uTa_aXd4",
+                display_name="Mount Desert Island Ice Cream",
+                formatted_address="7 Firefly Ln, Bar Harbor, ME 04609",
+                price_range="¥177,790",
+                room_price="¥177,790",
+                primary_type="ice_cream_shop",
+                primary_type_display_name="Ice cream shop",
+                types=["bakery", "ice_cream_shop"],
+            ),
+        )
+
+        merged, warning = build_data.preserve_existing_enrichment(
+            slug="maine-coast-usa",
+            place_id="gid:g-1tj735th",
+            place_name="Mount Desert Island Ice Cream",
+            existing_entry=existing_entry,
+            refreshed_entry=refreshed_entry,
+        )
+
+        self.assertIs(merged, refreshed_entry)
+        assert merged.place is not None
+        self.assertEqual(merged.place.price_range, "$$")
+        self.assertIn("price_range", warning or "")
+
+    def test_preserve_existing_enrichment_keeps_saved_list_location_on_identity_shift(self) -> None:
+        raw_place = RawPlace(
+            name="Abito",
+            address="C. 56 451-Local 32, Zona Paseo Montejo, Centro, 97000 Mérida, Yuc., Mexico",
+            lat=20.9864,
+            lng=-89.6190,
+            maps_url="https://maps.google.com/?cid=111",
+            google_id="/g/11bym_dkp6",
+        )
+        existing_entry = EnrichmentCacheEntry(
+            fetched_at="2026-06-11T00:00:00+00:00",
+            source="google_maps_page",
+            query="Abito, Mérida",
+            matched=True,
+            place=EnrichmentPlace(
+                google_place_id="ChIJp4jyC1pxVo8RIVqMwMkIT8Q",
+                display_name="Abito",
+                formatted_address="Calle 60, C. 35 346, Zona Paseo Montejo, Centro, 97000 Mérida, Yuc., Mexico",
+                google_maps_uri="https://www.google.com/maps/place/Abito/@20.9854779,-89.6195071,17z/",
+                primary_type_display_name="Clothing store",
+            ),
+        )
+        refreshed_entry = EnrichmentCacheEntry(
+            fetched_at="2026-07-08T00:00:00+00:00",
+            source="google_maps_page",
+            query="Abito, Mérida",
+            matched=True,
+            place=EnrichmentPlace(
+                google_place_id="ChIJ1wykGfZyVo8RXFQFnJtWTTM",
+                display_name="Abito",
+                formatted_address="Internacional, 97295 Merida, Yucatan, Mexico",
+                google_maps_uri="https://www.google.com/maps/place/Abito/@20.933687,-89.6632749,17z/",
+                primary_type_display_name="Clothing store",
+            ),
+        )
+
+        merged, warning = build_data.preserve_existing_enrichment(
+            slug="merida-mexico",
+            place_id="gid:g-11bym_dkp6",
+            place_name="Abito",
+            existing_entry=existing_entry,
+            refreshed_entry=refreshed_entry,
+            raw_place=raw_place,
+        )
+
+        self.assertIs(merged, existing_entry)
+        self.assertIn("changed Google place identity", warning or "")
+
     def test_preserve_existing_enrichment_skips_invalid_cached_semantic_description(self) -> None:
         existing_entry = EnrichmentCacheEntry(
             fetched_at="2026-05-01T00:00:00+00:00",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -4001,6 +4001,50 @@ class BuildDataTests(unittest.TestCase):
         self.assertIs(merged, existing_entry)
         self.assertIn("limited view", warning or "")
 
+    def test_preserve_existing_enrichment_does_not_keep_limited_view_for_stale_identity(self) -> None:
+        raw_place = RawPlace(
+            name="Lola Underground",
+            address="Hay St &, Cathedral Ave, Perth WA 6000, Australia",
+            maps_url="https://www.google.com/maps/search/?api=1&query=Lola+Underground",
+        )
+        existing_entry = EnrichmentCacheEntry(
+            fetched_at="2026-05-01T00:00:00+00:00",
+            source="google_maps_page",
+            query="Lola Underground, Perth",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="Pooles Temple",
+                formatted_address="Hay St &, Cathedral Ave, Perth WA 6000, Australia",
+                google_place_id="stale-pooles-place-id",
+                limited_view=False,
+            ),
+        )
+        refreshed_entry = EnrichmentCacheEntry(
+            fetched_at="2026-05-02T00:00:00+00:00",
+            source="google_maps_page",
+            query="Lola Underground, Perth",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="Lola Underground",
+                formatted_address="Hay St &, Cathedral Ave, Perth WA 6000, Australia",
+                limited_view=True,
+            ),
+        )
+
+        merged, warning = build_data.preserve_existing_enrichment(
+            slug="perth-and-fremantle-australia",
+            place_id="cid:3040698308894550531",
+            place_name="Lola Underground",
+            existing_entry=existing_entry,
+            refreshed_entry=refreshed_entry,
+            raw_place=raw_place,
+        )
+
+        self.assertIs(merged, refreshed_entry)
+        self.assertIsNone(warning)
+        assert merged.place is not None
+        self.assertEqual(merged.place.display_name, "Lola Underground")
+
     def test_preserve_existing_enrichment_keeps_symbolic_price_tier(self) -> None:
         existing_entry = EnrichmentCacheEntry(
             fetched_at="2026-06-11T00:00:00+00:00",
@@ -4015,6 +4059,9 @@ class BuildDataTests(unittest.TestCase):
                 primary_type="ice_cream_shop",
                 primary_type_display_name="Ice cream shop",
                 types=["bakery", "ice_cream_shop"],
+                semantic_description="A popular Bar Harbor scoop shop for housemade ice cream.",
+                semantic_description_signature="old-price-signature",
+                semantic_source="llm",
             ),
         )
         refreshed_entry = EnrichmentCacheEntry(
@@ -4031,6 +4078,9 @@ class BuildDataTests(unittest.TestCase):
                 primary_type="ice_cream_shop",
                 primary_type_display_name="Ice cream shop",
                 types=["bakery", "ice_cream_shop"],
+                semantic_description="An ice cream shop with ¥177,790 pricing.",
+                semantic_description_signature="bad-price-signature",
+                semantic_source="llm",
             ),
         )
 
@@ -4045,7 +4095,13 @@ class BuildDataTests(unittest.TestCase):
         self.assertIs(merged, refreshed_entry)
         assert merged.place is not None
         self.assertEqual(merged.place.price_range, "$$")
+        self.assertEqual(
+            merged.place.semantic_description,
+            "A popular Bar Harbor scoop shop for housemade ice cream.",
+        )
+        self.assertEqual(merged.place.semantic_description_signature, "old-price-signature")
         self.assertIn("price_range", warning or "")
+        self.assertIn("semantic_description", warning or "")
 
     def test_preserve_existing_enrichment_keeps_saved_list_location_on_identity_shift(self) -> None:
         raw_place = RawPlace(
@@ -4080,6 +4136,91 @@ class BuildDataTests(unittest.TestCase):
                 formatted_address="Internacional, 97295 Merida, Yucatan, Mexico",
                 google_maps_uri="https://www.google.com/maps/place/Abito/@20.933687,-89.6632749,17z/",
                 primary_type_display_name="Clothing store",
+            ),
+        )
+
+        merged, warning = build_data.preserve_existing_enrichment(
+            slug="merida-mexico",
+            place_id="gid:g-11bym_dkp6",
+            place_name="Abito",
+            existing_entry=existing_entry,
+            refreshed_entry=refreshed_entry,
+            raw_place=raw_place,
+        )
+
+        self.assertIs(merged, existing_entry)
+        self.assertIn("changed Google place identity", warning or "")
+
+    def test_preserve_existing_enrichment_catches_identity_shift_without_refreshed_place_id(self) -> None:
+        raw_place = RawPlace(
+            name="Abito",
+            address="C. 56 451-Local 32, Zona Paseo Montejo, Centro, 97000 Mérida, Yuc., Mexico",
+            maps_url="https://maps.google.com/?cid=111",
+        )
+        existing_entry = EnrichmentCacheEntry(
+            fetched_at="2026-06-11T00:00:00+00:00",
+            source="google_maps_page",
+            query="Abito, Mérida",
+            matched=True,
+            place=EnrichmentPlace(
+                google_place_id="ChIJp4jyC1pxVo8RIVqMwMkIT8Q",
+                display_name="Abito",
+                formatted_address="C. 56 451-Local 32, Zona Paseo Montejo, Centro, 97000 Mérida, Yuc., Mexico",
+                google_maps_uri="https://www.google.com/maps/place/Abito/@20.9854779,-89.6195071,17z/",
+            ),
+        )
+        refreshed_entry = EnrichmentCacheEntry(
+            fetched_at="2026-07-08T00:00:00+00:00",
+            source="google_maps_page",
+            query="Abito, Mérida",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="Abito",
+                formatted_address="Internacional, 97295 Merida, Yucatan, Mexico",
+                google_maps_uri="https://www.google.com/maps/place/Abito/@20.933687,-89.6632749,17z/",
+            ),
+        )
+
+        merged, warning = build_data.preserve_existing_enrichment(
+            slug="merida-mexico",
+            place_id="gid:g-11bym_dkp6",
+            place_name="Abito",
+            existing_entry=existing_entry,
+            refreshed_entry=refreshed_entry,
+            raw_place=raw_place,
+        )
+
+        self.assertIs(merged, existing_entry)
+        self.assertIn("changed Google place identity", warning or "")
+
+    def test_preserve_existing_enrichment_treats_locality_only_address_overlap_as_conflict(self) -> None:
+        raw_place = RawPlace(
+            name="Abito",
+            address="123 First St, Merida, Yucatan, Mexico",
+            maps_url="https://maps.google.com/?cid=111",
+        )
+        existing_entry = EnrichmentCacheEntry(
+            fetched_at="2026-06-11T00:00:00+00:00",
+            source="google_maps_page",
+            query="Abito, Mérida",
+            matched=True,
+            place=EnrichmentPlace(
+                google_place_id="saved-list-branch",
+                display_name="Abito",
+                formatted_address="123 First St, Merida, Yucatan, Mexico",
+                google_maps_uri="https://www.google.com/maps/place/Abito/@20.9854779,-89.6195071,17z/",
+            ),
+        )
+        refreshed_entry = EnrichmentCacheEntry(
+            fetched_at="2026-07-08T00:00:00+00:00",
+            source="google_maps_page",
+            query="Abito, Mérida",
+            matched=True,
+            place=EnrichmentPlace(
+                google_place_id="other-branch",
+                display_name="Abito",
+                formatted_address="456 Second Ave, Merida, Yucatan, Mexico",
+                google_maps_uri="https://www.google.com/maps/place/Abito/@20.933687,-89.6632749,17z/",
             ),
         )
 

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -4045,6 +4045,49 @@ class BuildDataTests(unittest.TestCase):
         assert merged.place is not None
         self.assertEqual(merged.place.display_name, "Lola Underground")
 
+    def test_preserve_existing_enrichment_does_not_keep_limited_view_for_wrong_cached_address(self) -> None:
+        raw_place = RawPlace(
+            name="Tanta de Miraflores",
+            address="Av. Vasco Núñez de Balboa 660, Miraflores 15074, Peru",
+            maps_url="https://maps.google.com/?cid=111",
+        )
+        existing_entry = EnrichmentCacheEntry(
+            fetched_at="2026-07-06T00:00:00+00:00",
+            source="google_maps_page",
+            query="Tanta de Miraflores, Lima",
+            matched=True,
+            place=EnrichmentPlace(
+                google_place_id="same-name-wrong-branch",
+                display_name="Tanta de Miraflores",
+                formatted_address="Av. Primavera 120, Santiago de Surco 15023, Peru",
+                rating=4.6,
+                limited_view=False,
+            ),
+        )
+        refreshed_entry = EnrichmentCacheEntry(
+            fetched_at="2026-07-08T00:00:00+00:00",
+            source="google_maps_page",
+            query="Tanta de Miraflores, Lima",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="Tanta de Miraflores",
+                formatted_address="Av. Vasco Núñez de Balboa 660, Miraflores 15074, Peru",
+                limited_view=True,
+            ),
+        )
+
+        merged, warning = build_data.preserve_existing_enrichment(
+            slug="lima-peru",
+            place_id="cid:111",
+            place_name="Tanta de Miraflores",
+            existing_entry=existing_entry,
+            refreshed_entry=refreshed_entry,
+            raw_place=raw_place,
+        )
+
+        self.assertIs(merged, refreshed_entry)
+        self.assertIsNone(warning)
+
     def test_preserve_existing_enrichment_keeps_symbolic_price_tier(self) -> None:
         existing_entry = EnrichmentCacheEntry(
             fetched_at="2026-06-11T00:00:00+00:00",
@@ -4102,6 +4145,49 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(merged.place.semantic_description_signature, "old-price-signature")
         self.assertIn("price_range", warning or "")
         self.assertIn("semantic_description", warning or "")
+
+    def test_preserve_existing_enrichment_does_not_keep_symbolic_price_for_stale_identity(self) -> None:
+        raw_place = RawPlace(
+            name="Mount Desert Island Ice Cream",
+            address="7 Firefly Ln, Bar Harbor, ME 04609",
+            maps_url="https://maps.google.com/?cid=111",
+        )
+        existing_entry = EnrichmentCacheEntry(
+            fetched_at="2026-06-11T00:00:00+00:00",
+            source="google_maps_page",
+            query="Mount Desert Island Ice Cream, Bar Harbor",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="Different Hotel",
+                formatted_address="99 Other St, Bar Harbor, ME 04609",
+                price_range="$$",
+            ),
+        )
+        refreshed_entry = EnrichmentCacheEntry(
+            fetched_at="2026-07-08T00:00:00+00:00",
+            source="google_maps_page",
+            query="Mount Desert Island Ice Cream, Bar Harbor",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="Mount Desert Island Ice Cream",
+                formatted_address="7 Firefly Ln, Bar Harbor, ME 04609",
+                price_range="¥177,790",
+            ),
+        )
+
+        merged, warning = build_data.preserve_existing_enrichment(
+            slug="maine-coast-usa",
+            place_id="cid:111",
+            place_name="Mount Desert Island Ice Cream",
+            existing_entry=existing_entry,
+            refreshed_entry=refreshed_entry,
+            raw_place=raw_place,
+        )
+
+        self.assertIs(merged, refreshed_entry)
+        assert merged.place is not None
+        self.assertEqual(merged.place.price_range, "¥177,790")
+        self.assertIsNone(warning)
 
     def test_preserve_existing_enrichment_keeps_saved_list_location_on_identity_shift(self) -> None:
         raw_place = RawPlace(
@@ -4235,6 +4321,25 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertIs(merged, existing_entry)
         self.assertIn("changed Google place identity", warning or "")
+
+    def test_enrichment_identity_shift_normalizes_resource_names_and_query_place_urls(self) -> None:
+        self.assertEqual(
+            build_data.enrichment_google_identity_for_shift_detection(
+                EnrichmentPlace(google_place_resource_name="places/ChIJ123")
+            ),
+            "google_place_id:ChIJ123",
+        )
+        self.assertEqual(
+            build_data.enrichment_google_identity_for_shift_detection(
+                EnrichmentPlace(
+                    google_maps_uri=(
+                        "https://www.google.com/maps/search/?api=1&query=Abito"
+                        "&query_place_id=ChIJ123"
+                    )
+                )
+            ),
+            "google_place_id:ChIJ123",
+        )
 
     def test_preserve_existing_enrichment_skips_invalid_cached_semantic_description(self) -> None:
         existing_entry = EnrichmentCacheEntry(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -3956,6 +3956,8 @@ class BuildDataTests(unittest.TestCase):
     def test_preserve_existing_enrichment_keeps_rich_row_when_refresh_is_limited_view(self) -> None:
         existing_entry = EnrichmentCacheEntry(
             fetched_at="2026-07-06T00:00:00+00:00",
+            refresh_after="2026-07-07T00:00:00+00:00",
+            input_signature="old-signature",
             source="google_maps_page",
             query="Tanta de Miraflores, Lima",
             matched=True,
@@ -3976,6 +3978,8 @@ class BuildDataTests(unittest.TestCase):
         )
         refreshed_entry = EnrichmentCacheEntry(
             fetched_at="2026-07-08T00:00:00+00:00",
+            refresh_after="2026-07-15T00:00:00+00:00",
+            input_signature="new-signature",
             source="google_maps_page",
             query="Tanta de Miraflores, Lima",
             matched=True,
@@ -3998,7 +4002,11 @@ class BuildDataTests(unittest.TestCase):
             refreshed_entry=refreshed_entry,
         )
 
-        self.assertIs(merged, existing_entry)
+        self.assertIsNot(merged, existing_entry)
+        self.assertIs(merged.place, existing_entry.place)
+        self.assertEqual(merged.fetched_at, "2026-07-08T00:00:00+00:00")
+        self.assertEqual(merged.refresh_after, "2026-07-15T00:00:00+00:00")
+        self.assertEqual(merged.input_signature, "new-signature")
         self.assertIn("limited view", warning or "")
 
     def test_preserve_existing_enrichment_does_not_keep_limited_view_for_stale_identity(self) -> None:
@@ -4138,6 +4146,7 @@ class BuildDataTests(unittest.TestCase):
         self.assertIs(merged, refreshed_entry)
         assert merged.place is not None
         self.assertEqual(merged.place.price_range, "$$")
+        self.assertIsNone(merged.place.room_price)
         self.assertEqual(
             merged.place.semantic_description,
             "A popular Bar Harbor scoop shop for housemade ice cream.",
@@ -4568,11 +4577,11 @@ class BuildDataTests(unittest.TestCase):
             raw_place=raw_place,
         )
 
-        self.assertIsNotNone(warning)
+        self.assertIsNone(warning)
         assert merged.place is not None
         self.assertIsNone(merged.place.google_maps_uri)
         self.assertIsNone(merged.place.google_place_id)
-        self.assertEqual(merged.place.business_status, "OPERATIONAL")
+        self.assertIsNone(merged.place.business_status)
 
         refreshed_entry = EnrichmentCacheEntry(
             fetched_at="2026-05-02T00:00:00+00:00",
@@ -12022,6 +12031,7 @@ class BuildDataTests(unittest.TestCase):
             entry.place.about_sections,
             [{"title": "Amenities", "items": [{"label": "Restroom"}]}],
         )
+        self.assertTrue(entry.place.limited_view)
         self.assertEqual(entry.place.google_maps_uri, "https://maps.google.com/?cid=1")
         self.assertEqual(entry.merged_sources, ["google_maps_page", "google_places_api"])
 

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -4009,6 +4009,48 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(merged.input_signature, "new-signature")
         self.assertIn("limited view", warning or "")
 
+    def test_preserve_existing_enrichment_keeps_api_backed_limited_refresh(self) -> None:
+        existing_entry = EnrichmentCacheEntry(
+            fetched_at="2026-07-06T00:00:00+00:00",
+            source="google_maps_page",
+            query="Tanta de Miraflores, Lima",
+            matched=True,
+            place=EnrichmentPlace(
+                google_place_id="ChIJcRZpcB3IBZERnslL022_dbs",
+                display_name="Tanta de Miraflores",
+                formatted_address="Av. Vasco Núñez de Balboa 660, Miraflores 15074, Peru",
+                rating=4.4,
+                limited_view=False,
+            ),
+        )
+        refreshed_entry = EnrichmentCacheEntry(
+            fetched_at="2026-07-08T00:00:00+00:00",
+            source="google_places_api",
+            merged_sources=["google_maps_page", "google_places_api"],
+            query="Tanta de Miraflores, Lima",
+            matched=True,
+            place=EnrichmentPlace(
+                google_place_id="ChIJcRZpcB3IBZERnslL022_dbs",
+                display_name="Tanta de Miraflores",
+                formatted_address="Av. Vasco Núñez de Balboa 660, Miraflores 15074, Peru",
+                rating=4.5,
+                limited_view=True,
+            ),
+        )
+
+        merged, warning = build_data.preserve_existing_enrichment(
+            slug="lima-peru",
+            place_id="gid:g-1hd_kmn5v",
+            place_name="Tanta de Miraflores",
+            existing_entry=existing_entry,
+            refreshed_entry=refreshed_entry,
+        )
+
+        self.assertIs(merged, refreshed_entry)
+        self.assertIsNone(warning)
+        assert merged.place is not None
+        self.assertEqual(merged.place.rating, 4.5)
+
     def test_preserve_existing_enrichment_does_not_keep_limited_view_for_stale_identity(self) -> None:
         raw_place = RawPlace(
             name="Lola Underground",
@@ -4348,6 +4390,37 @@ class BuildDataTests(unittest.TestCase):
                 )
             ),
             "google_place_id:ChIJ123",
+        )
+
+    def test_google_maps_url_identity_prefers_maps_place_token(self) -> None:
+        token = "0x89c259a61c75684f:0x79d31adb12345678"
+
+        self.assertEqual(
+            build_data.google_maps_url_identity(
+                f"https://www.google.com/maps/place/Old+Name/data=!4m2!3m1!1s{token}"
+            ),
+            f"gms:{token}",
+        )
+        self.assertEqual(
+            build_data.google_maps_url_identity(
+                f"https://www.google.com/maps/place/New+Name/@20.0,-89.0,17z/data=!4m2!3m1!1s{token}"
+            ),
+            f"gms:{token}",
+        )
+
+    def test_address_texts_conflict_ignores_generic_street_and_postal_overlap(self) -> None:
+        self.assertTrue(build_data.address_texts_conflict("Oak Street, City", "Pine Street, City"))
+        self.assertTrue(
+            build_data.address_texts_conflict(
+                "123 First St, Merida 97000",
+                "456 Second Ave, Merida 97000",
+            )
+        )
+        self.assertFalse(
+            build_data.address_texts_conflict(
+                "123 First St, Merida 97000",
+                "123 First Street, Merida 97000",
+            )
         )
 
     def test_preserve_existing_enrichment_skips_invalid_cached_semantic_description(self) -> None:


### PR DESCRIPTION
## Summary
- preserve existing rich cache rows when a refresh returns a limited-view result
- keep symbolic price tiers when refresh output replaces them with localized numeric quotes
- keep the saved-list location when a refreshed Google place identity moves to a conflicting address

## Tests
- `uv run ruff check scripts/build_data.py tests/python/test_build_data.py`
- `uv run python3 -m unittest tests.python.test_build_data.BuildDataTests.test_preserve_existing_enrichment_keeps_rich_row_when_refresh_is_limited_view tests.python.test_build_data.BuildDataTests.test_preserve_existing_enrichment_keeps_symbolic_price_tier tests.python.test_build_data.BuildDataTests.test_preserve_existing_enrichment_keeps_saved_list_location_on_identity_shift tests.python.test_build_data.BuildDataTests.test_preserve_existing_enrichment_keeps_thinner_successful_refresh_fields tests.python.test_build_data.BuildDataTests.test_preserve_existing_enrichment_does_not_restore_incompatible_previous_identity`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core place-enrichment merge and preservation logic that directly affects cached Google data shown in the product; mistakes could show wrong locations or stale rich data, but scope is confined to the build pipeline.
> 
> **Overview**
> Tightens **enrichment cache refresh** so bad or thinner Google results do not overwrite good cached rows.
> 
> **Limited-view refreshes:** When a maps-page refresh comes back `limited_view` but the cached row is still rich and identity-compatible, the pipeline keeps the old place payload and only updates cache metadata (`fetched_at`, `refresh_after`, `input_signature`). API-backed limited refreshes are still accepted. Stale or wrong-branch cache (identity/address mismatch with the saved list) is not protected—those limited refreshes win.
> 
> **Identity shifts:** New helpers derive a stable Google identity from place IDs, `query_place_id` URLs, CID/GMS tokens, and maps URIs. If a refresh changes identity and the new address conflicts with the raw list or previous enrichment, the **previous entry is kept** with a warning instead of merging field-by-field.
> 
> **Price and merge:** Symbolic tiers like `$$` are preserved when refresh replaces them with parsed numeric/localized quotes (and related semantic description is reset or kept consistently). Merging API + page enrichment now copies `limited_view` from the page side when set.
> 
> Extensive unit tests cover limited view, price tier, identity shift, and address conflict behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a57b216a14d6614e39e816e3072f813e18fec458. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->