### PR TITLE
Preserve CID aliases during raw refresh

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -4258,6 +4258,7 @@ def enrich_raw_sources(
                     place,
                     place_id=place_id,
                     selectors=normalized_place_selectors,
+                    blocked_alias_keys=current_primary_keys,
                 )
                 matched_place_selectors.update(selector_matches)
                 if not selector_matches:
@@ -4385,6 +4386,7 @@ def enrichment_source_refresh_lists(place_selectors: Sequence[str] | None) -> li
     }
     for raw_path in sorted(RAW_DIR.glob("*.json")):
         raw = RawSavedList.model_validate_json(raw_path.read_text(encoding="utf-8"))
+        current_primary_keys = raw_saved_list_primary_match_key_set(raw)
         for place in raw.places:
             place_id = stable_place_id(place, source_type=raw.configured_source_type)
             if place_selector_matches(
@@ -4392,6 +4394,7 @@ def enrichment_source_refresh_lists(place_selectors: Sequence[str] | None) -> li
                 place,
                 place_id=place_id,
                 selectors=normalized_place_selectors,
+                blocked_alias_keys=current_primary_keys,
             ):
                 refresh_slugs.add(raw_path.stem)
                 break
@@ -4448,6 +4451,7 @@ def refresh_cached_semantic_enrichment(
                     place,
                     place_id=place_id,
                     selectors=normalized_place_selectors,
+                    blocked_alias_keys=current_primary_keys,
                 )
                 matched_place_selectors.update(selector_matches)
                 if not selector_matches:
@@ -12950,6 +12954,7 @@ def place_selector_matches(
     *,
     place_id: str,
     selectors: set[str],
+    blocked_alias_keys: set[str] | None = None,
 ) -> set[str]:
     if not selectors:
         return set()
@@ -12959,11 +12964,16 @@ def place_selector_matches(
         f"{slug}:{place_id}".casefold(),
         f"guide-slug:{slug}".casefold(),
     }
+    cid_aliases = [
+        cid_alias
+        for cid_alias in place.cid_aliases
+        if not cid_alias or blocked_alias_keys is None or f"cid:{cid_alias}" not in blocked_alias_keys
+    ]
     for candidate in (
         place.name,
         place.maps_url,
         place.cid,
-        *place.cid_aliases,
+        *cid_aliases,
         place.google_id,
         place.maps_place_token,
     ):
@@ -12975,7 +12985,7 @@ def place_selector_matches(
     for prefix, candidate in (
         ("cid", place.cid),
         ("cid", extract_maps_cid(place.maps_url)),
-        *((("cid", cid_alias) for cid_alias in place.cid_aliases)),
+        *((("cid", cid_alias) for cid_alias in cid_aliases)),
         ("gms", place.maps_place_token),
         ("gms", extract_maps_place_token(place.maps_url)),
     ):

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6400,6 +6400,9 @@ def raw_place_match_keys(place: RawPlace, *, source_type: str | None = None) -> 
     cid = as_string(place.cid) or extract_maps_cid(place.maps_url)
     if cid:
         keys.append(f"cid:{cid}")
+    for cid_alias in place.cid_aliases:
+        if cid_alias:
+            keys.append(f"cid:{cid_alias}")
 
     google_id = as_string(place.google_id)
     if google_id:
@@ -6464,6 +6467,15 @@ def preserve_existing_raw_place(
     if names_compatible and not refreshed_place.cid and existing_place.cid:
         updates["cid"] = existing_place.cid
         preserved_fields.append("cid")
+    if (
+        names_compatible
+        and existing_place.cid
+        and refreshed_place.cid
+        and existing_place.cid != refreshed_place.cid
+        and existing_place.cid not in refreshed_place.cid_aliases
+    ):
+        updates["cid_aliases"] = [*refreshed_place.cid_aliases, existing_place.cid]
+        preserved_fields.append("cid_alias")
     if names_compatible and not refreshed_place.maps_place_token and existing_place.maps_place_token:
         updates["maps_place_token"] = existing_place.maps_place_token
         preserved_fields.append("maps_place_token")

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6605,6 +6605,7 @@ def preserve_existing_raw_place(
     existing_name = as_string(existing_place.name)
     refreshed_name = as_string(refreshed_place.name)
     names_compatible = raw_place_names_are_compatible(existing_name, refreshed_name)
+    strong_identity_compatible = raw_place_strong_google_identity_matches(existing_place, refreshed_place)
 
     if (
         names_compatible
@@ -6621,7 +6622,7 @@ def preserve_existing_raw_place(
         preserved_fields.append("cid")
     existing_cid = as_string(existing_place.cid) or extract_maps_cid(existing_place.maps_url)
     refreshed_cid = as_string(refreshed_place.cid) or extract_maps_cid(refreshed_place.maps_url)
-    if names_compatible:
+    if names_compatible or strong_identity_compatible:
         preserved_cid_aliases = list(refreshed_place.cid_aliases)
         for cid_alias in [*existing_place.cid_aliases, existing_cid]:
             if not cid_alias or cid_alias == refreshed_cid or cid_alias in preserved_cid_aliases:
@@ -6644,6 +6645,16 @@ def preserve_existing_raw_place(
         return refreshed_place, preserved_fields
 
     return refreshed_place.model_copy(update=updates), preserved_fields
+
+
+def raw_place_strong_google_identity_matches(left: RawPlace, right: RawPlace) -> bool:
+    left_google_id = raw_place_google_id_identity(left)
+    right_google_id = raw_place_google_id_identity(right)
+    if left_google_id is not None and left_google_id == right_google_id:
+        return True
+    left_maps_place_token = raw_place_maps_place_token_identity(left)
+    right_maps_place_token = raw_place_maps_place_token_identity(right)
+    return left_maps_place_token is not None and left_maps_place_token == right_maps_place_token
 
 
 def raw_place_names_are_compatible(existing_name: str | None, refreshed_name: str | None) -> bool:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -3084,16 +3084,33 @@ def normalize_guide(
     normalized_places: list[NormalizedPlace] = []
     category_counter: Counter[str] = Counter()
     prefer_enrichment_names = raw.configured_source_type == "google_export_csv"
+    current_primary_keys = raw_saved_list_primary_match_key_set(raw)
 
     for place in raw.places:
         place_id = stable_place_id(place, source_type=raw.configured_source_type)
+        override_key = raw_place_mapping_lookup_key(
+            place_override_map,
+            place,
+            source_type=raw.configured_source_type,
+            blocked_alias_keys=current_primary_keys,
+        )
+        cache_key = raw_place_mapping_lookup_key(
+            enrichment_cache,
+            place,
+            source_type=raw.configured_source_type,
+            blocked_alias_keys=current_primary_keys,
+        )
         place_trust_signals = (
             [display_trust_signal(signal) for signal in trust_signals.get(place_id, [])]
             if trust_signals is not None
             else []
         )
-        override = place_override_for_ui_copy(slug, place_id, place_override_map.get(place_id, {}))
-        enrichment_cache_entry = enrichment_cache.get(place_id)
+        override = place_override_for_ui_copy(
+            slug,
+            place_id,
+            place_override_map.get(override_key, {}) if override_key is not None else {},
+        )
+        enrichment_cache_entry = enrichment_cache.get(cache_key) if cache_key is not None else None
         enrichment = coerce_enrichment_place(enrichment_cache_entry)
         usable_enrichment_category = usable_enrichment_primary_category(
             enrichment,
@@ -4192,7 +4209,7 @@ def enrich_raw_sources(
 ) -> None:
     api_key = google_places_api_key()
     cache_payloads: dict[str, dict[str, EnrichmentCacheEntry]] = {}
-    enrich_jobs: list[tuple[str, str, str, str, dict[str, Any], str | None, str | None]] = []
+    enrich_jobs: list[tuple[str, str, str | None, str | None, str, str, dict[str, Any], str | None, str | None]] = []
     normalized_place_selectors = normalize_place_selectors(place_selectors or [])
     matched_place_selectors: set[str] = set()
 
@@ -4207,8 +4224,16 @@ def enrich_raw_sources(
             if pruned_count:
                 save_places_cache(slug, cache_payload, allow_empty_overwrite=True)
         cache_payloads[slug] = cache_payload
+        current_primary_keys = raw_saved_list_primary_match_key_set(raw)
         for place in raw.places:
             place_id = stable_place_id(place, source_type=raw.configured_source_type)
+            cache_key = raw_place_mapping_lookup_key(
+                cache_payload,
+                place,
+                source_type=raw.configured_source_type,
+                blocked_alias_keys=current_primary_keys,
+            )
+            cache_entry = cache_payload.get(cache_key) if cache_key is not None else None
             if normalized_place_selectors:
                 selector_matches = place_selector_matches(
                     slug,
@@ -4219,11 +4244,21 @@ def enrich_raw_sources(
                 matched_place_selectors.update(selector_matches)
                 if not selector_matches:
                     continue
-            override = place_override_for_ui_copy(slug, place_id, place_override_map.get(place_id, {}))
+            override_key = raw_place_mapping_lookup_key(
+                place_override_map,
+                place,
+                source_type=raw.configured_source_type,
+                blocked_alias_keys=current_primary_keys,
+            )
+            override = place_override_for_ui_copy(
+                slug,
+                place_id,
+                place_override_map.get(override_key, {}) if override_key is not None else {},
+            )
             override_google_place_id = as_string(override.get("google_place_id"))
             refresh_reason = enrichment_refresh_reason(
                 place,
-                cache_payload.get(place_id),
+                cache_entry,
                 city_name=city_name,
                 country_name=country_name,
                 signature_google_place_id=override_google_place_id,
@@ -4237,6 +4272,8 @@ def enrich_raw_sources(
                 (
                     slug,
                     place_id,
+                    cache_key,
+                    override_key,
                     place.name,
                     refresh_reason,
                     place.model_dump(mode="json"),
@@ -4261,7 +4298,7 @@ def enrich_raw_sources(
     )
     max_workers = max(1, min(refresh_workers, len(enrich_jobs)))
     if max_workers == 1 or len(enrich_jobs) == 1:
-        for slug, place_id, place_name, refresh_reason, place_payload, city_name, country_name in enrich_jobs:
+        for slug, place_id, cache_key, override_key, place_name, refresh_reason, place_payload, city_name, country_name in enrich_jobs:
             entry = enrich_place_job(
                 slug,
                 place_id,
@@ -4272,8 +4309,11 @@ def enrich_raw_sources(
                 country_name=country_name,
                 api_key=api_key,
                 refresh_startup_jitter_seconds=effective_startup_jitter_seconds,
-                existing_entry=cache_payloads[slug].get(place_id),
+                existing_entry=cache_payloads[slug].get(cache_key) if cache_key is not None else None,
+                override_key=override_key,
             )
+            if cache_key is not None and cache_key != place_id:
+                cache_payloads[slug].pop(cache_key, None)
             cache_payloads[slug][place_id] = entry
             save_places_cache(slug, cache_payloads[slug])
         return
@@ -4294,12 +4334,15 @@ def enrich_raw_sources(
                 country_name=country_name,
                 api_key=api_key,
                 refresh_startup_jitter_seconds=effective_startup_jitter_seconds,
-                existing_entry=cache_payloads[slug].get(place_id),
-            ): (slug, place_id)
-            for slug, place_id, place_name, refresh_reason, place_payload, city_name, country_name in enrich_jobs
+                existing_entry=cache_payloads[slug].get(cache_key) if cache_key is not None else None,
+                override_key=override_key,
+            ): (slug, place_id, cache_key)
+            for slug, place_id, cache_key, override_key, place_name, refresh_reason, place_payload, city_name, country_name in enrich_jobs
         }
         for future in as_completed(future_map):
-            slug, place_id = future_map[future]
+            slug, place_id, cache_key = future_map[future]
+            if cache_key is not None and cache_key != place_id:
+                cache_payloads[slug].pop(cache_key, None)
             cache_payloads[slug][place_id] = future.result()
             save_places_cache(slug, cache_payloads[slug])
     except KeyboardInterrupt:
@@ -4377,6 +4420,7 @@ def refresh_cached_semantic_enrichment(
             if pruned_count:
                 save_places_cache(slug, cache_payload, allow_empty_overwrite=True)
         cache_payloads[slug] = cache_payload
+        current_primary_keys = raw_saved_list_primary_match_key_set(raw)
 
         for place in raw.places:
             place_id = stable_place_id(place, source_type=raw.configured_source_type)
@@ -4391,11 +4435,27 @@ def refresh_cached_semantic_enrichment(
                 if not selector_matches:
                     continue
 
-            entry = cache_payload.get(place_id)
+            cache_key = raw_place_mapping_lookup_key(
+                cache_payload,
+                place,
+                source_type=raw.configured_source_type,
+                blocked_alias_keys=current_primary_keys,
+            )
+            entry = cache_payload.get(cache_key) if cache_key is not None else None
             if not cache_entry_has_publishable_enrichment(entry) or entry is None or entry.place is None:
                 skipped_count += 1
                 continue
-            override = place_override_for_ui_copy(slug, place_id, place_override_map.get(place_id, {}))
+            override_key = raw_place_mapping_lookup_key(
+                place_override_map,
+                place,
+                source_type=raw.configured_source_type,
+                blocked_alias_keys=current_primary_keys,
+            )
+            override = place_override_for_ui_copy(
+                slug,
+                place_id,
+                place_override_map.get(override_key, {}) if override_key is not None else {},
+            )
             suppress_description = bool(as_string(override.get("note")))
             semantic_jobs.append((slug, place_id, place, entry, city_name, country_name, suppress_description))
 
@@ -4493,6 +4553,7 @@ def enrich_place_job(
     api_key: str | None,
     refresh_startup_jitter_seconds: float,
     existing_entry: EnrichmentCacheEntry | None = None,
+    override_key: str | None = None,
 ) -> EnrichmentCacheEntry:
     print(
         f"Enriching {slug}:{place_id} [{place_name}] ({refresh_reason})",
@@ -4501,7 +4562,11 @@ def enrich_place_job(
     sleep_for_refresh_startup_jitter(refresh_startup_jitter_seconds)
     place = RawPlace.model_validate(place_payload)
     place_override_map = read_json(PLACE_OVERRIDES_DIR / f"{slug}.json")
-    override = place_override_for_ui_copy(slug, place_id, place_override_map.get(place_id, {}))
+    override = place_override_for_ui_copy(
+        slug,
+        place_id,
+        place_override_map.get(override_key or place_id, {}),
+    )
     suppress_description = bool(as_string(override.get("note")))
     override_google_place_id = as_string(override.get("google_place_id"))
     allow_identity_mismatch = as_bool(override.get("allow_enrichment_identity_mismatch")) is True
@@ -6394,15 +6459,12 @@ def stamp_raw_saved_list(payload: RawSavedList, source: SourceConfig, *, source_
     payload.configured_source_path = source.path
 
 
-def raw_place_match_keys(place: RawPlace, *, source_type: str | None = None) -> list[str]:
+def raw_place_primary_match_keys(place: RawPlace, *, source_type: str | None = None) -> list[str]:
     keys: list[str] = []
 
     cid = as_string(place.cid) or extract_maps_cid(place.maps_url)
     if cid:
         keys.append(f"cid:{cid}")
-    for cid_alias in place.cid_aliases:
-        if cid_alias:
-            keys.append(f"cid:{cid_alias}")
 
     google_id = as_string(place.google_id)
     if google_id:
@@ -6431,6 +6493,69 @@ def raw_place_match_keys(place: RawPlace, *, source_type: str | None = None) -> 
     return list(dict.fromkeys(keys))
 
 
+def raw_place_cid_alias_keys(place: RawPlace) -> list[str]:
+    primary_cid = as_string(place.cid) or extract_maps_cid(place.maps_url)
+    keys = [
+        f"cid:{cid_alias}"
+        for cid_alias in place.cid_aliases
+        if cid_alias and cid_alias != primary_cid
+    ]
+    return list(dict.fromkeys(keys))
+
+
+def raw_place_match_keys(place: RawPlace, *, source_type: str | None = None) -> list[str]:
+    return list(
+        dict.fromkeys(
+            [
+                *raw_place_primary_match_keys(place, source_type=source_type),
+                *raw_place_cid_alias_keys(place),
+            ]
+        )
+    )
+
+
+def raw_saved_list_primary_match_key_set(raw: RawSavedList) -> set[str]:
+    return {
+        key
+        for place in raw.places
+        for key in raw_place_primary_match_keys(
+            place,
+            source_type=raw.configured_source_type,
+        )
+    }
+
+
+def raw_place_lookup_keys(
+    place: RawPlace,
+    *,
+    source_type: str | None = None,
+    blocked_alias_keys: set[str] | None = None,
+) -> list[str]:
+    keys = raw_place_primary_match_keys(place, source_type=source_type)
+    for key in raw_place_cid_alias_keys(place):
+        if blocked_alias_keys is not None and key in blocked_alias_keys:
+            continue
+        keys.append(key)
+    return list(dict.fromkeys(keys))
+
+
+def raw_place_mapping_lookup_key(
+    mapping: Mapping[str, Any],
+    place: RawPlace,
+    *,
+    source_type: str | None = None,
+    blocked_alias_keys: set[str] | None = None,
+) -> str | None:
+    for key in raw_place_lookup_keys(
+        place,
+        source_type=source_type,
+        blocked_alias_keys=blocked_alias_keys,
+    ):
+        if key in mapping:
+            return key
+    return None
+
+
 def build_raw_place_preservation_index(
     raw: RawSavedList,
     *,
@@ -6438,8 +6563,13 @@ def build_raw_place_preservation_index(
 ) -> dict[str, RawPlace]:
     index: dict[str, RawPlace] = {}
     for place in raw.places:
-        for key in raw_place_match_keys(place, source_type=source_type):
+        for key in raw_place_primary_match_keys(place, source_type=source_type):
             index.setdefault(key, place)
+    primary_keys = set(index)
+    for place in raw.places:
+        for key in raw_place_cid_alias_keys(place):
+            if key not in primary_keys:
+                index.setdefault(key, place)
     return index
 
 
@@ -6467,15 +6597,17 @@ def preserve_existing_raw_place(
     if names_compatible and not refreshed_place.cid and existing_place.cid:
         updates["cid"] = existing_place.cid
         preserved_fields.append("cid")
-    if (
-        names_compatible
-        and existing_place.cid
-        and refreshed_place.cid
-        and existing_place.cid != refreshed_place.cid
-        and existing_place.cid not in refreshed_place.cid_aliases
-    ):
-        updates["cid_aliases"] = [*refreshed_place.cid_aliases, existing_place.cid]
-        preserved_fields.append("cid_alias")
+    existing_cid = as_string(existing_place.cid) or extract_maps_cid(existing_place.maps_url)
+    refreshed_cid = as_string(refreshed_place.cid) or extract_maps_cid(refreshed_place.maps_url)
+    if names_compatible:
+        preserved_cid_aliases = list(refreshed_place.cid_aliases)
+        for cid_alias in [*existing_place.cid_aliases, existing_cid]:
+            if not cid_alias or cid_alias == refreshed_cid or cid_alias in preserved_cid_aliases:
+                continue
+            preserved_cid_aliases.append(cid_alias)
+        if preserved_cid_aliases != refreshed_place.cid_aliases:
+            updates["cid_aliases"] = preserved_cid_aliases
+            preserved_fields.append("cid_alias")
     if names_compatible and not refreshed_place.maps_place_token and existing_place.maps_place_token:
         updates["maps_place_token"] = existing_place.maps_place_token
         preserved_fields.append("maps_place_token")
@@ -6977,10 +7109,19 @@ def preserve_existing_raw_saved_list(
 
     for refreshed_place in refreshed_payload.places:
         existing_place = None
-        for key in raw_place_match_keys(refreshed_place, source_type=source_type):
+        for key in raw_place_primary_match_keys(refreshed_place, source_type=source_type):
             existing_place = existing_index.get(key)
             if existing_place is not None:
                 break
+        if existing_place is None:
+            refreshed_name = as_string(refreshed_place.name)
+            for key in raw_place_cid_alias_keys(refreshed_place):
+                candidate = existing_index.get(key)
+                if candidate is None:
+                    continue
+                if raw_place_names_are_compatible(as_string(candidate.name), refreshed_name):
+                    existing_place = candidate
+                    break
 
         if existing_place is None:
             updated_places.append(refreshed_place)
@@ -7654,10 +7795,20 @@ def prune_places_cache_to_raw_places(
     payload: dict[str, EnrichmentCacheEntry],
     raw: RawSavedList,
 ) -> tuple[dict[str, EnrichmentCacheEntry], int]:
+    current_primary_keys = raw_saved_list_primary_match_key_set(raw)
     current_place_ids = {
+        key
+        for place in raw.places
+        for key in raw_place_lookup_keys(
+            place,
+            source_type=raw.configured_source_type,
+            blocked_alias_keys=current_primary_keys,
+        )
+    }
+    current_place_ids.update(
         stable_place_id(place, source_type=raw.configured_source_type)
         for place in raw.places
-    }
+    )
     if not current_place_ids:
         return {}, len(payload)
     pruned_payload = {

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7813,28 +7813,64 @@ def prune_places_cache_to_raw_places(
     payload: dict[str, EnrichmentCacheEntry],
     raw: RawSavedList,
 ) -> tuple[dict[str, EnrichmentCacheEntry], int]:
+    if not raw.places:
+        return {}, len(payload)
+
+    candidate_key_counts: Counter[str] = Counter()
+    place_candidate_keys: list[tuple[str, list[str]]] = []
     current_primary_keys = raw_saved_list_primary_match_key_set(raw)
-    current_place_ids = {
-        key
-        for place in raw.places
-        for key in raw_place_lookup_keys(
+    for place in raw.places:
+        place_id = stable_place_id(place, source_type=raw.configured_source_type)
+        candidate_keys = raw_place_lookup_keys(
             place,
             source_type=raw.configured_source_type,
             blocked_alias_keys=current_primary_keys,
         )
-    }
-    current_place_ids.update(
-        stable_place_id(place, source_type=raw.configured_source_type)
-        for place in raw.places
-    )
-    if not current_place_ids:
-        return {}, len(payload)
-    pruned_payload = {
-        place_id: entry
-        for place_id, entry in payload.items()
-        if place_id in current_place_ids
-    }
-    return pruned_payload, len(payload) - len(pruned_payload)
+        candidate_key_counts.update(candidate_keys)
+        place_candidate_keys.append((place_id, candidate_keys))
+
+    pruned_payload: dict[str, EnrichmentCacheEntry] = {}
+    used_payload_keys: set[str] = set()
+    changed_count = 0
+
+    for place_id, candidate_keys in place_candidate_keys:
+        candidates = [
+            (key, payload[key])
+            for key in candidate_keys
+            if key in payload and (key == place_id or candidate_key_counts[key] == 1)
+        ]
+        if not candidates:
+            continue
+
+        selected_key, selected_entry = max(
+            candidates,
+            key=lambda candidate: cache_entry_alias_priority(
+                candidate[1],
+                exact_match=candidate[0] == place_id,
+            ),
+        )
+        pruned_payload[place_id] = selected_entry
+        used_payload_keys.add(selected_key)
+        if selected_key != place_id:
+            changed_count += 1
+
+    changed_count += len(payload) - len(used_payload_keys)
+    return pruned_payload, changed_count
+
+
+def cache_entry_alias_priority(
+    entry: EnrichmentCacheEntry,
+    *,
+    exact_match: bool,
+) -> tuple[datetime, bool]:
+    for value in (entry.last_verified_at, entry.fetched_at):
+        if value is None:
+            continue
+        try:
+            return (parse_metadata_datetime(value), exact_match)
+        except ValueError:
+            continue
+    return (datetime.min.replace(tzinfo=UTC), exact_match)
 
 
 def export_places_cache_json(slug: str, payload: dict[str, EnrichmentCacheEntry]) -> None:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -3100,17 +3100,35 @@ def normalize_guide(
             source_type=raw.configured_source_type,
             blocked_alias_keys=current_primary_keys,
         )
-        place_trust_signals = (
-            [display_trust_signal(signal) for signal in trust_signals.get(place_id, [])]
-            if trust_signals is not None
-            else []
-        )
+        place_trust_signals: list[TrustSignal] = []
+        seen_trust_signals: set[tuple[Any, ...]] = set()
+        if trust_signals is not None:
+            for trust_signal_key in raw_place_lookup_keys(
+                place,
+                source_type=raw.configured_source_type,
+                blocked_alias_keys=current_primary_keys,
+            ):
+                for signal in trust_signals.get(trust_signal_key, []):
+                    dedupe_key = (
+                        signal.source,
+                        signal.label,
+                        signal.tier,
+                        signal.url,
+                        signal.title,
+                        signal.award_year,
+                    )
+                    if dedupe_key in seen_trust_signals:
+                        continue
+                    seen_trust_signals.add(dedupe_key)
+                    place_trust_signals.append(display_trust_signal(signal))
         override = place_override_for_ui_copy(
             slug,
             place_id,
             place_override_map.get(override_key, {}) if override_key is not None else {},
         )
         enrichment_cache_entry = enrichment_cache.get(cache_key) if cache_key is not None else None
+        if cache_key is not None and cache_key != place_id and place_id not in enrichment_cache:
+            enrichment_cache[place_id] = enrichment_cache[cache_key]
         enrichment = coerce_enrichment_place(enrichment_cache_entry)
         usable_enrichment_category = usable_enrichment_primary_category(
             enrichment,
@@ -7354,9 +7372,9 @@ def enrichment_refresh_reason(
 
 
 def enrichment_job_priority(
-    job: tuple[str, str, str, str, dict[str, Any], str | None, str | None]
+    job: tuple[str, str, str | None, str | None, str, str, dict[str, Any], str | None, str | None]
 ) -> tuple[int, str, str]:
-    slug, place_id, _place_name, refresh_reason, _place_payload, _city_name, _country_name = job
+    slug, place_id, _cache_key, _override_key, _place_name, refresh_reason, _place_payload, _city_name, _country_name = job
     return (
         ENRICHMENT_REFRESH_REASON_PRIORITY.get(refresh_reason, 99),
         slug,
@@ -12909,6 +12927,7 @@ def place_selector_matches(
         place.name,
         place.maps_url,
         place.cid,
+        *place.cid_aliases,
         place.google_id,
         place.maps_place_token,
     ):
@@ -12920,6 +12939,7 @@ def place_selector_matches(
     for prefix, candidate in (
         ("cid", place.cid),
         ("cid", extract_maps_cid(place.maps_url)),
+        *((("cid", cid_alias) for cid_alias in place.cid_aliases)),
         ("gms", place.maps_place_token),
         ("gms", extract_maps_place_token(place.maps_url)),
     ):

--- a/scripts/pipeline_models.py
+++ b/scripts/pipeline_models.py
@@ -163,6 +163,7 @@ class RawPlace(PipelineModel):
     lng: float | None = None
     maps_url: str
     cid: str | None = None
+    cid_aliases: list[str] = Field(default_factory=list)
     google_id: str | None = None
     maps_place_token: str | None = None
     rating: float | None = None

--- a/scripts/trust_signals.py
+++ b/scripts/trust_signals.py
@@ -877,10 +877,16 @@ def load_trust_signals_for_places(
         if place_id is None:
             continue
         match_signature = trust_match_signature(place.name, city_name, country_name)
+        enrichment_entry = trust_enrichment_entry_for_place(
+            enrichment_cache,
+            place,
+            place_id=place_id,
+            blocked_cid_alias_keys=blocked_cid_alias_keys,
+        )
         keys = trust_place_keys(
             place,
             place_id=place_id,
-            enrichment_entry=enrichment_cache.get(place_id),
+            enrichment_entry=enrichment_entry,
             blocked_cid_alias_keys=blocked_cid_alias_keys,
         )
         lookup_keys[place_id] = keys
@@ -986,10 +992,16 @@ def refresh_trust_signals_for_raw_guides(
             place_id = stable_place_ids.get((slug, index))
             if place_id is None:
                 continue
+            enrichment_entry = trust_enrichment_entry_for_place(
+                enrichment_cache,
+                place,
+                place_id=place_id,
+                blocked_cid_alias_keys=blocked_cid_alias_keys,
+            )
             keys = trust_place_keys(
                 place,
                 place_id=place_id,
-                enrichment_entry=enrichment_cache.get(place_id),
+                enrichment_entry=enrichment_entry,
                 blocked_cid_alias_keys=blocked_cid_alias_keys,
             )
             query = trust_search_query(
@@ -2710,6 +2722,44 @@ def trust_place_keys(
     if place.maps_place_token:
         keys.append(f"gms:{place.maps_place_token}")
     keys.append(place_id)
+    return list(dict.fromkeys(keys))
+
+
+def trust_enrichment_entry_for_place(
+    enrichment_cache: Mapping[str, EnrichmentCacheEntry],
+    place: RawPlace,
+    *,
+    place_id: str,
+    blocked_cid_alias_keys: set[str] | None = None,
+) -> EnrichmentCacheEntry | None:
+    for key in trust_enrichment_cache_lookup_keys(
+        place,
+        place_id=place_id,
+        blocked_cid_alias_keys=blocked_cid_alias_keys,
+    ):
+        entry = enrichment_cache.get(key)
+        if entry is not None:
+            return entry
+    return None
+
+
+def trust_enrichment_cache_lookup_keys(
+    place: RawPlace,
+    *,
+    place_id: str,
+    blocked_cid_alias_keys: set[str] | None = None,
+) -> list[str]:
+    keys: list[str] = [place_id]
+    if place.cid:
+        keys.append(f"cid:{place.cid}")
+    for cid_alias in place.cid_aliases:
+        cid_alias_key = f"cid:{cid_alias}" if cid_alias else None
+        if cid_alias_key and (blocked_cid_alias_keys is None or cid_alias_key not in blocked_cid_alias_keys):
+            keys.append(cid_alias_key)
+    if place.google_id:
+        keys.append(f"gid:{place.google_id.strip('/').replace('/', '-')}")
+    if place.maps_place_token:
+        keys.append(f"gms:{place.maps_place_token}")
     return list(dict.fromkeys(keys))
 
 

--- a/scripts/trust_signals.py
+++ b/scripts/trust_signals.py
@@ -2696,6 +2696,9 @@ def trust_place_keys(
             keys.append(f"gpid:{google_place_id}")
     if place.cid:
         keys.append(f"cid:{place.cid}")
+    for cid_alias in place.cid_aliases:
+        if cid_alias:
+            keys.append(f"cid:{cid_alias}")
     if place.google_id:
         keys.append(f"gid:{place.google_id.strip('/').replace('/', '-')}")
     if place.maps_place_token:

--- a/scripts/trust_signals.py
+++ b/scripts/trust_signals.py
@@ -871,6 +871,7 @@ def load_trust_signals_for_places(
         if location_context is not None and location_context[1]
         else infer_country_name(raw.title or slug)
     )
+    blocked_cid_alias_keys = raw_saved_list_current_cid_keys(raw)
     for index, place in enumerate(raw.places):
         place_id = stable_place_ids.get((slug, index))
         if place_id is None:
@@ -880,6 +881,7 @@ def load_trust_signals_for_places(
             place,
             place_id=place_id,
             enrichment_entry=enrichment_cache.get(place_id),
+            blocked_cid_alias_keys=blocked_cid_alias_keys,
         )
         lookup_keys[place_id] = keys
         all_keys.update(keys)
@@ -979,6 +981,7 @@ def refresh_trust_signals_for_raw_guides(
         ]
         guide_has_michelin_sources = bool(michelin_sources_by_guide.get(slug))
         guide_has_tabelog_sources = bool(tabelog_sources_by_guide.get(slug))
+        blocked_cid_alias_keys = raw_saved_list_current_cid_keys(raw)
         for index, place in enumerate(raw.places):
             place_id = stable_place_ids.get((slug, index))
             if place_id is None:
@@ -987,6 +990,7 @@ def refresh_trust_signals_for_raw_guides(
                 place,
                 place_id=place_id,
                 enrichment_entry=enrichment_cache.get(place_id),
+                blocked_cid_alias_keys=blocked_cid_alias_keys,
             )
             query = trust_search_query(
                 place.name,
@@ -2687,6 +2691,7 @@ def trust_place_keys(
     *,
     place_id: str,
     enrichment_entry: EnrichmentCacheEntry | None,
+    blocked_cid_alias_keys: set[str] | None = None,
 ) -> list[str]:
     keys: list[str] = []
     enrichment_place = enrichment_entry.place if enrichment_entry is not None else None
@@ -2697,14 +2702,19 @@ def trust_place_keys(
     if place.cid:
         keys.append(f"cid:{place.cid}")
     for cid_alias in place.cid_aliases:
-        if cid_alias:
-            keys.append(f"cid:{cid_alias}")
+        cid_alias_key = f"cid:{cid_alias}" if cid_alias else None
+        if cid_alias_key and (blocked_cid_alias_keys is None or cid_alias_key not in blocked_cid_alias_keys):
+            keys.append(cid_alias_key)
     if place.google_id:
         keys.append(f"gid:{place.google_id.strip('/').replace('/', '-')}")
     if place.maps_place_token:
         keys.append(f"gms:{place.maps_place_token}")
     keys.append(place_id)
     return list(dict.fromkeys(keys))
+
+
+def raw_saved_list_current_cid_keys(raw: RawSavedList) -> set[str]:
+    return {f"cid:{place.cid}" for place in raw.places if place.cid}
 
 
 def trust_search_query(place_name: str, *, city_name: str | None, country_name: str | None) -> str:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1399,6 +1399,39 @@ class BuildDataTests(unittest.TestCase):
             ],
         )
 
+    def test_preserve_existing_raw_saved_list_keeps_cid_alias_for_strong_identity_rename(self) -> None:
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Old Name",
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                    google_id="/g/11sameplace",
+                )
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Completely New Brand",
+                    maps_url="https://maps.google.com/?cid=222",
+                    cid="222",
+                    google_id="/g/11sameplace",
+                )
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="tokyo-japan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].cid, "222")
+        self.assertEqual(merged.places[0].cid_aliases, ["111"])
+
     def test_preserve_existing_raw_saved_list_uses_old_maps_url_cid_as_alias(self) -> None:
         existing_payload = RawSavedList(
             configured_source_type="google_list_url",
@@ -1588,6 +1621,31 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertIn("cid:111", keys)
         self.assertNotIn("cid:222", keys)
+
+    def test_trust_enrichment_entry_for_place_uses_cid_alias_cache_row(self) -> None:
+        entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="AFURI Harajuku",
+            matched=True,
+            place=EnrichmentPlace(
+                display_name="AFURI Harajuku",
+                google_place_id="place123",
+            ),
+        )
+
+        resolved = trust_signals.trust_enrichment_entry_for_place(
+            {"cid:6924437575605096209": entry},
+            RawPlace(
+                name="AFURI Harajuku",
+                maps_url="https://maps.google.com/?cid=9055794338847426964",
+                cid="9055794338847426964",
+                cid_aliases=["6924437575605096209"],
+            ),
+            place_id="cid:9055794338847426964",
+            blocked_cid_alias_keys={"cid:9055794338847426964"},
+        )
+
+        self.assertIs(resolved, entry)
 
     def test_place_selector_matches_cid_alias(self) -> None:
         place = RawPlace(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 from pydantic import ValidationError
 from PIL import Image
 
-from scripts import build_data
+from scripts import build_data, trust_signals
 from scripts.pipeline_models import (
     EnrichmentCacheEntry,
     EnrichmentPlace,
@@ -28,6 +28,7 @@ from scripts.pipeline_models import (
     RawPlace,
     RawSavedList,
     SourceConfig,
+    TrustSignal,
 )
 
 
@@ -1524,6 +1525,87 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(guide.places[0].id, "cid:9055794338847426964")
         self.assertEqual(guide.places[0].note, "Manual ramen note")
         self.assertEqual(guide.places[0].website, "https://afuri.example/")
+        self.assertIs(enrichment_cache["cid:9055794338847426964"], enrichment_cache[old_place_id])
+
+    def test_normalize_guide_uses_cid_alias_for_trust_signal_lookup(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo",
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="AFURI Harajuku",
+                    address="1 Chome-63-1 Jingumae, Shibuya City, Tokyo",
+                    maps_url="https://maps.google.com/?cid=9055794338847426964",
+                    cid="9055794338847426964",
+                    cid_aliases=["6924437575605096209"],
+                )
+            ],
+        )
+        signal = TrustSignal(
+            source="michelin",
+            label="Michelin Selected",
+            fetched_at="2026-04-20T00:00:00+00:00",
+            confidence="high",
+            match_reason="name_match",
+        )
+
+        with patch.object(build_data, "read_json", return_value={}):
+            guide = build_data.normalize_guide(
+                "tokyo-japan",
+                raw,
+                enrichment_cache={},
+                trust_signals={"cid:6924437575605096209": [signal]},
+            )
+
+        self.assertEqual([trust_signal.label for trust_signal in guide.places[0].trust_signals], ["Michelin Selected"])
+
+    def test_trust_place_keys_include_cid_aliases(self) -> None:
+        keys = trust_signals.trust_place_keys(
+            RawPlace(
+                name="AFURI Harajuku",
+                maps_url="https://maps.google.com/?cid=9055794338847426964",
+                cid="9055794338847426964",
+                cid_aliases=["6924437575605096209"],
+            ),
+            place_id="cid:9055794338847426964",
+            enrichment_entry=None,
+        )
+
+        self.assertIn("cid:6924437575605096209", keys)
+
+    def test_place_selector_matches_cid_alias(self) -> None:
+        place = RawPlace(
+            name="AFURI Harajuku",
+            maps_url="https://maps.google.com/?cid=9055794338847426964",
+            cid="9055794338847426964",
+            cid_aliases=["6924437575605096209"],
+        )
+
+        matches = build_data.place_selector_matches(
+            "tokyo-japan",
+            place,
+            place_id="cid:9055794338847426964",
+            selectors={"cid:6924437575605096209", "tokyo-japan:cid:6924437575605096209"},
+        )
+
+        self.assertEqual(matches, {"cid:6924437575605096209", "tokyo-japan:cid:6924437575605096209"})
+
+    def test_enrichment_job_priority_handles_alias_cache_tuple_shape(self) -> None:
+        priority = build_data.enrichment_job_priority(
+            (
+                "tokyo-japan",
+                "cid:9055794338847426964",
+                "cid:6924437575605096209",
+                None,
+                "AFURI Harajuku",
+                "missing-cache-entry",
+                {},
+                "Tokyo",
+                "Japan",
+            )
+        )
+
+        self.assertEqual(priority, (0, "tokyo-japan", "cid:9055794338847426964"))
 
     def test_preserve_existing_raw_saved_list_does_not_apply_to_non_matching_place(self) -> None:
         existing_payload = RawSavedList(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1573,6 +1573,22 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertIn("cid:6924437575605096209", keys)
 
+    def test_trust_place_keys_skip_shadowed_cid_aliases(self) -> None:
+        keys = trust_signals.trust_place_keys(
+            RawPlace(
+                name="AFURI Harajuku",
+                maps_url="https://maps.google.com/?cid=111",
+                cid="111",
+                cid_aliases=["222"],
+            ),
+            place_id="cid:111",
+            enrichment_entry=None,
+            blocked_cid_alias_keys={"cid:222"},
+        )
+
+        self.assertIn("cid:111", keys)
+        self.assertNotIn("cid:222", keys)
+
     def test_place_selector_matches_cid_alias(self) -> None:
         place = RawPlace(
             name="AFURI Harajuku",
@@ -1589,6 +1605,40 @@ class BuildDataTests(unittest.TestCase):
         )
 
         self.assertEqual(matches, {"cid:6924437575605096209", "tokyo-japan:cid:6924437575605096209"})
+
+    def test_place_selector_does_not_match_shadowed_cid_alias(self) -> None:
+        alias_holder = RawPlace(
+            name="Alias Holder",
+            maps_url="https://maps.google.com/?cid=111",
+            cid="111",
+            cid_aliases=["222"],
+        )
+        current_holder = RawPlace(
+            name="Current Holder",
+            maps_url="https://maps.google.com/?cid=222",
+            cid="222",
+        )
+
+        self.assertEqual(
+            build_data.place_selector_matches(
+                "tokyo-japan",
+                alias_holder,
+                place_id="cid:111",
+                selectors={"cid:222"},
+                blocked_alias_keys={"cid:111", "cid:222"},
+            ),
+            set(),
+        )
+        self.assertEqual(
+            build_data.place_selector_matches(
+                "tokyo-japan",
+                current_holder,
+                place_id="cid:222",
+                selectors={"cid:222"},
+                blocked_alias_keys={"cid:111", "cid:222"},
+            ),
+            {"cid:222"},
+        )
 
     def test_enrichment_job_priority_handles_alias_cache_tuple_shape(self) -> None:
         priority = build_data.enrichment_job_priority(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1355,6 +1355,176 @@ class BuildDataTests(unittest.TestCase):
             ),
         )
 
+    def test_preserve_existing_raw_saved_list_carries_forward_cid_aliases(self) -> None:
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="AFURI Harajuku",
+                    address="1 Chome-63-1 Jingumae, Shibuya City, Tokyo",
+                    maps_url="https://maps.google.com/?cid=6924437575605096209",
+                    cid="6924437575605096209",
+                    cid_aliases=["1111111111111111111"],
+                    google_id="/g/1pty5xgj1",
+                )
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="AFURI Harajuku",
+                    address="1 Chome-63-1 Jingumae, Shibuya City, Tokyo",
+                    maps_url="https://maps.google.com/?cid=9055794338847426964",
+                    cid="9055794338847426964",
+                    cid_aliases=["2222222222222222222"],
+                    google_id="/g/1pty5xgj1",
+                )
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="tokyo-japan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(
+            merged.places[0].cid_aliases,
+            [
+                "2222222222222222222",
+                "1111111111111111111",
+                "6924437575605096209",
+            ],
+        )
+
+    def test_preserve_existing_raw_saved_list_uses_old_maps_url_cid_as_alias(self) -> None:
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="AFURI Harajuku",
+                    address="1 Chome-63-1 Jingumae, Shibuya City, Tokyo",
+                    maps_url="https://maps.google.com/?cid=6924437575605096209",
+                    cid=None,
+                    google_id="/g/1pty5xgj1",
+                )
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="AFURI Harajuku",
+                    address="1 Chome-63-1 Jingumae, Shibuya City, Tokyo",
+                    maps_url="https://maps.google.com/?cid=9055794338847426964",
+                    cid="9055794338847426964",
+                    google_id="/g/1pty5xgj1",
+                )
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="tokyo-japan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].cid_aliases, ["6924437575605096209"])
+
+    def test_preserve_existing_raw_saved_list_does_not_let_alias_shadow_primary_cid(self) -> None:
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Original Cafe",
+                    address="1 Coffee St",
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                ),
+                RawPlace(
+                    name="Other Bakery",
+                    address="2 Bread St",
+                    maps_url="https://maps.google.com/?cid=222",
+                    cid="222",
+                ),
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Original Cafe",
+                    address=None,
+                    maps_url="https://maps.google.com/?cid=333",
+                    cid="333",
+                    cid_aliases=["222"],
+                )
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="tokyo-japan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertIsNone(merged.places[0].address)
+        self.assertEqual(merged.places[0].cid, "333")
+
+    def test_normalize_guide_uses_cid_alias_for_override_and_cache_lookup(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo",
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="AFURI Harajuku",
+                    address="1 Chome-63-1 Jingumae, Shibuya City, Tokyo",
+                    maps_url="https://maps.google.com/?cid=9055794338847426964",
+                    cid="9055794338847426964",
+                    cid_aliases=["6924437575605096209"],
+                )
+            ],
+        )
+        old_place_id = "cid:6924437575605096209"
+        enrichment_cache = {
+            old_place_id: EnrichmentCacheEntry(
+                fetched_at="2026-04-20T00:00:00+00:00",
+                source="google_maps_page",
+                query="AFURI Harajuku",
+                matched=True,
+                place=EnrichmentPlace(
+                    display_name="AFURI Harajuku",
+                    website="https://afuri.example/",
+                ),
+            )
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            list_overrides_dir = tmpdir_path / "lists"
+            place_overrides_dir = tmpdir_path / "places"
+            list_overrides_dir.mkdir()
+            place_overrides_dir.mkdir()
+            (place_overrides_dir / "tokyo-japan.json").write_text(
+                json.dumps({old_place_id: {"note": "Manual ramen note"}}),
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(build_data, "LIST_OVERRIDES_DIR", list_overrides_dir),
+                patch.object(build_data, "PLACE_OVERRIDES_DIR", place_overrides_dir),
+            ):
+                guide = build_data.normalize_guide(
+                    "tokyo-japan",
+                    raw,
+                    enrichment_cache=enrichment_cache,
+                )
+
+        self.assertEqual(guide.places[0].id, "cid:9055794338847426964")
+        self.assertEqual(guide.places[0].note, "Manual ramen note")
+        self.assertEqual(guide.places[0].website, "https://afuri.example/")
+
     def test_preserve_existing_raw_saved_list_does_not_apply_to_non_matching_place(self) -> None:
         existing_payload = RawSavedList(
             configured_source_type="google_list_url",
@@ -14198,6 +14368,42 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(pruned_count, 1)
         self.assertEqual(list(pruned_payload), ["cid:14063537238082844765"])
         self.assertIs(pruned_payload["cid:14063537238082844765"], current_entry)
+
+    def test_prune_places_cache_to_raw_places_keeps_cid_alias_rows(self) -> None:
+        raw = RawSavedList(
+            title="Tokyo",
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="AFURI Harajuku",
+                    maps_url="https://maps.google.com/?cid=9055794338847426964",
+                    cid="9055794338847426964",
+                    cid_aliases=["6924437575605096209"],
+                )
+            ],
+        )
+        alias_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-20T00:00:00+00:00",
+            query="AFURI old cid",
+            matched=True,
+        )
+        stale_entry = EnrichmentCacheEntry(
+            fetched_at="2026-04-01T00:00:00+00:00",
+            query="Deleted",
+            matched=True,
+        )
+
+        pruned_payload, pruned_count = build_data.prune_places_cache_to_raw_places(
+            {
+                "cid:6924437575605096209": alias_entry,
+                "cid:123": stale_entry,
+            },
+            raw,
+        )
+
+        self.assertEqual(pruned_count, 1)
+        self.assertEqual(list(pruned_payload), ["cid:6924437575605096209"])
+        self.assertIs(pruned_payload["cid:6924437575605096209"], alias_entry)
 
     def test_prune_places_cache_to_raw_places_drops_all_rows_for_empty_guide(self) -> None:
         raw = RawSavedList(title="Empty", places=[])

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -14451,7 +14451,7 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(list(pruned_payload), ["cid:14063537238082844765"])
         self.assertIs(pruned_payload["cid:14063537238082844765"], current_entry)
 
-    def test_prune_places_cache_to_raw_places_keeps_cid_alias_rows(self) -> None:
+    def test_prune_places_cache_to_raw_places_migrates_cid_alias_rows(self) -> None:
         raw = RawSavedList(
             title="Tokyo",
             configured_source_type="google_list_url",
@@ -14483,9 +14483,9 @@ class BuildDataTests(unittest.TestCase):
             raw,
         )
 
-        self.assertEqual(pruned_count, 1)
-        self.assertEqual(list(pruned_payload), ["cid:6924437575605096209"])
-        self.assertIs(pruned_payload["cid:6924437575605096209"], alias_entry)
+        self.assertEqual(pruned_count, 2)
+        self.assertEqual(list(pruned_payload), ["cid:9055794338847426964"])
+        self.assertIs(pruned_payload["cid:9055794338847426964"], alias_entry)
 
     def test_prune_places_cache_to_raw_places_drops_all_rows_for_empty_guide(self) -> None:
         raw = RawSavedList(title="Empty", places=[])

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1309,6 +1309,52 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(merged.places[0].added_by, ListAuthor(name="Second Curator", profile_id="second-id"))
         self.assertTrue(merged.places[0].is_favorite)
 
+    def test_preserve_existing_raw_saved_list_keeps_old_cid_alias_when_cid_changes(self) -> None:
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="AFURI Harajuku",
+                    address="1 Chome-63-1 Jingumae, Shibuya City, Tokyo",
+                    lat=35.670991,
+                    lng=139.703802,
+                    maps_url="https://maps.google.com/?cid=6924437575605096209",
+                    cid="6924437575605096209",
+                    google_id="/g/1pty5xgj1",
+                )
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="AFURI Harajuku",
+                    address="1 Chome-63-1 Jingumae, Shibuya City, Tokyo",
+                    lat=35.670991,
+                    lng=139.703802,
+                    maps_url="https://maps.google.com/?cid=9055794338847426964",
+                    cid="9055794338847426964",
+                    google_id="/g/1pty5xgj1",
+                )
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="tokyo-japan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].cid, "9055794338847426964")
+        self.assertEqual(merged.places[0].cid_aliases, ["6924437575605096209"])
+        self.assertIn(
+            "cid:6924437575605096209",
+            build_data.raw_place_match_keys(
+                merged.places[0],
+                source_type=merged.configured_source_type,
+            ),
+        )
+
     def test_preserve_existing_raw_saved_list_does_not_apply_to_non_matching_place(self) -> None:
         existing_payload = RawSavedList(
             configured_source_type="google_list_url",


### PR DESCRIPTION
## Summary
- add raw place CID aliases so old CID-keyed overrides still resolve after scraper CID parsing changes
- preserve the previous CID as an alias when a refreshed raw place matches by identity but emits a different CID

## Tests
- `uv run ruff check scripts/build_data.py scripts/pipeline_models.py tests/python/test_build_data.py`
- `uv run python3 -m unittest tests.python.test_build_data.BuildDataTests.test_preserve_existing_raw_saved_list_keeps_old_cid_alias_when_cid_changes tests.python.test_build_data.BuildDataTests.test_preserve_existing_raw_saved_list_keeps_stronger_prior_place_fields`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core place identity, enrichment cache migration, and cross-place alias blocking; wrong alias logic could mis-attach overrides, cache, or trust data between venues.
> 
> **Overview**
> Adds **`cid_aliases`** on raw places and keeps the previous Google Maps CID when a scraper refresh changes the primary CID but the place still matches (name or strong Google identity).
> 
> **Lookup and cache behavior** now resolves overrides, enrichment cache, trust signals, and place selectors through alias keys, while **blocking aliases** that would shadow another place’s primary CID in the same list. Guide normalization dedupes trust signals across alias keys and can backfill cache entries under the canonical place id. Enrichment jobs migrate alias-keyed cache rows to stable ids and drop stale alias keys after refresh. **`prune_places_cache_to_raw_places`** picks the best cache row per place (recency + exact id preference) instead of only matching stable place ids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5faa6632470ead797dcd45aeff2055f29b61c781. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved place matching to recognize alternate identifiers, helping the system connect records even when a place’s main ID changes.
  * Added support for preserving and using alias IDs across enrichment, trust signals, and selector matching.

* **Bug Fixes**
  * Reduced duplicate or incorrect matches by preferring canonical IDs while still falling back to valid aliases.
  * Improved cache selection so enrichment updates and saved place data stay aligned with the best available match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->