### PR TITLE
feat: add deterministic conversational search UX

### DIFF
--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -1,4 +1,5 @@
 import { loadSearchIndex, searchPlaces } from "./place-search.js";
+import { buildSearchConversation, buildSearchSuggestions } from "./search-conversation.js";
 
 function getTagComparisonValue(value) {
   const normalizedText = String(value || "")
@@ -650,6 +651,9 @@ if (root) {
   const reviewSummary = root.querySelector("[data-review-summary]");
   const metricMenus = Array.from(root.querySelectorAll(".metric-filter-menu"));
   const selectedTagsRow = root.querySelector("[data-selected-tags]");
+  const searchConversation = root.querySelector("[data-guide-search-conversation]");
+  const searchConversationSummary = root.querySelector("[data-guide-search-summary]");
+  const searchConversationSuggestions = root.querySelector("[data-guide-search-suggestions]");
   const suggestionList = root.querySelector("[data-suggestion-list]");
   const suggestionGroup = suggestionList?.closest(".control-group") || null;
   const autocomplete = root.querySelector("[data-tag-autocomplete]");
@@ -1455,6 +1459,31 @@ if (root) {
       resultsCount.textContent = `${visibleCards.length} place${visibleCards.length === 1 ? "" : "s"}${suffix}`;
     }
 
+    if (searchConversation && searchConversationSummary && searchConversationSuggestions) {
+      searchConversation.hidden = !query || !searchState;
+      searchConversationSummary.textContent =
+        query && searchState
+          ? buildSearchConversation({
+              count: visibleCards.length,
+              parsed: searchState.parsed,
+              scopeLabel: "this guide",
+            })
+          : "";
+      searchConversationSuggestions.replaceChildren(
+        ...(query && searchState
+          ? buildSearchSuggestions({ parsed: searchState.parsed, results: searchState.results })
+          : []
+        ).map((suggestion) => {
+          const button = document.createElement("button");
+          button.className = "tag-pill ui-tag-pill";
+          button.type = "button";
+          button.dataset.guideSearchSuggestion = suggestion.query;
+          button.textContent = suggestion.label;
+          return button;
+        }),
+      );
+    }
+
     if (emptyState) {
       emptyState.dataset.visible = visibleCards.length === 0 ? "true" : "false";
       emptyState.textContent = buildEmptyStateMessage({
@@ -1499,6 +1528,16 @@ if (root) {
     consumeCompletedTags();
     updateAutocomplete();
     update();
+  });
+
+  searchConversationSuggestions?.addEventListener("click", (event) => {
+    const button = event.target.closest("[data-guide-search-suggestion]");
+    const suggestion = button?.dataset.guideSearchSuggestion || "";
+    if (!suggestion || !searchInput) return;
+
+    searchInput.value = `${searchInput.value.trim()} ${suggestion}`.trim();
+    searchInput.focus();
+    update("search-suggestion");
   });
 
   searchInput?.addEventListener("keydown", (event) => {

--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -1460,18 +1460,24 @@ if (root) {
     }
 
     if (searchConversation && searchConversationSummary && searchConversationSuggestions) {
+      const visiblePlaceIds = new Set(
+        visibleCards.map((card) => card.dataset.placeId).filter(Boolean),
+      );
+      const visibleSearchResults = searchState
+        ? searchState.results.filter((result) => visiblePlaceIds.has(result.entry.id))
+        : [];
       searchConversation.hidden = !query || !searchState;
       searchConversationSummary.textContent =
         query && searchState
           ? buildSearchConversation({
               count: visibleCards.length,
               parsed: searchState.parsed,
-              scopeLabel: "this guide",
+              scopeLabel: hasAdditionalFilters ? "the active filters in this guide" : "this guide",
             })
           : "";
       searchConversationSuggestions.replaceChildren(
         ...(query && searchState
-          ? buildSearchSuggestions({ parsed: searchState.parsed, results: searchState.results })
+          ? buildSearchSuggestions({ parsed: searchState.parsed, results: visibleSearchResults })
           : []
         ).map((suggestion) => {
           const button = document.createElement("button");

--- a/public/scripts/guide-filters.js
+++ b/public/scripts/guide-filters.js
@@ -1477,6 +1477,7 @@ if (root) {
           const button = document.createElement("button");
           button.className = "tag-pill ui-tag-pill";
           button.type = "button";
+          button.dataset.guideSearchSuggestionAction = suggestion.action;
           button.dataset.guideSearchSuggestion = suggestion.query;
           button.textContent = suggestion.label;
           return button;
@@ -1512,6 +1513,20 @@ if (root) {
       button.hidden = !mapFramePlaceIds;
     });
 
+    const urlParams = new URLSearchParams(window.location.search);
+    if (query) {
+      urlParams.set("q", query);
+    } else {
+      urlParams.delete("q");
+    }
+    urlParams.delete("tag");
+    selectedTags.forEach((tag) => urlParams.append("tag", tag));
+    const nextSearch = urlParams.toString();
+    const nextUrl = `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ""}${window.location.hash}`;
+    if (`${window.location.pathname}${window.location.search}${window.location.hash}` !== nextUrl) {
+      history.replaceState(history.state, "", nextUrl);
+    }
+
     root.dispatchEvent(
       new CustomEvent("guide:places-updated", {
         bubbles: true,
@@ -1533,9 +1548,11 @@ if (root) {
   searchConversationSuggestions?.addEventListener("click", (event) => {
     const button = event.target.closest("[data-guide-search-suggestion]");
     const suggestion = button?.dataset.guideSearchSuggestion || "";
-    if (!suggestion || !searchInput) return;
+    const action = button?.dataset.guideSearchSuggestionAction || "append";
+    if (!searchInput) return;
 
-    searchInput.value = `${searchInput.value.trim()} ${suggestion}`.trim();
+    searchInput.value =
+      action === "clear" ? "" : `${searchInput.value.trim()} ${suggestion}`.trim();
     searchInput.focus();
     update("search-suggestion");
   });

--- a/public/scripts/home-browser.js
+++ b/public/scripts/home-browser.js
@@ -1,6 +1,7 @@
 import { nearbyGuidesForLocation } from "./home-browser-nearby.js";
 import { parseHomeBrowserHash, serializeHomeBrowserHash } from "./home-browser-state.js";
 import { loadSearchIndex, searchGuides, searchPlaces } from "./place-search.js";
+import { buildSearchConversation, buildSearchSuggestions } from "./search-conversation.js";
 
 const GROUP_LIMIT = 5;
 const INDIVIDUAL_RESULT_LIMIT = 24;
@@ -20,7 +21,9 @@ if (root) {
   const homeGuideMap = root.querySelector("[data-home-guide-map]");
   const globalResults = root.querySelector("[data-global-search-results]");
   const globalResultsTitle = root.querySelector("[data-global-search-title]");
+  const globalResultsConversation = root.querySelector("[data-global-search-conversation]");
   const globalResultsSummary = root.querySelector("[data-global-search-summary]");
+  const globalResultsSuggestions = root.querySelector("[data-global-search-suggestions]");
   const globalResultsToolbar = root.querySelector("[data-global-search-toolbar]");
   const globalResultsList = root.querySelector("[data-global-search-list]");
   const groupedResultsList = root.querySelector("[data-grouped-search-list]");
@@ -370,6 +373,43 @@ if (root) {
     );
   };
 
+  const renderSearchConversation = (query, state, visibleResults) => {
+    if (!globalResultsConversation || !globalResultsSummary || !globalResultsSuggestions) {
+      return;
+    }
+
+    if (!query || !state) {
+      globalResultsConversation.hidden = true;
+      globalResultsSummary.textContent = "";
+      globalResultsSuggestions.replaceChildren();
+      return;
+    }
+
+    const scopeLabel = activeCountry
+      ? countryLabel(activeCountry)
+      : nearbyGuideState
+        ? "nearby guides"
+        : "your guides";
+    globalResultsConversation.hidden = false;
+    globalResultsSummary.textContent = buildSearchConversation({
+      count: visibleResults.length,
+      parsed: state.parsed,
+      scopeLabel,
+    });
+    globalResultsSuggestions.replaceChildren(
+      ...buildSearchSuggestions({ parsed: state.parsed, results: visibleResults }).map(
+        (suggestion) => {
+          const button = document.createElement("button");
+          button.className = "tag-pill ui-tag-pill";
+          button.type = "button";
+          button.dataset.globalSearchSuggestion = suggestion.query;
+          button.textContent = suggestion.label;
+          return button;
+        },
+      ),
+    );
+  };
+
   const renderGlobalSearch = (query, placeSearchState, filteredResults) => {
     if (!globalResults || !globalResultsList || !groupedResultsList || !globalResultsEmpty) {
       return;
@@ -393,6 +433,7 @@ if (root) {
       if (globalResultsSummary) {
         globalResultsSummary.textContent = "";
       }
+      renderSearchConversation("", null, []);
       updateSearchViewButtons();
       return;
     }
@@ -413,6 +454,7 @@ if (root) {
       if (globalResultsSummary) {
         globalResultsSummary.textContent = "";
       }
+      renderSearchConversation("", null, []);
       return;
     }
 
@@ -429,6 +471,7 @@ if (root) {
       if (globalResultsSummary) {
         globalResultsSummary.textContent = "Loading index...";
       }
+      renderSearchConversation("", null, []);
       return;
     }
 
@@ -473,34 +516,7 @@ if (root) {
           : `${pluralize(visibleResults.length, "matching place")}`;
     }
 
-    if (globalResultsSummary) {
-      const parsed = [
-        ...state.parsed.vibes.map((vibe) => vibe.replaceAll("-", " ")),
-        ...state.parsed.categories,
-      ];
-      const summaryBits = [];
-
-      if (parsed.length > 0) {
-        summaryBits.push(parsed.join(" · "));
-      }
-
-      if (activeCountry) {
-        summaryBits.push(`Filtered to ${countryLabel(activeCountry)}`);
-      } else if (nearbyGuideState) {
-        summaryBits.push("Filtered to guides near you");
-      }
-
-      if (searchResultView === "grouped" && visibleResults.length > 0) {
-        summaryBits.push(`Showing up to ${GROUP_LIMIT} places per guide`);
-      } else if (
-        searchResultView === "individual" &&
-        visibleResults.length > INDIVIDUAL_RESULT_LIMIT
-      ) {
-        summaryBits.push(`Showing top ${INDIVIDUAL_RESULT_LIMIT} individual matches`);
-      }
-
-      globalResultsSummary.textContent = summaryBits.join(" · ") || "All guides";
-    }
+    renderSearchConversation(query, state, visibleResults);
 
     updateSearchViewButtons();
   };
@@ -700,6 +716,16 @@ if (root) {
     toggle.addEventListener("click", () => {
       setSearchView(toggle.dataset.searchView || "grouped");
     });
+  });
+
+  globalResultsSuggestions?.addEventListener("click", (event) => {
+    const button = event.target.closest("[data-global-search-suggestion]");
+    const suggestion = button?.dataset.globalSearchSuggestion || "";
+    if (!suggestion || !searchInput) return;
+
+    searchInput.value = `${searchInput.value.trim()} ${suggestion}`.trim();
+    searchInput.focus();
+    update();
   });
 
   window.addEventListener("hashchange", () => {

--- a/public/scripts/home-browser.js
+++ b/public/scripts/home-browser.js
@@ -391,11 +391,15 @@ if (root) {
         ? "nearby guides"
         : "your guides";
     globalResultsConversation.hidden = false;
-    globalResultsSummary.textContent = buildSearchConversation({
+    const summary = buildSearchConversation({
       count: visibleResults.length,
       parsed: state.parsed,
       scopeLabel,
     });
+    globalResultsSummary.textContent =
+      searchResultView === "individual" && visibleResults.length > INDIVIDUAL_RESULT_LIMIT
+        ? `${summary} Showing the top ${INDIVIDUAL_RESULT_LIMIT} individual matches.`
+        : summary;
     globalResultsSuggestions.replaceChildren(
       ...buildSearchSuggestions({ parsed: state.parsed, results: visibleResults }).map(
         (suggestion) => {

--- a/public/scripts/home-browser.js
+++ b/public/scripts/home-browser.js
@@ -402,6 +402,7 @@ if (root) {
           const button = document.createElement("button");
           button.className = "tag-pill ui-tag-pill";
           button.type = "button";
+          button.dataset.globalSearchSuggestionAction = suggestion.action;
           button.dataset.globalSearchSuggestion = suggestion.query;
           button.textContent = suggestion.label;
           return button;
@@ -721,9 +722,11 @@ if (root) {
   globalResultsSuggestions?.addEventListener("click", (event) => {
     const button = event.target.closest("[data-global-search-suggestion]");
     const suggestion = button?.dataset.globalSearchSuggestion || "";
-    if (!suggestion || !searchInput) return;
+    const action = button?.dataset.globalSearchSuggestionAction || "append";
+    if (!searchInput) return;
 
-    searchInput.value = `${searchInput.value.trim()} ${suggestion}`.trim();
+    searchInput.value =
+      action === "clear" ? "" : `${searchInput.value.trim()} ${suggestion}`.trim();
     searchInput.focus();
     update();
   });

--- a/public/scripts/search-conversation.js
+++ b/public/scripts/search-conversation.js
@@ -53,10 +53,15 @@ export function buildSearchSuggestions({ parsed = {}, results = [], limit = 4 } 
     (Array.isArray(entry.vibe_tags) ? entry.vibe_tags : []).forEach(addCandidate);
   });
 
+  if (candidates.size === 0 && activeTerms.size > 0) {
+    return [{ action: "clear", label: "Clear search", query: "" }];
+  }
+
   return [...candidates.entries()]
     .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
     .slice(0, limit)
     .map(([query]) => ({
+      action: "append",
       label: query.replace(/\b\w/g, (letter) => letter.toUpperCase()),
       query,
     }));

--- a/public/scripts/search-conversation.js
+++ b/public/scripts/search-conversation.js
@@ -1,0 +1,63 @@
+const normalizePhrase = (value) =>
+  String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/-/g, " ")
+    .replace(/\s+/g, " ");
+
+const pluralize = (count, singular, plural = `${singular}s`) =>
+  `${count} ${count === 1 ? singular : plural}`;
+
+const joinTerms = (terms) => {
+  if (terms.length === 0) return "";
+  if (terms.length === 1) return terms[0];
+  if (terms.length === 2) return `${terms[0]} and ${terms[1]}`;
+  return `${terms.slice(0, -1).join(", ")}, and ${terms.at(-1)}`;
+};
+
+export function buildSearchConversation({ count = 0, parsed = {}, scopeLabel = "" } = {}) {
+  const categories = Array.isArray(parsed.categories) ? parsed.categories : [];
+  const vibes = Array.isArray(parsed.vibes) ? parsed.vibes : [];
+  const terms = [...new Set([...vibes, ...categories].map(normalizePhrase).filter(Boolean))];
+  const scope = scopeLabel ? ` in ${scopeLabel}` : "";
+
+  if (count === 0) {
+    const understood = terms.length > 0 ? ` for ${joinTerms(terms)}` : "";
+    return `No places matched${understood}${scope}. Try removing a term or choosing a suggested refinement.`;
+  }
+
+  const descriptor = terms.length > 0 ? ` for ${joinTerms(terms)}` : "";
+  return `I found ${pluralize(count, "place")}${descriptor}${scope}. Results are matched from saved place details and tags.`;
+}
+
+export function buildSearchSuggestions({ parsed = {}, results = [], limit = 4 } = {}) {
+  const activeTerms = new Set(
+    [
+      ...(Array.isArray(parsed.categories) ? parsed.categories : []),
+      ...(Array.isArray(parsed.vibes) ? parsed.vibes : []),
+    ]
+      .map(normalizePhrase)
+      .filter(Boolean),
+  );
+  const candidates = new Map();
+
+  const addCandidate = (value) => {
+    const term = normalizePhrase(value);
+    if (!term || activeTerms.has(term)) return;
+    candidates.set(term, (candidates.get(term) || 0) + 1);
+  };
+
+  results.forEach(({ entry } = {}) => {
+    if (!entry) return;
+    addCandidate(entry.category);
+    (Array.isArray(entry.vibe_tags) ? entry.vibe_tags : []).forEach(addCandidate);
+  });
+
+  return [...candidates.entries()]
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .slice(0, limit)
+    .map(([query]) => ({
+      label: query.replace(/\b\w/g, (letter) => letter.toUpperCase()),
+      query,
+    }));
+}

--- a/public/scripts/search-conversation.js
+++ b/public/scripts/search-conversation.js
@@ -18,7 +18,10 @@ const joinTerms = (terms) => {
 export function buildSearchConversation({ count = 0, parsed = {}, scopeLabel = "" } = {}) {
   const categories = Array.isArray(parsed.categories) ? parsed.categories : [];
   const vibes = Array.isArray(parsed.vibes) ? parsed.vibes : [];
-  const terms = [...new Set([...vibes, ...categories].map(normalizePhrase).filter(Boolean))];
+  const unmatchedTerms = Array.isArray(parsed.unmatchedTerms) ? parsed.unmatchedTerms : [];
+  const terms = [
+    ...new Set([...vibes, ...categories, ...unmatchedTerms].map(normalizePhrase).filter(Boolean)),
+  ];
   const scope = scopeLabel ? ` in ${scopeLabel}` : "";
 
   if (count === 0) {

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -390,6 +390,10 @@ const guideJsonLd = [
                 <div class="tag-autocomplete" data-tag-autocomplete hidden></div>
               </div>
               <div class="selected-tag-row" data-selected-tags hidden></div>
+              <div class="search-conversation" data-guide-search-conversation hidden>
+                <p class="small-copy ui-copy ui-copy--sm" data-guide-search-summary></p>
+                <div class="tag-row ui-tag-row" data-guide-search-suggestions></div>
+              </div>
             </div>
 
             {areaFilters.length > 0 && (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -334,7 +334,10 @@ const homeJsonLd = [
         </div>
       </div>
       <div class="search-results-toolbar" data-global-search-toolbar>
-        <p class="small-copy ui-copy ui-copy--sm" data-global-search-summary></p>
+        <div class="search-conversation" data-global-search-conversation hidden>
+          <p class="small-copy ui-copy ui-copy--sm" data-global-search-summary></p>
+          <div class="tag-row ui-tag-row" data-global-search-suggestions></div>
+        </div>
         <fieldset class="search-view-toggle-group">
           <legend class="visually-hidden">Search results view</legend>
           <button

--- a/tests/e2e/home-browser.spec.ts
+++ b/tests/e2e/home-browser.spec.ts
@@ -32,6 +32,10 @@ test("filters guides by country and renders global place search results", async 
   await page.locator("[data-home-search-input]").fill("museum");
   await expect(page.locator("[data-global-search-results]")).toBeVisible();
   await expect(page.locator("[data-global-search-title]")).toContainText("matching");
+  await expect(page.locator("[data-global-search-summary]")).toContainText(
+    "Results are matched from saved place details and tags.",
+  );
+  await expect(page.locator("[data-global-search-suggestions] button").first()).toBeVisible();
   await expect(page.locator("[data-global-search-disclosure]")).toHaveCount(0);
   await expect(page.locator("[data-grouped-search-list]")).toBeVisible();
   await expect(page.locator("[data-grouped-search-list]")).toContainText("Taipei");

--- a/tests/frontend/searchConversation.test.mjs
+++ b/tests/frontend/searchConversation.test.mjs
@@ -50,9 +50,18 @@ describe("search conversation", () => {
         ],
       }),
     ).toEqual([
-      { label: "Coffee Shop", query: "coffee shop" },
-      { label: "Laptop Friendly", query: "laptop friendly" },
-      { label: "Cozy", query: "cozy" },
+      { action: "append", label: "Coffee Shop", query: "coffee shop" },
+      { action: "append", label: "Laptop Friendly", query: "laptop friendly" },
+      { action: "append", label: "Cozy", query: "cozy" },
     ]);
+  });
+
+  it("offers a deterministic broadening action when there are no result signals", () => {
+    expect(
+      buildSearchSuggestions({
+        parsed: { categories: ["cafe"], vibes: [] },
+        results: [],
+      }),
+    ).toEqual([{ action: "clear", label: "Clear search", query: "" }]);
   });
 });

--- a/tests/frontend/searchConversation.test.mjs
+++ b/tests/frontend/searchConversation.test.mjs
@@ -30,6 +30,18 @@ describe("search conversation", () => {
     );
   });
 
+  it("includes literal query terms that the parser did not classify", () => {
+    expect(
+      buildSearchConversation({
+        count: 1,
+        parsed: { categories: [], unmatchedTerms: ["shibuya"], vibes: ["quiet"] },
+        scopeLabel: "this guide",
+      }),
+    ).toBe(
+      "I found 1 place for quiet and shibuya in this guide. Results are matched from saved place details and tags.",
+    );
+  });
+
   it("suggests frequent unused categories and vibe tags as refinements", () => {
     expect(
       buildSearchSuggestions({

--- a/tests/frontend/searchConversation.test.mjs
+++ b/tests/frontend/searchConversation.test.mjs
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSearchConversation,
+  buildSearchSuggestions,
+} from "../../public/scripts/search-conversation.js";
+
+describe("search conversation", () => {
+  it("turns deterministic parser state into a scoped result summary", () => {
+    expect(
+      buildSearchConversation({
+        count: 2,
+        parsed: { categories: ["cafe"], vibes: ["quiet"] },
+        scopeLabel: "Tokyo",
+      }),
+    ).toBe(
+      "I found 2 places for quiet and cafe in Tokyo. Results are matched from saved place details and tags.",
+    );
+  });
+
+  it("explains empty results without implying a model answered", () => {
+    expect(
+      buildSearchConversation({
+        count: 0,
+        parsed: { categories: [], vibes: ["date-night"] },
+        scopeLabel: "this guide",
+      }),
+    ).toBe(
+      "No places matched for date night in this guide. Try removing a term or choosing a suggested refinement.",
+    );
+  });
+
+  it("suggests frequent unused categories and vibe tags as refinements", () => {
+    expect(
+      buildSearchSuggestions({
+        parsed: { categories: ["cafe"], vibes: ["quiet"] },
+        results: [
+          {
+            entry: {
+              category: "Coffee shop",
+              vibe_tags: ["quiet", "laptop-friendly", "cozy"],
+            },
+          },
+          {
+            entry: {
+              category: "Coffee shop",
+              vibe_tags: ["laptop-friendly"],
+            },
+          },
+        ],
+      }),
+    ).toEqual([
+      { label: "Coffee Shop", query: "coffee shop" },
+      { label: "Laptop Friendly", query: "laptop friendly" },
+      { label: "Cozy", query: "cozy" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

Adds transparent, client-side search guidance to both global and guide-scoped place search.

- Renders concise summaries from the existing parsed category/vibe state.
- Offers result-distribution refinement chips that append deterministic search terms, plus a clear-search broadening action for empty result sets.
- Keeps retrieval and filtering entirely static; the copy explicitly identifies saved place details and tags as the source.
- Keeps guide query/tag refinements shareable through the existing deep-link URL.
- Adds unit and browser coverage.

## Related Issue

Fixes #23

## How Has This Been Tested?

- `bun run test:frontend -- tests/frontend/searchConversation.test.mjs tests/frontend/placeSearch.test.mjs`
- `bun run check`
- `bun run test:e2e -- tests/e2e/home-browser.spec.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only client behavior on top of existing static search; guide URL updates use replaceState without server changes.
> 
> **Overview**
> Adds **client-side “search conversation”** UI on the home global place search and on guide-scoped search: a short summary from parsed categories/vibes/unmatched terms plus **refinement chips** that append terms or clear the query.
> 
> New shared module `search-conversation.js` drives copy and suggestions from existing `place-search` parser state and visible results (no LLM). Home replaces the ad-hoc summary string with this flow; guides show the panel when a query is active and suggestions respect filters already applied.
> 
> Guide search also **syncs `q` and `tag` into the URL** via `history.replaceState` so filtered searches stay shareable. Unit tests cover conversation/suggestion logic; e2e asserts the home summary and suggestion buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2821edb8841bfa11c4a61ada7eaefdd9069d825b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversational search summaries and refinement suggestions to guide and global search.
  * Search suggestions can append filters or clear the current search.
  * Search URLs now preserve the active query and selected tags for easier sharing and navigation.

* **Bug Fixes**
  * Search summaries and suggestions now reflect only currently visible results.
  * Improved handling of empty queries, unavailable search data, and searches with no matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->