### PR TITLE
Guard raw refreshes against incoherent coordinate shifts

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -171,10 +171,32 @@ RAW_PLACE_ADDRESS_TOKEN_ALIASES = {
     "parkway": "pkwy",
     "place": "pl",
     "road": "rd",
+    "route": "rte",
     "square": "sq",
     "street": "st",
     "terrace": "ter",
 }
+RAW_PLACE_STREET_SUFFIX_TOKENS = frozenset(
+    {*RAW_PLACE_ADDRESS_TOKEN_ALIASES.values(), "way"}
+)
+RAW_PLACE_UNIT_PREFIX_TOKENS = frozenset(
+    {
+        "apartment",
+        "apt",
+        "building",
+        "floor",
+        "fl",
+        "level",
+        "lvl",
+        "room",
+        "rm",
+        "ste",
+        "suite",
+        "tower",
+        "unit",
+    }
+)
+RAW_PLACE_UNIT_NUMBER_LABEL_TOKENS = frozenset({"no", "number"})
 SOURCE_HTTP_TIMEOUT_SECONDS = 30
 SOURCE_HTTP_USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
@@ -6828,12 +6850,12 @@ def raw_place_coordinate_address_is_stable(
     if existing_address_key == refreshed_address_key:
         return True
 
-    existing_street_numbers = address_street_numbers(existing_address)
-    refreshed_street_numbers = address_street_numbers(refreshed_address)
+    existing_street_numbers = raw_place_coordinate_street_numbers(existing_address)
+    refreshed_street_numbers = raw_place_coordinate_street_numbers(refreshed_address)
     if (
         existing_street_numbers
         and refreshed_street_numbers
-        and not existing_street_numbers & refreshed_street_numbers
+        and existing_street_numbers != refreshed_street_numbers
     ):
         return False
 
@@ -6868,9 +6890,100 @@ def raw_place_coordinate_address_key(address: str) -> str | None:
 
 
 def raw_place_coordinate_address_tokens(address_key: str) -> set[str]:
-    return {
+    return set(raw_place_coordinate_address_token_list(address_key))
+
+
+def raw_place_coordinate_address_token_list(address_key: str) -> list[str]:
+    return [
         RAW_PLACE_ADDRESS_TOKEN_ALIASES.get(token, token)
         for token in address_key.split()
+    ]
+
+
+def raw_place_coordinate_street_numbers(address: str) -> set[str]:
+    parts = [part.strip() for part in re.split(r"[,、]", address) if part.strip()]
+    if not parts:
+        parts = [address]
+
+    parsed_parts: list[tuple[str, list[str]]] = []
+    for part in parts:
+        address_key = raw_place_coordinate_address_key(part)
+        if address_key is None:
+            continue
+        tokens = raw_place_coordinate_address_token_list(address_key)
+        if any(re.search(r"\d", token) for token in tokens):
+            parsed_parts.append((part, tokens))
+
+    for part, tokens in parsed_parts:
+        if set(tokens) & RAW_PLACE_STREET_SUFFIX_TOKENS:
+            return raw_place_coordinate_part_street_numbers(part, tokens)
+
+    for part, tokens in parsed_parts:
+        if part.lstrip().startswith("#") or set(tokens) & RAW_PLACE_UNIT_PREFIX_TOKENS:
+            continue
+        return {
+            number
+            for token in tokens
+            for number in re.findall(r"\d+", token)
+        }
+    return set()
+
+
+def raw_place_coordinate_part_street_numbers(
+    part: str,
+    tokens: list[str],
+) -> set[str]:
+    slash_unit_match = re.match(
+        r"\s*(?:unit\s+)?[^/\s,]+\s*/\s*(\d+(?:\s*-\s*\d+)?)",
+        part,
+        re.IGNORECASE,
+    )
+    if slash_unit_match is not None:
+        return set(re.findall(r"\d+", slash_unit_match.group(1)))
+
+    numeric_tokens = {
+        index: set(re.findall(r"\d+", token))
+        for index, token in enumerate(tokens)
+        if re.search(r"\d", token)
+    }
+    skipped_indexes: set[int] = set()
+    for index, token in enumerate(tokens):
+        if token not in RAW_PLACE_UNIT_PREFIX_TOKENS:
+            continue
+        candidate_index = index + 1
+        if (
+            candidate_index < len(tokens)
+            and tokens[candidate_index] in RAW_PLACE_UNIT_NUMBER_LABEL_TOKENS
+        ):
+            candidate_index += 1
+        if candidate_index in numeric_tokens:
+            skipped_indexes.add(candidate_index)
+    if part.lstrip().startswith("#") and numeric_tokens:
+        skipped_indexes.add(min(numeric_tokens))
+
+    candidate_indexes = [
+        index
+        for index in numeric_tokens
+        if index not in skipped_indexes
+    ]
+    if not candidate_indexes:
+        return set()
+
+    street_suffix_index = max(
+        index
+        for index, token in enumerate(tokens)
+        if token in RAW_PLACE_STREET_SUFFIX_TOKENS
+    )
+    before_suffix = [index for index in candidate_indexes if index < street_suffix_index]
+    selected_indexes = before_suffix or [
+        index
+        for index in candidate_indexes
+        if index > street_suffix_index
+    ][:1]
+    return {
+        number
+        for index in selected_indexes
+        for number in numeric_tokens[index]
     }
 
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7124,6 +7124,7 @@ def raw_place_coordinate_address_key(address: str) -> str | None:
             and "LATIN" in unicodedata.name(character, "")
         )
     normalized = unicodedata.normalize("NFKC", "".join(without_latin_diacritics))
+    normalized = re.sub(r"(?<=\w)['’ʼ](?=\w)", "", normalized)
     normalized_characters = [
         character
         if unicodedata.category(character)[0] in {"L", "M", "N"}
@@ -7179,10 +7180,18 @@ def raw_place_coordinate_token_is_ordinal(token: str) -> bool:
 
 
 def raw_place_coordinate_part_has_street_intersection(tokens: list[str]) -> bool:
-    return sum(
+    ordinal_street_count = sum(
         raw_place_coordinate_token_is_ordinal(token)
         and index + 1 < len(tokens)
         and tokens[index + 1] in RAW_PLACE_STREET_SUFFIX_TOKENS
+        for index, token in enumerate(tokens)
+    )
+    if ordinal_street_count >= 2:
+        return True
+    return sum(
+        index > 0
+        and token in RAW_PLACE_STREET_SUFFIX_TOKENS
+        and tokens[index - 1] not in RAW_PLACE_UNIT_PREFIX_TOKENS
         for index, token in enumerate(tokens)
     ) >= 2
 
@@ -7699,7 +7708,9 @@ def raw_place_coordinate_country_token_identities() -> tuple[
         "UK": "GB",
         "UAE": "AE",
         "US": "US",
+        "U.S.": "US",
         "USA": "US",
+        "U.S.A.": "US",
         "Korea": "KR",
         "South Korea": "KR",
         "韓国": "KR",

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6716,7 +6716,7 @@ def preserve_existing_raw_place(
     if names_compatible and refreshed_place.added_by is None and existing_place.added_by is not None:
         updates["added_by"] = existing_place.added_by
         preserved_fields.append("added_by")
-    if names_compatible and raw_place_coordinates_should_be_preserved(
+    if raw_place_coordinates_should_be_preserved(
         existing_place,
         refreshed_place,
     ):

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6906,27 +6906,42 @@ def raw_place_coordinate_address_is_stable(
 
     existing_street_numbers = raw_place_coordinate_street_numbers(existing_address)
     refreshed_street_numbers = raw_place_coordinate_street_numbers(refreshed_address)
+    existing_comparison_address = existing_address
+    refreshed_comparison_address = refreshed_address
     if (
         existing_street_numbers
         and refreshed_street_numbers
         and existing_street_numbers != refreshed_street_numbers
     ):
-        return False
+        collapsed_existing_address = raw_place_coordinate_collapse_street_number_range(
+            existing_address,
+            refreshed_street_numbers,
+        )
+        collapsed_refreshed_address = raw_place_coordinate_collapse_street_number_range(
+            refreshed_address,
+            existing_street_numbers,
+        )
+        if collapsed_existing_address is not None:
+            existing_comparison_address = collapsed_existing_address
+        elif collapsed_refreshed_address is not None:
+            refreshed_comparison_address = collapsed_refreshed_address
+        else:
+            return False
 
     existing_parts, existing_country = raw_place_coordinate_address_comparison_key(
-        existing_address
+        existing_comparison_address
     )
     refreshed_parts, refreshed_country = raw_place_coordinate_address_comparison_key(
-        refreshed_address
+        refreshed_comparison_address
     )
     if existing_country and not refreshed_country:
         refreshed_parts, _ = raw_place_coordinate_address_comparison_key(
-            refreshed_address,
+            refreshed_comparison_address,
             country_hint=existing_country,
         )
     elif refreshed_country and not existing_country:
         existing_parts, _ = raw_place_coordinate_address_comparison_key(
-            existing_address,
+            existing_comparison_address,
             country_hint=refreshed_country,
         )
     if not existing_parts or existing_parts != refreshed_parts:
@@ -7018,6 +7033,8 @@ def raw_place_coordinate_part_has_street_marker(
         address_key,
     ):
         return True
+    if re.search(r"(?:strasse|straße)\b", address_key):
+        return True
     return bool(re.search(r"(?:丁目|番地|號|号|路|街|道|巷|弄)", part))
 
 
@@ -7069,7 +7086,12 @@ def raw_place_coordinate_address_comparison_key(
     street_numbers = raw_place_coordinate_street_numbers(address)
     country: str | None = None
     normalized_address = raw_place_coordinate_strip_japanese_postal_prefix(address)
-    for raw_part in re.split(r"[,、]", normalized_address):
+    raw_parts = [
+        part
+        for part in re.split(r"[,、]", normalized_address)
+        if raw_place_coordinate_address_key(part) is not None
+    ]
+    for raw_part_index, raw_part in enumerate(raw_parts):
         part = re.sub(
             r"^\s*(?:unit\s+)?[^/\s,]+\s*/\s*",
             "",
@@ -7109,10 +7131,16 @@ def raw_place_coordinate_address_comparison_key(
 
             index = unit_identifier_index + 1
         for country_suffix, country_code in raw_place_coordinate_country_token_identities():
+            if (
+                raw_part_index != len(raw_parts) - 1
+                and country_code != country_hint
+            ):
+                continue
             suffix_length = len(country_suffix)
             if tuple(comparison_part_tokens[-suffix_length:]) == country_suffix:
                 del comparison_part_tokens[-suffix_length:]
-                country = country_code
+                if raw_part_index == len(raw_parts) - 1:
+                    country = country_code
                 break
 
         comparison_part_tokens = [
@@ -7134,6 +7162,30 @@ def raw_place_coordinate_address_comparison_key(
         for part in comparison_parts
     ]
     return tuple(sorted(comparison_parts)), country
+
+
+def raw_place_coordinate_collapse_street_number_range(
+    address: str,
+    endpoint_numbers: set[str],
+) -> str | None:
+    if len(endpoint_numbers) != 1:
+        return None
+    endpoint = next(iter(endpoint_numbers))
+    replaced = False
+
+    def collapse(match: re.Match[str]) -> str:
+        nonlocal replaced
+        if endpoint not in {match.group("start"), match.group("end")}:
+            return match.group(0)
+        replaced = True
+        return endpoint
+
+    collapsed = re.sub(
+        r"(?<!\d)(?P<start>\d+)\s*[-–—]\s*(?P<end>\d+)(?!\d)",
+        collapse,
+        address,
+    )
+    return collapsed if replaced else None
 
 
 def raw_place_coordinate_token_is_postal(
@@ -7175,7 +7227,11 @@ def raw_place_coordinate_token_is_postal(
 
 def raw_place_coordinate_strip_japanese_postal_prefix(address: str) -> str:
     normalized = unicodedata.normalize("NFKC", address)
-    return re.sub(r"^\s*〒\s*\d{3}\s*-\s*\d{4}\s*", "", normalized)
+    return re.sub(
+        r"\s*〒\s*\d{3}\s*-\s*\d{4}\s*(?:[,、]\s*)?",
+        " ",
+        normalized,
+    )
 
 
 @lru_cache(maxsize=1)

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7179,7 +7179,11 @@ def raw_place_coordinate_token_is_ordinal(token: str) -> bool:
     return token.startswith("ordinal_")
 
 
-def raw_place_coordinate_part_has_street_intersection(tokens: list[str]) -> bool:
+def raw_place_coordinate_part_has_street_intersection(
+    tokens: list[str],
+    *,
+    part: str | None = None,
+) -> bool:
     ordinal_street_count = sum(
         raw_place_coordinate_token_is_ordinal(token)
         and index + 1 < len(tokens)
@@ -7188,6 +7192,11 @@ def raw_place_coordinate_part_has_street_intersection(tokens: list[str]) -> bool
     )
     if ordinal_street_count >= 2:
         return True
+    if part is None or re.search(
+        r"(?:&|\b(?:and|at)\b)",
+        unicodedata.normalize("NFKC", part).casefold(),
+    ) is None:
+        return False
     return sum(
         index > 0
         and token in RAW_PLACE_STREET_SUFFIX_TOKENS
@@ -7225,8 +7234,8 @@ def raw_place_coordinate_address_has_street_level_evidence(address: str) -> bool
             return True
 
     if any(
-        raw_place_coordinate_part_has_street_intersection(tokens)
-        for _, _, tokens in parsed_parts
+        raw_place_coordinate_part_has_street_intersection(tokens, part=part)
+        for part, _, tokens in parsed_parts
     ):
         return True
 
@@ -7423,7 +7432,10 @@ def raw_place_coordinate_address_comparison_key(
         if address_key is None:
             continue
         part_tokens = raw_place_coordinate_address_token_list(address_key)
-        if raw_place_coordinate_part_has_street_intersection(part_tokens):
+        if raw_place_coordinate_part_has_street_intersection(
+            part_tokens,
+            part=raw_part,
+        ):
             part_tokens = [token for token in part_tokens if token != "and"]
         uppercase_word_suffixes = {
             tuple(raw_place_coordinate_address_token_list(word_key))

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6859,24 +6859,19 @@ def raw_place_coordinate_address_is_stable(
     ):
         return False
 
-    existing_tokens = raw_place_coordinate_address_tokens(existing_address_key)
-    refreshed_tokens = raw_place_coordinate_address_tokens(refreshed_address_key)
-    for shorter_tokens, longer_tokens in (
-        (existing_tokens, refreshed_tokens),
-        (refreshed_tokens, existing_tokens),
-    ):
-        numeric_tokens = {
-            token
-            for token in shorter_tokens
-            if any(character.isdigit() for character in token)
-        }
-        if (
-            len(shorter_tokens) >= 3
-            and numeric_tokens
-            and shorter_tokens <= longer_tokens
-        ):
-            return True
-    return False
+    existing_tokens, existing_country = raw_place_coordinate_address_comparison_key(
+        existing_address
+    )
+    refreshed_tokens, refreshed_country = raw_place_coordinate_address_comparison_key(
+        refreshed_address
+    )
+    if not existing_tokens or existing_tokens != refreshed_tokens:
+        return False
+    return bool(
+        existing_country is None
+        or refreshed_country is None
+        or existing_country == refreshed_country
+    )
 
 
 def raw_place_coordinate_address_key(address: str) -> str | None:
@@ -6889,10 +6884,6 @@ def raw_place_coordinate_address_key(address: str) -> str | None:
     return compact or None
 
 
-def raw_place_coordinate_address_tokens(address_key: str) -> set[str]:
-    return set(raw_place_coordinate_address_token_list(address_key))
-
-
 def raw_place_coordinate_address_token_list(address_key: str) -> list[str]:
     return [
         RAW_PLACE_ADDRESS_TOKEN_ALIASES.get(token, token)
@@ -6900,7 +6891,134 @@ def raw_place_coordinate_address_token_list(address_key: str) -> list[str]:
     ]
 
 
+def raw_place_coordinate_address_comparison_key(
+    address: str,
+) -> tuple[tuple[str, ...], str | None]:
+    tokens: list[str] = []
+    normalized_address = raw_place_coordinate_strip_japanese_postal_prefix(address)
+    for raw_part in re.split(r"[,、]", normalized_address):
+        part = re.sub(
+            r"^\s*(?:unit\s+)?[^/\s,]+\s*/\s*",
+            "",
+            raw_part,
+            flags=re.IGNORECASE,
+        )
+        part = re.sub(r"#\s*[\w-]+", "", part)
+        address_key = raw_place_coordinate_address_key(part)
+        if address_key is None:
+            continue
+        part_tokens = raw_place_coordinate_address_token_list(address_key)
+        comparison_part_tokens: list[str] = []
+        index = 0
+        while index < len(part_tokens):
+            token = part_tokens[index]
+            unit_identifier_index = index + 1
+            if (
+                unit_identifier_index < len(part_tokens)
+                and part_tokens[unit_identifier_index]
+                in RAW_PLACE_UNIT_NUMBER_LABEL_TOKENS
+            ):
+                unit_identifier_index += 1
+            is_unit_designator = bool(
+                token in RAW_PLACE_UNIT_PREFIX_TOKENS
+                and unit_identifier_index < len(part_tokens)
+                and part_tokens[unit_identifier_index]
+                not in RAW_PLACE_STREET_SUFFIX_TOKENS
+                and (
+                    not comparison_part_tokens
+                    or comparison_part_tokens[-1] in RAW_PLACE_STREET_SUFFIX_TOKENS
+                )
+            )
+            if not is_unit_designator:
+                comparison_part_tokens.append(token)
+                index += 1
+                continue
+
+            index = unit_identifier_index + 1
+        tokens.extend(comparison_part_tokens)
+
+    country: str | None = None
+    for country_suffix, country_code in raw_place_coordinate_country_token_identities():
+        suffix_length = len(country_suffix)
+        if tuple(tokens[-suffix_length:]) == country_suffix:
+            del tokens[-suffix_length:]
+            country = country_code
+            break
+    return tuple(tokens), country
+
+
+def raw_place_coordinate_strip_japanese_postal_prefix(address: str) -> str:
+    normalized = unicodedata.normalize("NFKC", address)
+    return re.sub(r"^\s*〒\s*\d{3}\s*-\s*\d{4}\s*", "", normalized)
+
+
+@lru_cache(maxsize=1)
+def raw_place_coordinate_country_token_identities() -> tuple[
+    tuple[tuple[str, ...], str],
+    ...,
+]:
+    country_alias_codes = {
+        "England": "GB",
+        "Scotland": "GB",
+        "Wales": "GB",
+        "Northern Ireland": "GB",
+        "UK": "GB",
+        "UAE": "AE",
+        "USA": "US",
+        "Korea": "KR",
+        "South Korea": "KR",
+        "韓国": "KR",
+        "Taiwan": "TW",
+        "台灣": "TW",
+        "台湾": "TW",
+        "Trinidad & Tobago": "TT",
+        "España": "ES",
+        "Espanya": "ES",
+        "スペイン": "ES",
+        "フランス": "FR",
+        "モナコ": "MC",
+        "日本": "JP",
+        "中国": "CN",
+        "Ivory Coast": "CI",
+    }
+    suffix_identities: dict[tuple[str, ...], str] = {}
+    for country in pycountry.countries:
+        country_code = country.alpha_2
+        for attribute in ("name", "official_name", "common_name"):
+            country_name = getattr(country, attribute, None)
+            if country_name:
+                raw_place_coordinate_add_country_token_identity(
+                    suffix_identities,
+                    country_name,
+                    country_code,
+                )
+    for country_name, country_code in country_alias_codes.items():
+        raw_place_coordinate_add_country_token_identity(
+            suffix_identities,
+            country_name,
+            country_code,
+        )
+    return tuple(
+        sorted(
+            suffix_identities.items(),
+            key=lambda item: (-len(item[0]), item[0]),
+        )
+    )
+
+
+def raw_place_coordinate_add_country_token_identity(
+    identities: dict[tuple[str, ...], str],
+    country_name: str,
+    country_code: str,
+) -> None:
+    address_key = raw_place_coordinate_address_key(country_name)
+    if address_key is None:
+        return
+    identities[tuple(raw_place_coordinate_address_token_list(address_key))] = country_code
+
+
 def raw_place_coordinate_street_numbers(address: str) -> set[str]:
+    address = raw_place_coordinate_strip_japanese_postal_prefix(address)
     parts = [part.strip() for part in re.split(r"[,、]", address) if part.strip()]
     if not parts:
         parts = [address]

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6838,6 +6838,8 @@ def raw_place_coordinate_address_is_stable(
     existing_address = as_string(existing_place.address)
     if not existing_address:
         return False
+    if not raw_place_coordinate_address_has_street_level_evidence(existing_address):
+        return False
 
     refreshed_address = as_string(refreshed_place.address)
     if not refreshed_address:
@@ -6889,6 +6891,40 @@ def raw_place_coordinate_address_token_list(address_key: str) -> list[str]:
         RAW_PLACE_ADDRESS_TOKEN_ALIASES.get(token, token)
         for token in address_key.split()
     ]
+
+
+def raw_place_coordinate_address_has_street_level_evidence(address: str) -> bool:
+    normalized_address = raw_place_coordinate_strip_japanese_postal_prefix(address)
+    for part in re.split(r"[,、]", normalized_address):
+        address_key = raw_place_coordinate_address_key(part)
+        if address_key is None:
+            continue
+        tokens = raw_place_coordinate_address_token_list(address_key)
+        numeric_indexes = {
+            index
+            for index, token in enumerate(tokens)
+            if any(character.isdigit() for character in token)
+        }
+        if not numeric_indexes:
+            continue
+
+        street_suffix_indexes = {
+            index
+            for index, token in enumerate(tokens)
+            if token in RAW_PLACE_STREET_SUFFIX_TOKENS
+        }
+        if any(index > 0 for index in street_suffix_indexes):
+            return True
+        if set(tokens) & {"hwy", "rte"}:
+            return True
+        if re.search(
+            r"\b(?:allee|allée|av|avenida|calle|carrer|chaussee|chaussée|chemin|corso|impasse|piazza|quai|rua|rue|strasse|straße|via)\b",
+            address_key,
+        ):
+            return True
+        if re.search(r"(?:丁目|番地|號|号|路|街|道|巷|弄)", part):
+            return True
+    return False
 
 
 def raw_place_coordinate_address_comparison_key(
@@ -7112,6 +7148,14 @@ def raw_place_maps_url_should_be_preserved(
     existing_url = as_string(existing_place.maps_url)
     refreshed_url = as_string(refreshed_place.maps_url)
     if not existing_url or existing_url == refreshed_url:
+        return False
+    if (
+        not raw_place_names_are_compatible(
+            as_string(existing_place.name),
+            as_string(refreshed_place.name),
+        )
+        and not raw_place_maps_url_has_embedded_identity(existing_url)
+    ):
         return False
     if google_maps_uri_strength(existing_url) < google_maps_uri_strength(refreshed_url):
         return False

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6575,6 +6575,10 @@ def raw_place_primary_match_keys(place: RawPlace, *, source_type: str | None = N
     if maps_place_token:
         keys.append(f"gms:{maps_place_token}")
 
+    query_place_id = extract_maps_query_place_id(place.maps_url)
+    if query_place_id:
+        keys.append(f"gpid:{query_place_id}")
+
     name = as_string(place.name)
     lat = as_float(place.lat)
     lng = as_float(place.lng)
@@ -6838,6 +6842,14 @@ def raw_place_coordinate_identity_matches(left: RawPlace, right: RawPlace) -> bo
     if raw_place_strong_google_identity_matches(left, right):
         return True
 
+    left_query_place_id = extract_maps_query_place_id(left.maps_url)
+    right_query_place_id = extract_maps_query_place_id(right.maps_url)
+    if (
+        left_query_place_id is not None
+        and left_query_place_id == right_query_place_id
+    ):
+        return True
+
     left_cids = {
         cid
         for cid in [raw_place_cid_identity(left), *left.cid_aliases]
@@ -6848,7 +6860,27 @@ def raw_place_coordinate_identity_matches(left: RawPlace, right: RawPlace) -> bo
         for cid in [raw_place_cid_identity(right), *right.cid_aliases]
         if cid
     }
-    return bool(left_cids & right_cids)
+    if left_cids & right_cids:
+        return True
+
+    return bool(
+        raw_place_names_are_compatible(
+            as_string(left.name),
+            as_string(right.name),
+        )
+        and raw_place_has_durable_google_identity(left)
+        and not raw_place_has_durable_google_identity(right)
+    )
+
+
+def raw_place_has_durable_google_identity(place: RawPlace) -> bool:
+    return bool(
+        raw_place_google_id_identity(place)
+        or raw_place_maps_place_token_identity(place)
+        or raw_place_cid_identity(place)
+        or extract_maps_query_place_id(place.maps_url)
+        or any(as_string(cid_alias) for cid_alias in place.cid_aliases)
+    )
 
 
 def raw_place_coordinate_address_is_stable(
@@ -6887,6 +6919,16 @@ def raw_place_coordinate_address_is_stable(
     refreshed_parts, refreshed_country = raw_place_coordinate_address_comparison_key(
         refreshed_address
     )
+    if existing_country and not refreshed_country:
+        refreshed_parts, _ = raw_place_coordinate_address_comparison_key(
+            refreshed_address,
+            country_hint=existing_country,
+        )
+    elif refreshed_country and not existing_country:
+        existing_parts, _ = raw_place_coordinate_address_comparison_key(
+            existing_address,
+            country_hint=refreshed_country,
+        )
     if not existing_parts or existing_parts != refreshed_parts:
         return False
     return bool(
@@ -6915,11 +6957,15 @@ def raw_place_coordinate_address_token_list(address_key: str) -> list[str]:
 
 def raw_place_coordinate_address_has_street_level_evidence(address: str) -> bool:
     normalized_address = raw_place_coordinate_strip_japanese_postal_prefix(address)
+    parsed_parts: list[tuple[str, str, list[str]]] = []
     for part in re.split(r"[,、]", normalized_address):
         address_key = raw_place_coordinate_address_key(part)
         if address_key is None:
             continue
         tokens = raw_place_coordinate_address_token_list(address_key)
+        parsed_parts.append((part, address_key, tokens))
+
+    for part, address_key, tokens in parsed_parts:
         numeric_indexes = {
             index
             for index, token in enumerate(tokens)
@@ -6927,28 +6973,97 @@ def raw_place_coordinate_address_has_street_level_evidence(address: str) -> bool
         }
         if not numeric_indexes:
             continue
-
-        street_suffix_indexes = {
-            index
-            for index, token in enumerate(tokens)
-            if token in RAW_PLACE_STREET_SUFFIX_TOKENS
-        }
-        if any(index > 0 for index in street_suffix_indexes):
-            return True
-        if set(tokens) & {"hwy", "rte"}:
-            return True
-        if re.search(
-            r"\b(?:allee|allée|av|avenida|calle|carrer|chaussee|chaussée|chemin|corso|impasse|piazza|quai|rua|rue|strasse|straße|via)\b",
+        if raw_place_coordinate_part_is_route_only(tokens):
+            continue
+        if raw_place_coordinate_part_has_street_marker(
+            part,
             address_key,
+            tokens,
         ):
             return True
-        if re.search(r"(?:丁目|番地|號|号|路|街|道|巷|弄)", part):
-            return True
+
+    for index, (part, address_key, tokens) in enumerate(parsed_parts):
+        if not raw_place_coordinate_part_has_street_marker(
+            part,
+            address_key,
+            tokens,
+        ):
+            continue
+        if set(tokens) & {"hwy", "rte"}:
+            continue
+        for neighbor_index in (index - 1, index + 1):
+            if not 0 <= neighbor_index < len(parsed_parts):
+                continue
+            if raw_place_coordinate_part_is_premise_number(
+                parsed_parts[neighbor_index][2]
+            ):
+                return True
     return False
+
+
+def raw_place_coordinate_part_has_street_marker(
+    part: str,
+    address_key: str,
+    tokens: list[str],
+) -> bool:
+    street_suffix_indexes = {
+        index
+        for index, token in enumerate(tokens)
+        if token in RAW_PLACE_STREET_SUFFIX_TOKENS
+    }
+    if any(index > 0 for index in street_suffix_indexes):
+        return True
+    if re.search(
+        r"\b(?:allee|allée|av|avenida|calle|carrer|chaussee|chaussée|chemin|chome|corso|impasse|piazza|quai|r|rua|rue|str|strasse|straße|via)\b",
+        address_key,
+    ):
+        return True
+    return bool(re.search(r"(?:丁目|番地|號|号|路|街|道|巷|弄)", part))
+
+
+def raw_place_coordinate_part_is_premise_number(tokens: list[str]) -> bool:
+    if not tokens or not any(character.isdigit() for character in tokens[0]):
+        return False
+    for token in tokens:
+        compact = re.sub(r"[^a-z0-9]", "", token)
+        if compact.isdigit() and 1 <= len(compact) <= 4:
+            continue
+        if compact.isalpha() and len(compact) <= 3:
+            continue
+        return False
+    return True
+
+
+def raw_place_coordinate_part_is_route_only(tokens: list[str]) -> bool:
+    route_indexes = [
+        index
+        for index, token in enumerate(tokens)
+        if token in {"hwy", "rte"}
+    ]
+    if not route_indexes:
+        return False
+    route_qualifiers = {"i", "interstate", "m", "state", "us"}
+    for index, token in enumerate(tokens[: route_indexes[0]]):
+        compact = re.sub(r"[^a-z0-9]", "", token)
+        if not compact or not compact[0].isdigit():
+            continue
+        previous_token = tokens[index - 1] if index > 0 else None
+        if previous_token in route_qualifiers | RAW_PLACE_UNIT_PREFIX_TOKENS:
+            continue
+        if (
+            previous_token in RAW_PLACE_UNIT_NUMBER_LABEL_TOKENS
+            and index > 1
+            and tokens[index - 2] in RAW_PLACE_UNIT_PREFIX_TOKENS
+        ):
+            continue
+        return False
+    return True
 
 
 def raw_place_coordinate_address_comparison_key(
     address: str,
+    *,
+    country_hint: str | None = None,
 ) -> tuple[tuple[tuple[str, ...], ...], str | None]:
     comparison_parts: list[tuple[str, ...]] = []
     street_numbers = raw_place_coordinate_street_numbers(address)
@@ -7011,6 +7126,13 @@ def raw_place_coordinate_address_comparison_key(
         ]
         if comparison_part_tokens:
             comparison_parts.append(tuple(comparison_part_tokens))
+    subdivision_identities = raw_place_coordinate_subdivision_token_identities(
+        country or country_hint
+    )
+    comparison_parts = [
+        subdivision_identities.get(part, part)
+        for part in comparison_parts
+    ]
     return tuple(sorted(comparison_parts)), country
 
 
@@ -7118,7 +7240,42 @@ def raw_place_coordinate_add_country_token_identity(
     address_key = raw_place_coordinate_address_key(country_name)
     if address_key is None:
         return
+    if address_key == "georgia":
+        return
     identities[tuple(raw_place_coordinate_address_token_list(address_key))] = country_code
+
+
+@lru_cache(maxsize=None)
+def raw_place_coordinate_subdivision_token_identities(
+    country_code: str | None,
+) -> dict[tuple[str, ...], tuple[str, ...]]:
+    candidates: dict[tuple[str, ...], set[str]] = {}
+    for subdivision in pycountry.subdivisions:
+        subdivision_code = as_string(getattr(subdivision, "code", None))
+        subdivision_name = as_string(getattr(subdivision, "name", None))
+        if not subdivision_code or not subdivision_name:
+            continue
+        subdivision_country_code = subdivision_code.split("-", 1)[0]
+        if country_code and subdivision_country_code != country_code:
+            continue
+
+        name_key = raw_place_coordinate_address_key(subdivision_name)
+        if name_key:
+            name_tokens = tuple(raw_place_coordinate_address_token_list(name_key))
+            candidates.setdefault(name_tokens, set()).add(subdivision_code)
+        if country_code and "-" in subdivision_code:
+            code_key = raw_place_coordinate_address_key(
+                subdivision_code.split("-", 1)[1]
+            )
+            if code_key:
+                code_tokens = tuple(raw_place_coordinate_address_token_list(code_key))
+                candidates.setdefault(code_tokens, set()).add(subdivision_code)
+
+    return {
+        tokens: ("subdivision", next(iter(subdivision_codes)).casefold())
+        for tokens, subdivision_codes in candidates.items()
+        if len(subdivision_codes) == 1
+    }
 
 
 def raw_place_coordinate_street_numbers(address: str) -> set[str]:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6770,6 +6770,46 @@ def build_raw_place_preservation_index(
     return index
 
 
+def raw_place_identity_loss_fallback_candidate(
+    *,
+    existing_payload: RawSavedList,
+    refreshed_payload: RawSavedList,
+    refreshed_place: RawPlace,
+) -> RawPlace | None:
+    refreshed_name = as_string(refreshed_place.name)
+    if (
+        not refreshed_name
+        or as_string(refreshed_place.address)
+        or raw_place_has_durable_google_identity(refreshed_place)
+    ):
+        return None
+
+    compatible_refreshed_places = [
+        place
+        for place in refreshed_payload.places
+        if (place_name := as_string(place.name))
+        and raw_place_names_are_compatible(place_name, refreshed_name)
+    ]
+    if len(compatible_refreshed_places) != 1:
+        return None
+
+    compatible_existing_places = [
+        place
+        for place in existing_payload.places
+        if (place_name := as_string(place.name))
+        and raw_place_names_are_compatible(place_name, refreshed_name)
+    ]
+    if len(compatible_existing_places) != 1:
+        return None
+
+    candidate = compatible_existing_places[0]
+    if not raw_place_has_durable_google_identity(candidate):
+        return None
+    if not raw_place_coordinate_address_is_stable(candidate, refreshed_place):
+        return None
+    return candidate
+
+
 def preserve_existing_raw_place(
     *,
     existing_place: RawPlace,
@@ -9070,6 +9110,13 @@ def preserve_existing_raw_saved_list(
                 if raw_place_names_are_compatible(as_string(candidate.name), refreshed_name):
                     existing_place = candidate
                     break
+
+        if existing_place is None:
+            existing_place = raw_place_identity_loss_fallback_candidate(
+                existing_payload=existing_payload,
+                refreshed_payload=refreshed_payload,
+                refreshed_place=refreshed_place,
+            )
 
         if existing_place is None:
             updated_places.append(refreshed_place)
@@ -15163,7 +15210,10 @@ def place_selector_matches(
         ("cid", place.cid),
         ("cid", extract_maps_cid(place.maps_url)),
         *((("cid", cid_alias) for cid_alias in cid_aliases)),
-        ("gpid", extract_maps_query_place_id(place.maps_url)),
+        *(
+            ("gpid", google_places_id)
+            for google_places_id in sorted(raw_place_google_places_identities(place))
+        ),
         ("gms", place.maps_place_token),
         ("gms", extract_maps_place_token(place.maps_url)),
     ):

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6957,7 +6957,12 @@ def raw_place_coordinate_identity_matches(left: RawPlace, right: RawPlace) -> bo
 
     left_primary_cid = raw_place_cid_identity(left)
     right_primary_cid = raw_place_cid_identity(right)
-    if left_primary_cid is not None and left_primary_cid == right_primary_cid:
+    if (
+        left_primary_cid is not None
+        and left_primary_cid == right_primary_cid
+        and not google_places_ids_conflict
+        and not legacy_google_ids_conflict
+    ):
         return True
 
     left_cids = {
@@ -6978,6 +6983,7 @@ def raw_place_coordinate_identity_matches(left: RawPlace, right: RawPlace) -> bo
         left_cids & right_cids
         and google_places_ids_are_consistent
         and not google_places_ids_conflict
+        and not legacy_google_ids_conflict
         and names_are_compatible
     ):
         return True
@@ -7282,11 +7288,16 @@ def raw_place_coordinate_address_has_street_level_evidence(address: str) -> bool
         parsed_parts.append((part, address_key, tokens))
 
     for part, address_key, tokens in parsed_parts:
+        hash_unit_token_indexes = raw_place_coordinate_hash_unit_token_indexes(
+            part,
+            tokens,
+        )
         numeric_indexes = {
             index
             for index, token in enumerate(tokens)
             if any(character.isdigit() for character in token)
             and not raw_place_coordinate_token_is_ordinal(token)
+            and index not in hash_unit_token_indexes
         }
         if not numeric_indexes:
             continue
@@ -7346,7 +7357,7 @@ def raw_place_coordinate_part_has_street_marker(
     if any(index > 0 for index in street_suffix_indexes):
         return True
     if re.search(
-        r"\b(?:allee|allée|av|avenida|calle|carrer|chaussee|chaussée|chemin|chome|corso|impasse|largo|passeig|piazza|plaza|quai|r|rua|rue|str|strada|strasse|straße|via|viale)\b",
+        r"\b(?:allee|allée|av|avenida|avenue|boulevard|calle|carrer|chaussee|chaussée|chemin|chome|corso|impasse|largo|passeig|piazza|plaza|quai|r|rua|rue|str|strada|strasse|straße|via|viale)\b",
         address_key,
     ):
         return True
@@ -7373,6 +7384,33 @@ def raw_place_coordinate_part_is_premise_number(tokens: list[str]) -> bool:
             continue
         return False
     return True
+
+
+def raw_place_coordinate_hash_unit_token_indexes(
+    part: str,
+    tokens: Sequence[str],
+) -> set[int]:
+    matched_indexes: set[int] = set()
+    search_end = len(tokens)
+    hash_units = re.findall(
+        r"#\s*([\w-]+)",
+        unicodedata.normalize("NFKC", part),
+    )
+    for hash_unit in reversed(hash_units):
+        address_key = raw_place_coordinate_address_key(hash_unit)
+        if address_key is None:
+            continue
+        unit_tokens = raw_place_coordinate_address_token_list(address_key)
+        if not unit_tokens:
+            continue
+        for start in range(search_end - len(unit_tokens), -1, -1):
+            end = start + len(unit_tokens)
+            if list(tokens[start:end]) != unit_tokens:
+                continue
+            matched_indexes.update(range(start, end))
+            search_end = start
+            break
+    return matched_indexes
 
 
 def raw_place_coordinate_numeric_indexes_include_premise(
@@ -7475,6 +7513,8 @@ def raw_place_coordinate_postal_evidence_is_valid_for_country(
         return bool(re.fullmatch(r"\d{4}", compact_postal))
     if country_code == "IT":
         return bool(re.fullmatch(r"\d{5}", compact_postal))
+    if country_code == "TW":
+        return bool(re.fullmatch(r"\d{3,6}", compact_postal))
     if country_code == "GB":
         return bool(
             re.fullmatch(
@@ -7483,6 +7523,32 @@ def raw_place_coordinate_postal_evidence_is_valid_for_country(
             )
         )
     return False
+
+
+def raw_place_coordinate_country_span(
+    tokens: Sequence[str],
+    *,
+    expected_country: str | None = None,
+) -> tuple[int, int, str] | None:
+    for country_tokens, country_code in raw_place_coordinate_country_token_identities():
+        if expected_country is not None and country_code != expected_country:
+            continue
+        country_length = len(country_tokens)
+        for start in range(len(tokens) - country_length, -1, -1):
+            end = start + country_length
+            if tuple(tokens[start:end]) != country_tokens:
+                continue
+            trailing_indexes = set(range(end, len(tokens)))
+            if trailing_indexes and not (
+                raw_place_coordinate_postal_evidence_is_valid_for_country(
+                    tokens,
+                    trailing_indexes,
+                    country_code,
+                )
+            ):
+                continue
+            return start, end, country_code
+    return None
 
 
 def raw_place_coordinate_address_comparison_key(
@@ -7501,16 +7567,16 @@ def raw_place_coordinate_address_comparison_key(
         if raw_place_coordinate_address_key(part) is not None
     ]
     if raw_parts:
-        last_part_key = raw_place_coordinate_address_key(raw_parts[-1])
-        last_part_tokens = (
-            raw_place_coordinate_address_token_list(last_part_key)
-            if last_part_key
-            else []
-        )
-        for country_suffix, country_code in raw_place_coordinate_country_token_identities():
-            suffix_length = len(country_suffix)
-            if tuple(last_part_tokens[-suffix_length:]) == country_suffix:
-                country = country_code
+        for raw_part_index in dict.fromkeys((len(raw_parts) - 1, 0)):
+            part_key = raw_place_coordinate_address_key(raw_parts[raw_part_index])
+            part_tokens = (
+                raw_place_coordinate_address_token_list(part_key)
+                if part_key
+                else []
+            )
+            country_span = raw_place_coordinate_country_span(part_tokens)
+            if country_span is not None:
+                country = country_span[2]
                 break
     if country is None:
         country = raw_place_coordinate_infer_country_from_subdivision_postal(
@@ -7650,18 +7716,14 @@ def raw_place_coordinate_address_comparison_key(
                 continue
 
             index = unit_identifier_index + 1
-        for country_suffix, country_code in raw_place_coordinate_country_token_identities():
-            if (
-                raw_part_index != len(raw_parts) - 1
-                and country_code != country_hint
-            ):
-                continue
-            suffix_length = len(country_suffix)
-            if tuple(comparison_part_tokens[-suffix_length:]) == country_suffix:
-                del comparison_part_tokens[-suffix_length:]
-                if raw_part_index == len(raw_parts) - 1:
-                    country = country_code
-                break
+        country_span = raw_place_coordinate_country_span(
+            comparison_part_tokens,
+            expected_country=country or country_hint,
+        )
+        if country_span is not None:
+            country_start, country_end, country_code = country_span
+            del comparison_part_tokens[country_start:country_end]
+            country = country or country_code
 
         postal_token_indexes = {
             index
@@ -7819,6 +7881,8 @@ def raw_place_coordinate_token_is_postal(
         return False
 
     if compact.isdigit():
+        if country_code == "TW" and 3 <= len(compact) <= 6:
+            return True
         if 4 <= len(compact) <= 6:
             return True
         if len(compact) == 3:
@@ -7878,6 +7942,9 @@ def raw_place_coordinate_country_token_identities() -> tuple[
         "スペイン": "ES",
         "フランス": "FR",
         "モナコ": "MC",
+        "イタリア": "IT",
+        "メキシコ": "MX",
+        "オーストラリア": "AU",
         "日本": "JP",
         "中国": "CN",
         "Ivory Coast": "CI",
@@ -15096,6 +15163,7 @@ def place_selector_matches(
         ("cid", place.cid),
         ("cid", extract_maps_cid(place.maps_url)),
         *((("cid", cid_alias) for cid_alias in cid_aliases)),
+        ("gpid", extract_maps_query_place_id(place.maps_url)),
         ("gms", place.maps_place_token),
         ("gms", extract_maps_place_token(place.maps_url)),
     ):

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -160,6 +160,21 @@ PHOTOLESS_REAL_PLACE_CACHE_TTL = timedelta(days=1)
 RAW_SOURCE_CACHE_TTL = timedelta(days=14)
 RAW_SOURCE_REFRESH_JITTER = timedelta(days=3)
 RAW_PLACE_SUSPICIOUS_COORDINATE_SHIFT_METERS = 1_000.0
+RAW_PLACE_ADDRESS_TOKEN_ALIASES = {
+    "avenue": "ave",
+    "boulevard": "blvd",
+    "circle": "cir",
+    "court": "ct",
+    "drive": "dr",
+    "highway": "hwy",
+    "lane": "ln",
+    "parkway": "pkwy",
+    "place": "pl",
+    "road": "rd",
+    "square": "sq",
+    "street": "st",
+    "terrace": "ter",
+}
 SOURCE_HTTP_TIMEOUT_SECONDS = 30
 SOURCE_HTTP_USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
@@ -6682,9 +6697,13 @@ def preserve_existing_raw_place(
     refreshed_name = as_string(refreshed_place.name)
     names_compatible = raw_place_names_are_compatible(existing_name, refreshed_name)
     strong_identity_compatible = raw_place_strong_google_identity_matches(existing_place, refreshed_place)
+    preserve_coordinates = raw_place_coordinates_should_be_preserved(
+        existing_place,
+        refreshed_place,
+    )
 
     if (
-        names_compatible
+        (names_compatible or preserve_coordinates)
         and not refreshed_place.address
         and raw_place_address_is_preservable(existing_place, refreshed_place)
     ):
@@ -6716,10 +6735,7 @@ def preserve_existing_raw_place(
     if names_compatible and refreshed_place.added_by is None and existing_place.added_by is not None:
         updates["added_by"] = existing_place.added_by
         preserved_fields.append("added_by")
-    if raw_place_coordinates_should_be_preserved(
-        existing_place,
-        refreshed_place,
-    ):
+    if preserve_coordinates:
         updates["lat"] = existing_place.lat
         updates["lng"] = existing_place.lng
         preserved_fields.append("coordinates")
@@ -6807,7 +6823,38 @@ def raw_place_coordinate_address_is_stable(
 
     existing_address_key = raw_place_coordinate_address_key(existing_address)
     refreshed_address_key = raw_place_coordinate_address_key(refreshed_address)
-    return existing_address_key is not None and existing_address_key == refreshed_address_key
+    if existing_address_key is None or refreshed_address_key is None:
+        return False
+    if existing_address_key == refreshed_address_key:
+        return True
+
+    existing_street_numbers = address_street_numbers(existing_address)
+    refreshed_street_numbers = address_street_numbers(refreshed_address)
+    if (
+        existing_street_numbers
+        and refreshed_street_numbers
+        and not existing_street_numbers & refreshed_street_numbers
+    ):
+        return False
+
+    existing_tokens = raw_place_coordinate_address_tokens(existing_address_key)
+    refreshed_tokens = raw_place_coordinate_address_tokens(refreshed_address_key)
+    for shorter_tokens, longer_tokens in (
+        (existing_tokens, refreshed_tokens),
+        (refreshed_tokens, existing_tokens),
+    ):
+        numeric_tokens = {
+            token
+            for token in shorter_tokens
+            if any(character.isdigit() for character in token)
+        }
+        if (
+            len(shorter_tokens) >= 3
+            and numeric_tokens
+            and shorter_tokens <= longer_tokens
+        ):
+            return True
+    return False
 
 
 def raw_place_coordinate_address_key(address: str) -> str | None:
@@ -6818,6 +6865,13 @@ def raw_place_coordinate_address_key(address: str) -> str | None:
     ]
     compact = re.sub(r"\s+", " ", "".join(normalized_characters)).strip()
     return compact or None
+
+
+def raw_place_coordinate_address_tokens(address_key: str) -> set[str]:
+    return {
+        RAW_PLACE_ADDRESS_TOKEN_ALIASES.get(token, token)
+        for token in address_key.split()
+    }
 
 
 def raw_place_maps_url_should_be_preserved(

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6731,10 +6731,22 @@ def preserve_existing_raw_place(
     ):
         updates["address"] = existing_place.address
         preserved_fields.append("address")
-    if names_compatible and not refreshed_place.google_id and existing_place.google_id:
+    if (
+        (names_compatible or preserve_coordinates)
+        and not refreshed_place.google_id
+        and existing_place.google_id
+    ):
         updates["google_id"] = existing_place.google_id
         preserved_fields.append("google_id")
-    if names_compatible and not refreshed_place.cid and existing_place.cid:
+    if (
+        (names_compatible or preserve_coordinates)
+        and not refreshed_place.cid
+        and existing_place.cid
+        and raw_place_refreshed_url_identity_is_compatible(
+            existing_place,
+            refreshed_place.maps_url,
+        )
+    ):
         updates["cid"] = existing_place.cid
         preserved_fields.append("cid")
     existing_cid = as_string(existing_place.cid) or extract_maps_cid(existing_place.maps_url)
@@ -6748,7 +6760,15 @@ def preserve_existing_raw_place(
         if preserved_cid_aliases != refreshed_place.cid_aliases:
             updates["cid_aliases"] = preserved_cid_aliases
             preserved_fields.append("cid_alias")
-    if names_compatible and not refreshed_place.maps_place_token and existing_place.maps_place_token:
+    if (
+        (names_compatible or preserve_coordinates)
+        and not refreshed_place.maps_place_token
+        and existing_place.maps_place_token
+        and raw_place_refreshed_url_identity_is_compatible(
+            existing_place,
+            refreshed_place.maps_url,
+        )
+    ):
         updates["maps_place_token"] = existing_place.maps_place_token
         preserved_fields.append("maps_place_token")
     if names_compatible and not refreshed_place.is_favorite and existing_place.is_favorite:
@@ -6861,13 +6881,13 @@ def raw_place_coordinate_address_is_stable(
     ):
         return False
 
-    existing_tokens, existing_country = raw_place_coordinate_address_comparison_key(
+    existing_parts, existing_country = raw_place_coordinate_address_comparison_key(
         existing_address
     )
-    refreshed_tokens, refreshed_country = raw_place_coordinate_address_comparison_key(
+    refreshed_parts, refreshed_country = raw_place_coordinate_address_comparison_key(
         refreshed_address
     )
-    if not existing_tokens or existing_tokens != refreshed_tokens:
+    if not existing_parts or existing_parts != refreshed_parts:
         return False
     return bool(
         existing_country is None
@@ -6929,8 +6949,10 @@ def raw_place_coordinate_address_has_street_level_evidence(address: str) -> bool
 
 def raw_place_coordinate_address_comparison_key(
     address: str,
-) -> tuple[tuple[str, ...], str | None]:
-    tokens: list[str] = []
+) -> tuple[tuple[tuple[str, ...], ...], str | None]:
+    comparison_parts: list[tuple[str, ...]] = []
+    street_numbers = raw_place_coordinate_street_numbers(address)
+    country: str | None = None
     normalized_address = raw_place_coordinate_strip_japanese_postal_prefix(address)
     for raw_part in re.split(r"[,、]", normalized_address):
         part = re.sub(
@@ -6971,16 +6993,62 @@ def raw_place_coordinate_address_comparison_key(
                 continue
 
             index = unit_identifier_index + 1
-        tokens.extend(comparison_part_tokens)
+        for country_suffix, country_code in raw_place_coordinate_country_token_identities():
+            suffix_length = len(country_suffix)
+            if tuple(comparison_part_tokens[-suffix_length:]) == country_suffix:
+                del comparison_part_tokens[-suffix_length:]
+                country = country_code
+                break
 
-    country: str | None = None
-    for country_suffix, country_code in raw_place_coordinate_country_token_identities():
-        suffix_length = len(country_suffix)
-        if tuple(tokens[-suffix_length:]) == country_suffix:
-            del tokens[-suffix_length:]
-            country = country_code
-            break
-    return tuple(tokens), country
+        comparison_part_tokens = [
+            token
+            for index, token in enumerate(comparison_part_tokens)
+            if not raw_place_coordinate_token_is_postal(
+                comparison_part_tokens,
+                index,
+                street_numbers,
+            )
+        ]
+        if comparison_part_tokens:
+            comparison_parts.append(tuple(comparison_part_tokens))
+    return tuple(sorted(comparison_parts)), country
+
+
+def raw_place_coordinate_token_is_postal(
+    tokens: list[str],
+    index: int,
+    street_numbers: set[str],
+) -> bool:
+    token = tokens[index]
+    numbers = set(re.findall(r"\d+", token))
+    if not numbers or numbers & street_numbers:
+        return False
+    previous_token = tokens[index - 1] if index > 0 else None
+    if previous_token in {"hwy", "rte"}:
+        return False
+
+    compact = re.sub(r"[^a-z0-9]", "", token)
+    if compact.isdigit():
+        if 4 <= len(compact) <= 6:
+            return True
+        if len(compact) == 3:
+            for neighbor_index in (index - 1, index + 1):
+                if not 0 <= neighbor_index < len(tokens):
+                    continue
+                neighbor = re.sub(r"[^0-9]", "", tokens[neighbor_index])
+                neighbor_numbers = set(re.findall(r"\d+", tokens[neighbor_index]))
+                if (
+                    4 <= len(neighbor) <= 6
+                    and neighbor_numbers
+                    and not neighbor_numbers & street_numbers
+                ):
+                    return True
+        return False
+    return (
+        3 <= len(compact) <= 7
+        and any(character.isalpha() for character in compact)
+        and any(character.isdigit() for character in compact)
+    )
 
 
 def raw_place_coordinate_strip_japanese_postal_prefix(address: str) -> str:
@@ -7195,11 +7263,77 @@ def raw_place_maps_url_should_be_preserved(
         ]
         if token
     }
-    return not (
+    if (
         existing_url_token
         and refreshed_tokens
         and existing_url_token not in refreshed_tokens
+    ):
+        return False
+
+    existing_url_has_identity = raw_place_maps_url_has_embedded_identity(existing_url)
+    refreshed_url_has_identity = raw_place_maps_url_has_embedded_identity(refreshed_url)
+    has_compatible_identity = bool(
+        (existing_url_cid and existing_url_cid in refreshed_cids)
+        or (
+            existing_query_place_id
+            and existing_query_place_id == refreshed_query_place_id
+        )
+        or (existing_url_token and existing_url_token in refreshed_tokens)
     )
+    return not (
+        existing_url_has_identity
+        and refreshed_url_has_identity
+        and not has_compatible_identity
+    )
+
+
+def raw_place_refreshed_url_identity_is_compatible(
+    existing_place: RawPlace,
+    refreshed_url: str | None,
+) -> bool:
+    url = as_string(refreshed_url)
+    if not url or not raw_place_maps_url_has_embedded_identity(url):
+        return True
+
+    matched_identity = False
+    refreshed_cid = extract_maps_cid(url)
+    if refreshed_cid:
+        existing_cids = {
+            cid
+            for cid in [
+                as_string(existing_place.cid),
+                extract_maps_cid(existing_place.maps_url),
+                *existing_place.cid_aliases,
+            ]
+            if cid
+        }
+        if existing_cids and refreshed_cid not in existing_cids:
+            return False
+        matched_identity = matched_identity or refreshed_cid in existing_cids
+
+    refreshed_query_place_id = extract_maps_query_place_id(url)
+    if refreshed_query_place_id:
+        existing_query_place_id = extract_maps_query_place_id(existing_place.maps_url)
+        if existing_query_place_id and refreshed_query_place_id != existing_query_place_id:
+            return False
+        matched_identity = matched_identity or (
+            refreshed_query_place_id == existing_query_place_id
+        )
+
+    refreshed_token = extract_maps_place_token(url)
+    if refreshed_token:
+        existing_tokens = {
+            token
+            for token in [
+                as_string(existing_place.maps_place_token),
+                extract_maps_place_token(existing_place.maps_url),
+            ]
+            if token
+        }
+        if existing_tokens and refreshed_token not in existing_tokens:
+            return False
+        matched_identity = matched_identity or refreshed_token in existing_tokens
+    return matched_identity
 
 
 def raw_place_maps_url_has_embedded_identity(url: str) -> bool:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -161,6 +161,8 @@ RAW_SOURCE_CACHE_TTL = timedelta(days=14)
 RAW_SOURCE_REFRESH_JITTER = timedelta(days=3)
 RAW_PLACE_SUSPICIOUS_COORDINATE_SHIFT_METERS = 1_000.0
 RAW_PLACE_ADDRESS_TOKEN_ALIASES = {
+    "av": "ave",
+    "avenida": "ave",
     "avenue": "ave",
     "boulevard": "blvd",
     "circle": "cir",
@@ -172,9 +174,50 @@ RAW_PLACE_ADDRESS_TOKEN_ALIASES = {
     "place": "pl",
     "road": "rd",
     "route": "rte",
+    "r": "rua",
+    "str": "strasse",
     "square": "sq",
     "street": "st",
     "terrace": "ter",
+}
+RAW_PLACE_ORDINAL_WORD_VALUES = {
+    "first": 1,
+    "second": 2,
+    "third": 3,
+    "fourth": 4,
+    "fifth": 5,
+    "sixth": 6,
+    "seventh": 7,
+    "eighth": 8,
+    "ninth": 9,
+    "tenth": 10,
+    "eleventh": 11,
+    "twelfth": 12,
+    "thirteenth": 13,
+    "fourteenth": 14,
+    "fifteenth": 15,
+    "sixteenth": 16,
+    "seventeenth": 17,
+    "eighteenth": 18,
+    "nineteenth": 19,
+    "twentieth": 20,
+    "thirtieth": 30,
+    "fortieth": 40,
+    "fiftieth": 50,
+    "sixtieth": 60,
+    "seventieth": 70,
+    "eightieth": 80,
+    "ninetieth": 90,
+}
+RAW_PLACE_CARDINAL_TENS_VALUES = {
+    "twenty": 20,
+    "thirty": 30,
+    "forty": 40,
+    "fifty": 50,
+    "sixty": 60,
+    "seventy": 70,
+    "eighty": 80,
+    "ninety": 90,
 }
 RAW_PLACE_STREET_SUFFIX_TOKENS = frozenset(
     {*RAW_PLACE_ADDRESS_TOKEN_ALIASES.values(), "way"}
@@ -197,6 +240,7 @@ RAW_PLACE_UNIT_PREFIX_TOKENS = frozenset(
     }
 )
 RAW_PLACE_UNIT_NUMBER_LABEL_TOKENS = frozenset({"no", "number"})
+RAW_PLACE_TRAILING_UNIT_TOKENS = frozenset({"fl", "floor", "level", "lvl"})
 SOURCE_HTTP_TIMEOUT_SECONDS = 30
 SOURCE_HTTP_USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
@@ -6575,9 +6619,9 @@ def raw_place_primary_match_keys(place: RawPlace, *, source_type: str | None = N
     if maps_place_token:
         keys.append(f"gms:{maps_place_token}")
 
-    query_place_id = extract_maps_query_place_id(place.maps_url)
-    if query_place_id:
-        keys.append(f"gpid:{query_place_id}")
+    google_places_id = raw_place_google_places_id_identity(place)
+    if google_places_id:
+        keys.append(f"gpid:{google_places_id}")
 
     name = as_string(place.name)
     lat = as_float(place.lat)
@@ -6727,10 +6771,17 @@ def preserve_existing_raw_place(
         existing_place,
         refreshed_place,
     )
+    address_precision_regressed = raw_place_coordinate_address_precision_regressed(
+        existing_place,
+        refreshed_place,
+    )
 
     if (
         (names_compatible or preserve_coordinates)
-        and not refreshed_place.address
+        and (
+            not refreshed_place.address
+            or (preserve_coordinates and address_precision_regressed)
+        )
         and raw_place_address_is_preservable(existing_place, refreshed_place)
     ):
         updates["address"] = existing_place.address
@@ -6739,6 +6790,10 @@ def preserve_existing_raw_place(
         (names_compatible or preserve_coordinates)
         and not refreshed_place.google_id
         and existing_place.google_id
+        and raw_place_refreshed_url_identity_is_compatible(
+            existing_place,
+            refreshed_place.maps_url,
+        )
     ):
         updates["google_id"] = existing_place.google_id
         preserved_fields.append("google_id")
@@ -6839,15 +6894,15 @@ def raw_place_coordinates_should_be_preserved(
 
 
 def raw_place_coordinate_identity_matches(left: RawPlace, right: RawPlace) -> bool:
+    left_google_places_ids = raw_place_google_places_identities(left)
+    right_google_places_ids = raw_place_google_places_identities(right)
+    if len(left_google_places_ids) > 1 or len(right_google_places_ids) > 1:
+        return False
+
     if raw_place_strong_google_identity_matches(left, right):
         return True
 
-    left_query_place_id = extract_maps_query_place_id(left.maps_url)
-    right_query_place_id = extract_maps_query_place_id(right.maps_url)
-    if (
-        left_query_place_id is not None
-        and left_query_place_id == right_query_place_id
-    ):
+    if left_google_places_ids & right_google_places_ids:
         return True
 
     left_cids = {
@@ -6896,6 +6951,11 @@ def raw_place_coordinate_address_is_stable(
     refreshed_address = as_string(refreshed_place.address)
     if not refreshed_address:
         return raw_place_address_is_preservable(existing_place, refreshed_place)
+    if not raw_place_coordinate_address_has_street_level_evidence(refreshed_address):
+        return raw_place_coordinate_address_precision_regressed(
+            existing_place,
+            refreshed_place,
+        )
 
     existing_address_key = raw_place_coordinate_address_key(existing_address)
     refreshed_address_key = raw_place_coordinate_address_key(refreshed_address)
@@ -6908,11 +6968,7 @@ def raw_place_coordinate_address_is_stable(
     refreshed_street_numbers = raw_place_coordinate_street_numbers(refreshed_address)
     existing_comparison_address = existing_address
     refreshed_comparison_address = refreshed_address
-    if (
-        existing_street_numbers
-        and refreshed_street_numbers
-        and existing_street_numbers != refreshed_street_numbers
-    ):
+    if existing_street_numbers and refreshed_street_numbers:
         collapsed_existing_address = raw_place_coordinate_collapse_street_number_range(
             existing_address,
             refreshed_street_numbers,
@@ -6923,9 +6979,13 @@ def raw_place_coordinate_address_is_stable(
         )
         if collapsed_existing_address is not None:
             existing_comparison_address = collapsed_existing_address
-        elif collapsed_refreshed_address is not None:
+        if collapsed_refreshed_address is not None:
             refreshed_comparison_address = collapsed_refreshed_address
-        else:
+        if (
+            collapsed_existing_address is None
+            and collapsed_refreshed_address is None
+            and existing_street_numbers != refreshed_street_numbers
+        ):
             return False
 
     existing_parts, existing_country = raw_place_coordinate_address_comparison_key(
@@ -6953,10 +7013,66 @@ def raw_place_coordinate_address_is_stable(
     )
 
 
+def raw_place_coordinate_address_precision_regressed(
+    existing_place: RawPlace,
+    refreshed_place: RawPlace,
+) -> bool:
+    existing_address = as_string(existing_place.address)
+    refreshed_address = as_string(refreshed_place.address)
+    if not existing_address or not refreshed_address:
+        return False
+    if not raw_place_coordinate_address_has_street_level_evidence(existing_address):
+        return False
+    if raw_place_coordinate_address_has_street_level_evidence(refreshed_address):
+        return False
+    if not raw_place_address_is_preservable(existing_place, refreshed_place):
+        return False
+
+    existing_parts, existing_country = raw_place_coordinate_address_comparison_key(
+        existing_address
+    )
+    refreshed_parts, refreshed_country = raw_place_coordinate_address_comparison_key(
+        refreshed_address,
+        country_hint=existing_country,
+    )
+    if (
+        existing_country is not None
+        and refreshed_country is not None
+        and existing_country != refreshed_country
+    ):
+        return False
+    return bool(
+        refreshed_parts
+        and all(
+            any(
+                set(refreshed_part).issubset(set(existing_part))
+                for existing_part in existing_parts
+            )
+            for refreshed_part in refreshed_parts
+        )
+    )
+
+
 def raw_place_coordinate_address_key(address: str) -> str | None:
-    normalized = unicodedata.normalize("NFKC", address).casefold()
+    decomposed = unicodedata.normalize("NFKD", address.casefold())
+    without_latin_diacritics: list[str] = []
+    previous_base_is_latin = False
+    for character in decomposed:
+        category = unicodedata.category(character)
+        if category.startswith("M"):
+            if not previous_base_is_latin:
+                without_latin_diacritics.append(character)
+            continue
+        without_latin_diacritics.append(character)
+        previous_base_is_latin = bool(
+            category.startswith("L")
+            and "LATIN" in unicodedata.name(character, "")
+        )
+    normalized = unicodedata.normalize("NFKC", "".join(without_latin_diacritics))
     normalized_characters = [
-        character if unicodedata.category(character)[0] in {"L", "N"} else " "
+        character
+        if unicodedata.category(character)[0] in {"L", "M", "N"}
+        else " "
         for character in normalized
     ]
     compact = re.sub(r"\s+", " ", "".join(normalized_characters)).strip()
@@ -6964,10 +7080,56 @@ def raw_place_coordinate_address_key(address: str) -> str | None:
 
 
 def raw_place_coordinate_address_token_list(address_key: str) -> list[str]:
-    return [
-        RAW_PLACE_ADDRESS_TOKEN_ALIASES.get(token, token)
-        for token in address_key.split()
-    ]
+    raw_tokens = address_key.split()
+    normalized_tokens: list[str] = []
+    index = 0
+    while index < len(raw_tokens):
+        token = raw_tokens[index]
+        compound_strasse_match = re.fullmatch(
+            r"(.{2,}?)(?:strasse|str)",
+            token,
+        )
+        if compound_strasse_match is not None:
+            normalized_tokens.append(f"{compound_strasse_match.group(1)}strasse")
+            index += 1
+            continue
+        ordinal_match = re.fullmatch(r"(\d+)(?:st|nd|rd|th)", token)
+        if ordinal_match is not None:
+            normalized_tokens.append(f"ordinal_{int(ordinal_match.group(1))}")
+            index += 1
+            continue
+        ordinal_value = RAW_PLACE_ORDINAL_WORD_VALUES.get(token)
+        if ordinal_value is not None:
+            normalized_tokens.append(f"ordinal_{ordinal_value}")
+            index += 1
+            continue
+        cardinal_tens_value = RAW_PLACE_CARDINAL_TENS_VALUES.get(token)
+        if cardinal_tens_value is not None and index + 1 < len(raw_tokens):
+            ordinal_unit_value = RAW_PLACE_ORDINAL_WORD_VALUES.get(
+                raw_tokens[index + 1]
+            )
+            if ordinal_unit_value is not None and ordinal_unit_value < 10:
+                normalized_tokens.append(
+                    f"ordinal_{cardinal_tens_value + ordinal_unit_value}"
+                )
+                index += 2
+                continue
+        normalized_tokens.append(RAW_PLACE_ADDRESS_TOKEN_ALIASES.get(token, token))
+        index += 1
+    return normalized_tokens
+
+
+def raw_place_coordinate_token_is_ordinal(token: str) -> bool:
+    return token.startswith("ordinal_")
+
+
+def raw_place_coordinate_part_has_street_intersection(tokens: list[str]) -> bool:
+    return sum(
+        raw_place_coordinate_token_is_ordinal(token)
+        and index + 1 < len(tokens)
+        and tokens[index + 1] in RAW_PLACE_STREET_SUFFIX_TOKENS
+        for index, token in enumerate(tokens)
+    ) >= 2
 
 
 def raw_place_coordinate_address_has_street_level_evidence(address: str) -> bool:
@@ -6985,10 +7147,11 @@ def raw_place_coordinate_address_has_street_level_evidence(address: str) -> bool
             index
             for index, token in enumerate(tokens)
             if any(character.isdigit() for character in token)
+            and not raw_place_coordinate_token_is_ordinal(token)
         }
         if not numeric_indexes:
             continue
-        if raw_place_coordinate_part_is_route_only(tokens):
+        if raw_place_coordinate_part_is_route_only(tokens, address_key=address_key):
             continue
         if raw_place_coordinate_part_has_street_marker(
             part,
@@ -6996,6 +7159,12 @@ def raw_place_coordinate_address_has_street_level_evidence(address: str) -> bool
             tokens,
         ):
             return True
+
+    if any(
+        raw_place_coordinate_part_has_street_intersection(tokens)
+        for _, _, tokens in parsed_parts
+    ):
+        return True
 
     for index, (part, address_key, tokens) in enumerate(parsed_parts):
         if not raw_place_coordinate_part_has_street_marker(
@@ -7033,7 +7202,7 @@ def raw_place_coordinate_part_has_street_marker(
         address_key,
     ):
         return True
-    if re.search(r"(?:strasse|straße)\b", address_key):
+    if re.search(r"[^\W\d_]{2,}(?:str|strasse|straße)\b", address_key):
         return True
     return bool(re.search(r"(?:丁目|番地|號|号|路|街|道|巷|弄)", part))
 
@@ -7051,7 +7220,20 @@ def raw_place_coordinate_part_is_premise_number(tokens: list[str]) -> bool:
     return True
 
 
-def raw_place_coordinate_part_is_route_only(tokens: list[str]) -> bool:
+def raw_place_coordinate_part_is_route_only(
+    tokens: list[str],
+    *,
+    address_key: str,
+) -> bool:
+    raw_tokens = address_key.split()
+    if raw_tokens and raw_tokens[0] == "r":
+        has_street_name = any(
+            token.isalpha() and token not in RAW_PLACE_UNIT_PREFIX_TOKENS
+            for token in raw_tokens[1:]
+        )
+        if not has_street_name:
+            return True
+
     route_indexes = [
         index
         for index, token in enumerate(tokens)
@@ -7103,6 +7285,17 @@ def raw_place_coordinate_address_comparison_key(
         if address_key is None:
             continue
         part_tokens = raw_place_coordinate_address_token_list(address_key)
+        if raw_place_coordinate_part_has_street_intersection(part_tokens):
+            part_tokens = [token for token in part_tokens if token != "and"]
+        if (
+            len(part_tokens) >= 2
+            and part_tokens[-1] in RAW_PLACE_TRAILING_UNIT_TOKENS
+            and (
+                any(character.isdigit() for character in part_tokens[-2])
+                or part_tokens[-2] in {"basement", "ground", "mezzanine"}
+            )
+        ):
+            del part_tokens[-2:]
         comparison_part_tokens: list[str] = []
         index = 0
         while index < len(part_tokens):
@@ -7181,9 +7374,9 @@ def raw_place_coordinate_collapse_street_number_range(
         return endpoint
 
     collapsed = re.sub(
-        r"(?<!\d)(?P<start>\d+)\s*[-–—]\s*(?P<end>\d+)(?!\d)",
+        r"(?<!\d)(?P<start>\d+)\s*[-–—−]\s*(?P<end>\d+)(?!\d)",
         collapse,
-        address,
+        unicodedata.normalize("NFKC", address),
     )
     return collapsed if replaced else None
 
@@ -7380,6 +7573,7 @@ def raw_place_coordinate_part_street_numbers(
         index: set(re.findall(r"\d+", token))
         for index, token in enumerate(tokens)
         if re.search(r"\d", token)
+        and not raw_place_coordinate_token_is_ordinal(token)
     }
     skipped_indexes: set[int] = set()
     for index, token in enumerate(tokens):
@@ -7504,6 +7698,9 @@ def raw_place_refreshed_url_identity_is_compatible(
     existing_place: RawPlace,
     refreshed_url: str | None,
 ) -> bool:
+    if len(raw_place_google_places_identities(existing_place)) > 1:
+        return False
+
     url = as_string(refreshed_url)
     if not url or not raw_place_maps_url_has_embedded_identity(url):
         return True
@@ -7526,11 +7723,17 @@ def raw_place_refreshed_url_identity_is_compatible(
 
     refreshed_query_place_id = extract_maps_query_place_id(url)
     if refreshed_query_place_id:
-        existing_query_place_id = extract_maps_query_place_id(existing_place.maps_url)
-        if existing_query_place_id and refreshed_query_place_id != existing_query_place_id:
+        existing_query_place_ids = raw_place_google_places_identities(existing_place)
+        if (
+            len(existing_query_place_ids) > 1
+            or (
+                existing_query_place_ids
+                and refreshed_query_place_id not in existing_query_place_ids
+            )
+        ):
             return False
         matched_identity = matched_identity or (
-            refreshed_query_place_id == existing_query_place_id
+            refreshed_query_place_id in existing_query_place_ids
         )
 
     refreshed_token = extract_maps_place_token(url)
@@ -7612,6 +7815,28 @@ def raw_place_google_id_identity(place: RawPlace) -> str | None:
     if not google_id:
         return None
     return google_id.strip("/").replace("/", "-")
+
+
+def raw_place_google_places_id_identity(place: RawPlace) -> str | None:
+    identities = raw_place_google_places_identities(place)
+    return next(iter(identities)) if len(identities) == 1 else None
+
+
+def raw_place_google_places_identities(place: RawPlace) -> set[str]:
+    identities = {
+        identity
+        for identity in (extract_maps_query_place_id(place.maps_url),)
+        if identity is not None
+    }
+    google_id = as_string(place.google_id)
+    if google_id:
+        if google_id.startswith("places/"):
+            google_id = google_id.removeprefix("places/")
+            if google_id:
+                identities.add(google_id)
+        elif "/" not in google_id:
+            identities.add(google_id)
+    return identities
 
 
 def raw_place_maps_place_token_identity(place: RawPlace) -> str | None:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6997,6 +6997,10 @@ def raw_place_maps_url_should_be_preserved(
         return False
     if google_maps_uri_strength(existing_url) < google_maps_uri_strength(refreshed_url):
         return False
+    if raw_place_maps_url_has_embedded_identity(
+        refreshed_url,
+    ) and not raw_place_maps_url_has_embedded_identity(existing_url):
+        return False
 
     existing_url_cid = extract_maps_cid(existing_url)
     refreshed_cids = {
@@ -7033,6 +7037,14 @@ def raw_place_maps_url_should_be_preserved(
         existing_url_token
         and refreshed_tokens
         and existing_url_token not in refreshed_tokens
+    )
+
+
+def raw_place_maps_url_has_embedded_identity(url: str) -> bool:
+    return bool(
+        extract_maps_cid(url)
+        or extract_maps_query_place_id(url)
+        or extract_maps_place_token(url)
     )
 
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6900,33 +6900,69 @@ def raw_place_coordinates_should_be_preserved(
 def raw_place_coordinate_identity_matches(left: RawPlace, right: RawPlace) -> bool:
     left_google_places_ids = raw_place_google_places_identities(left)
     right_google_places_ids = raw_place_google_places_identities(right)
-    if len(left_google_places_ids) > 1 or len(right_google_places_ids) > 1:
-        return False
+    google_places_ids_are_consistent = (
+        len(left_google_places_ids) <= 1 and len(right_google_places_ids) <= 1
+    )
 
-    if raw_place_strong_google_identity_matches(left, right):
+    left_maps_place_token = raw_place_maps_place_token_identity(left)
+    right_maps_place_token = raw_place_maps_place_token_identity(right)
+    if (
+        left_maps_place_token is not None
+        and left_maps_place_token == right_maps_place_token
+    ):
         return True
 
-    if left_google_places_ids & right_google_places_ids:
+    left_google_id = raw_place_google_id_identity(left)
+    right_google_id = raw_place_google_id_identity(right)
+    if (
+        google_places_ids_are_consistent
+        and left_google_id is not None
+        and left_google_id == right_google_id
+    ):
+        return True
+
+    if google_places_ids_are_consistent and (
+        left_google_places_ids & right_google_places_ids
+    ):
+        return True
+
+    left_primary_cid = raw_place_cid_identity(left)
+    right_primary_cid = raw_place_cid_identity(right)
+    if left_primary_cid is not None and left_primary_cid == right_primary_cid:
         return True
 
     left_cids = {
         cid
-        for cid in [raw_place_cid_identity(left), *left.cid_aliases]
+        for cid in [left_primary_cid, *left.cid_aliases]
         if cid
     }
     right_cids = {
         cid
-        for cid in [raw_place_cid_identity(right), *right.cid_aliases]
+        for cid in [right_primary_cid, *right.cid_aliases]
         if cid
     }
-    if left_cids & right_cids:
+    google_places_ids_conflict = bool(
+        left_google_places_ids
+        and right_google_places_ids
+        and left_google_places_ids.isdisjoint(right_google_places_ids)
+    )
+    names_are_compatible = raw_place_names_are_compatible(
+        as_string(left.name),
+        as_string(right.name),
+    )
+    if (
+        left_cids & right_cids
+        and google_places_ids_are_consistent
+        and not google_places_ids_conflict
+        and names_are_compatible
+    ):
         return True
 
+    if not google_places_ids_are_consistent:
+        return False
+
     return bool(
-        raw_place_names_are_compatible(
-            as_string(left.name),
-            as_string(right.name),
-        )
+        names_are_compatible
         and raw_place_has_durable_google_identity(left)
         and not raw_place_has_durable_google_identity(right)
     )
@@ -7278,12 +7314,65 @@ def raw_place_coordinate_part_is_route_only(
     return True
 
 
+def raw_place_coordinate_infer_country_from_subdivision_postal(
+    address: str,
+) -> str | None:
+    normalized_address = unicodedata.normalize("NFKC", address)
+    country_patterns = (
+        ("US", r"\b(?P<code>[A-Z]{2})\s*,?\s*\d{5}(?:-\d{4})?\b"),
+        ("CA", r"\b(?P<code>[A-Z]{2})\s*,?\s*[A-Z]\d[A-Z]\s*\d[A-Z]\d\b"),
+        ("AU", r"\b(?P<code>[A-Z]{2,3})\s*,?\s*\d{4}\b"),
+    )
+    for country_code, pattern in country_patterns:
+        subdivision_codes = raw_place_coordinate_subdivision_code_token_identities(
+            country_code
+        )
+        for match in re.finditer(pattern, normalized_address):
+            code_key = raw_place_coordinate_address_key(match.group("code"))
+            if not code_key:
+                continue
+            code_tokens = tuple(raw_place_coordinate_address_token_list(code_key))
+            if code_tokens in subdivision_codes:
+                return country_code
+    return None
+
+
+def raw_place_coordinate_postal_evidence_is_valid_for_country(
+    tokens: Sequence[str],
+    postal_token_indexes: set[int],
+    country_code: str | None,
+) -> bool:
+    if not postal_token_indexes:
+        return False
+    compact_postal = "".join(
+        re.sub(r"[^a-z0-9]", "", tokens[index])
+        for index in sorted(postal_token_indexes)
+    )
+    if country_code == "US":
+        return bool(re.fullmatch(r"\d{5}(?:\d{4})?", compact_postal))
+    if country_code == "CA":
+        return bool(re.fullmatch(r"[a-z]\d[a-z]\d[a-z]\d", compact_postal))
+    if country_code == "AU":
+        return bool(re.fullmatch(r"\d{4}", compact_postal))
+    if country_code == "IT":
+        return bool(re.fullmatch(r"\d{5}", compact_postal))
+    if country_code == "GB":
+        return bool(
+            re.fullmatch(
+                r"(?:gir0aa|[a-z]{1,2}\d[a-z\d]?\d[a-z]{2})",
+                compact_postal,
+            )
+        )
+    return False
+
+
 def raw_place_coordinate_address_comparison_key(
     address: str,
     *,
     country_hint: str | None = None,
 ) -> tuple[tuple[tuple[str, ...], ...], str | None]:
     comparison_parts: list[tuple[str, ...]] = []
+    embedded_subdivision_code_suffixes: list[tuple[str, ...] | None] = []
     street_numbers = raw_place_coordinate_street_numbers(address)
     country: str | None = None
     normalized_address = raw_place_coordinate_strip_japanese_postal_prefix(address)
@@ -7292,6 +7381,27 @@ def raw_place_coordinate_address_comparison_key(
         for part in re.split(r"[,、]", normalized_address)
         if raw_place_coordinate_address_key(part) is not None
     ]
+    if raw_parts:
+        last_part_key = raw_place_coordinate_address_key(raw_parts[-1])
+        last_part_tokens = (
+            raw_place_coordinate_address_token_list(last_part_key)
+            if last_part_key
+            else []
+        )
+        for country_suffix, country_code in raw_place_coordinate_country_token_identities():
+            suffix_length = len(country_suffix)
+            if tuple(last_part_tokens[-suffix_length:]) == country_suffix:
+                country = country_code
+                break
+    if country is None:
+        country = raw_place_coordinate_infer_country_from_subdivision_postal(
+            normalized_address
+        )
+    known_subdivision_code_identities = (
+        raw_place_coordinate_subdivision_code_token_identities(
+            country or country_hint
+        )
+    )
     for raw_part_index, raw_part in enumerate(raw_parts):
         part = re.sub(
             r"^\s*(?:unit\s+)?[^/\s,]+\s*/\s*",
@@ -7306,6 +7416,60 @@ def raw_place_coordinate_address_comparison_key(
         part_tokens = raw_place_coordinate_address_token_list(address_key)
         if raw_place_coordinate_part_has_street_intersection(part_tokens):
             part_tokens = [token for token in part_tokens if token != "and"]
+        uppercase_word_suffixes = {
+            tuple(raw_place_coordinate_address_token_list(word_key))
+            for word in re.findall(
+                r"[^\W_]+",
+                unicodedata.normalize("NFKC", raw_part),
+            )
+            if word == word.upper()
+            and any(character.isalpha() for character in word)
+            and (word_key := raw_place_coordinate_address_key(word))
+        }
+        raw_postal_token_indexes = {
+            index
+            for index in range(len(part_tokens))
+            if raw_place_coordinate_token_is_postal(
+                part_tokens,
+                index,
+                street_numbers,
+            )
+        }
+        current_part_has_valid_postal = (
+            raw_place_coordinate_postal_evidence_is_valid_for_country(
+                part_tokens,
+                raw_postal_token_indexes,
+                country or country_hint,
+            )
+        )
+        next_part_is_postal_only = False
+        if raw_part_index + 1 < len(raw_parts):
+            next_part_key = raw_place_coordinate_address_key(
+                raw_parts[raw_part_index + 1]
+            )
+            next_part_tokens = (
+                raw_place_coordinate_address_token_list(next_part_key)
+                if next_part_key
+                else []
+            )
+            next_part_postal_token_indexes = {
+                index
+                for index in range(len(next_part_tokens))
+                if raw_place_coordinate_token_is_postal(
+                    next_part_tokens,
+                    index,
+                    street_numbers,
+                )
+            }
+            next_part_is_postal_only = (
+                bool(next_part_tokens)
+                and len(next_part_postal_token_indexes) == len(next_part_tokens)
+                and raw_place_coordinate_postal_evidence_is_valid_for_country(
+                    next_part_tokens,
+                    next_part_postal_token_indexes,
+                    country or country_hint,
+                )
+            )
         if (
             len(part_tokens) >= 2
             and part_tokens[-1] in RAW_PLACE_TRAILING_UNIT_TOKENS
@@ -7335,6 +7499,20 @@ def raw_place_coordinate_address_comparison_key(
                     not comparison_part_tokens
                     or comparison_part_tokens[-1] in RAW_PLACE_STREET_SUFFIX_TOKENS
                 )
+                and not (
+                    (token,) in known_subdivision_code_identities
+                    and (token,) in uppercase_word_suffixes
+                    and (
+                        next_part_is_postal_only
+                        or (
+                            current_part_has_valid_postal
+                            and any(
+                                postal_index > index
+                                for postal_index in raw_postal_token_indexes
+                            )
+                        )
+                    )
+                )
             )
             if not is_unit_designator:
                 comparison_part_tokens.append(token)
@@ -7355,25 +7533,87 @@ def raw_place_coordinate_address_comparison_key(
                     country = country_code
                 break
 
-        comparison_part_tokens = [
-            token
-            for index, token in enumerate(comparison_part_tokens)
-            if not raw_place_coordinate_token_is_postal(
+        postal_token_indexes = {
+            index
+            for index in range(len(comparison_part_tokens))
+            if raw_place_coordinate_token_is_postal(
                 comparison_part_tokens,
                 index,
                 street_numbers,
             )
+        }
+        comparison_part_tokens = [
+            token
+            for index, token in enumerate(comparison_part_tokens)
+            if index not in postal_token_indexes
         ]
+        embedded_subdivision_code_suffix = None
+        if (
+            comparison_part_tokens
+            and (current_part_has_valid_postal or next_part_is_postal_only)
+        ):
+            candidate_suffix = (comparison_part_tokens[-1],)
+            if candidate_suffix in uppercase_word_suffixes:
+                embedded_subdivision_code_suffix = candidate_suffix
         if comparison_part_tokens:
             comparison_parts.append(tuple(comparison_part_tokens))
+            embedded_subdivision_code_suffixes.append(
+                embedded_subdivision_code_suffix
+            )
+    subdivision_country_code = country or country_hint
     subdivision_identities = raw_place_coordinate_subdivision_token_identities(
-        country or country_hint
+        subdivision_country_code
     )
-    comparison_parts = [
-        subdivision_identities.get(part, part)
-        for part in comparison_parts
-    ]
+    comparison_parts = raw_place_coordinate_normalize_subdivision_parts(
+        comparison_parts,
+        subdivision_identities,
+        raw_place_coordinate_subdivision_code_token_identities(
+            subdivision_country_code
+        ),
+        embedded_subdivision_code_suffixes,
+    )
     return tuple(sorted(comparison_parts)), country
+
+
+def raw_place_coordinate_normalize_subdivision_parts(
+    comparison_parts: Sequence[tuple[str, ...]],
+    subdivision_identities: Mapping[tuple[str, ...], tuple[str, ...]],
+    subdivision_code_identities: Mapping[tuple[str, ...], tuple[str, ...]],
+    embedded_subdivision_code_suffixes: Sequence[tuple[str, ...] | None],
+) -> list[tuple[str, ...]]:
+    normalized_parts: list[tuple[str, ...]] = []
+    subdivision_suffixes = sorted(
+        subdivision_code_identities.items(),
+        key=lambda item: (-len(item[0]), item[0]),
+    )
+    for part, allowed_suffix in zip(
+        comparison_parts,
+        embedded_subdivision_code_suffixes,
+        strict=True,
+    ):
+        exact_identity = subdivision_identities.get(part)
+        if exact_identity is not None:
+            normalized_parts.append(exact_identity)
+            continue
+
+        for suffix, identity in subdivision_suffixes:
+            suffix_length = len(suffix)
+            if (
+                suffix != allowed_suffix
+                or suffix_length >= len(part)
+                or part[-suffix_length:] != suffix
+            ):
+                continue
+            prefix = part[:-suffix_length]
+            if prefix:
+                normalized_parts.append(
+                    subdivision_identities.get(prefix, prefix)
+                )
+            normalized_parts.append(identity)
+            break
+        else:
+            normalized_parts.append(part)
+    return list(dict.fromkeys(normalized_parts))
 
 
 def raw_place_coordinate_collapse_street_number_range(
@@ -7539,6 +7779,33 @@ def raw_place_coordinate_subdivision_token_identities(
             if code_key:
                 code_tokens = tuple(raw_place_coordinate_address_token_list(code_key))
                 candidates.setdefault(code_tokens, set()).add(subdivision_code)
+
+    return {
+        tokens: ("subdivision", next(iter(subdivision_codes)).casefold())
+        for tokens, subdivision_codes in candidates.items()
+        if len(subdivision_codes) == 1
+    }
+
+
+@lru_cache(maxsize=None)
+def raw_place_coordinate_subdivision_code_token_identities(
+    country_code: str | None,
+) -> dict[tuple[str, ...], tuple[str, ...]]:
+    if country_code is None:
+        return {}
+
+    candidates: dict[tuple[str, ...], set[str]] = {}
+    for subdivision in pycountry.subdivisions:
+        subdivision_code = as_string(getattr(subdivision, "code", None))
+        if not subdivision_code or "-" not in subdivision_code:
+            continue
+        subdivision_country_code, local_code = subdivision_code.split("-", 1)
+        if subdivision_country_code != country_code:
+            continue
+        code_key = raw_place_coordinate_address_key(local_code)
+        if code_key:
+            code_tokens = tuple(raw_place_coordinate_address_token_list(code_key))
+            candidates.setdefault(code_tokens, set()).add(subdivision_code)
 
     return {
         tokens: ("subdivision", next(iter(subdivision_codes)).casefold())
@@ -7849,6 +8116,17 @@ def raw_place_cid_identity(place: RawPlace) -> str | None:
     return as_string(place.cid) or extract_maps_cid(place.maps_url)
 
 
+def raw_place_cid_identities(place: RawPlace) -> set[str]:
+    return {
+        identity
+        for identity in (
+            as_string(place.cid),
+            extract_maps_cid(place.maps_url),
+        )
+        if identity
+    }
+
+
 def raw_place_google_id_identity(place: RawPlace) -> str | None:
     google_id = as_string(place.google_id)
     if not google_id:
@@ -7880,6 +8158,17 @@ def raw_place_google_places_identities(place: RawPlace) -> set[str]:
 
 def raw_place_maps_place_token_identity(place: RawPlace) -> str | None:
     return as_string(place.maps_place_token) or extract_maps_place_token(place.maps_url)
+
+
+def raw_place_maps_place_token_identities(place: RawPlace) -> set[str]:
+    return {
+        identity
+        for identity in (
+            as_string(place.maps_place_token),
+            extract_maps_place_token(place.maps_url),
+        )
+        if identity
+    }
 
 
 def score_duplicate_raw_place_cid_candidate(
@@ -7938,6 +8227,24 @@ def score_duplicate_raw_place_cid_candidate(
     return score + best_prior_score
 
 
+def preserve_raw_place_url_cid(
+    updates: dict[str, Any],
+    place: RawPlace,
+    url_cid: str | None,
+    *,
+    replacing_cid: str | None = None,
+) -> None:
+    if url_cid is None:
+        return
+    primary_cid = as_string(place.cid)
+    if primary_cid is None or primary_cid == replacing_cid:
+        updates["cid"] = url_cid
+        return
+    if primary_cid == url_cid or url_cid in place.cid_aliases:
+        return
+    updates["cid_aliases"] = [*place.cid_aliases, url_cid]
+
+
 def strip_duplicate_raw_place_cid(
     place: RawPlace,
     *,
@@ -7949,47 +8256,74 @@ def strip_duplicate_raw_place_cid(
     protected_maps_place_tokens: set[str] | None = None,
 ) -> RawPlace:
     updates: dict[str, Any] = {}
+    maps_url = as_string(place.maps_url)
+    maps_url_cid = extract_maps_cid(maps_url)
+    maps_url_google_places_id = extract_maps_query_place_id(maps_url)
+    maps_url_place_token = extract_maps_place_token(maps_url)
     if as_string(place.cid) == cid:
         updates["cid"] = None
-    maps_url_place_token = extract_maps_place_token(place.maps_url)
     maps_place_token = raw_place_maps_place_token_identity(place)
-    if (
-        extract_maps_cid(place.maps_url) == cid
-        or (
-            maps_url_place_token is not None
-            and shared_maps_url_place_tokens is not None
-            and maps_url_place_token in shared_maps_url_place_tokens
+    maps_url_place_token_should_be_cleared = bool(
+        maps_url_place_token is not None
+        and (
+            (
+                shared_maps_url_place_tokens is not None
+                and maps_url_place_token in shared_maps_url_place_tokens
+            )
+            or (
+                protected_maps_place_tokens is not None
+                and maps_url_place_token in protected_maps_place_tokens
+            )
         )
-        or (
-            maps_url_place_token is not None
-            and protected_maps_place_tokens is not None
-            and maps_url_place_token in protected_maps_place_tokens
+    )
+    if maps_url_cid == cid or maps_url_place_token_should_be_cleared:
+        preserved_cid = maps_url_cid if maps_url_cid != cid else None
+        preserved_maps_place_token = (
+            None if maps_url_place_token_should_be_cleared else maps_url_place_token
         )
-    ):
-        updates["maps_url"] = build_public_google_maps_url(
-            name=place.name,
-            address=place.address,
-            lat=place.lat,
-            lng=place.lng,
-            raw_maps_url=None,
+        preserve_raw_place_url_cid(
+            updates,
+            place,
+            preserved_cid,
+            replacing_cid=cid,
         )
-    if not updates:
-        return place
+        updates["maps_url"] = build_raw_place_maps_url_preserving_identity(
+            place,
+            cid=preserved_cid,
+            google_places_id=maps_url_google_places_id,
+            maps_place_token=preserved_maps_place_token,
+        )
+    else:
+        preserved_maps_place_token = None
     google_id = raw_place_google_id_identity(place)
     if google_id and (
         (shared_google_ids is not None and google_id in shared_google_ids)
         or (protected_google_ids is not None and google_id in protected_google_ids)
     ):
         updates["google_id"] = None
-    if (
+    maps_place_token_should_be_cleared = bool(
         as_string(place.maps_place_token)
         and maps_place_token
         and (
-            (shared_maps_place_tokens is not None and maps_place_token in shared_maps_place_tokens)
-            or (protected_maps_place_tokens is not None and maps_place_token in protected_maps_place_tokens)
+            (
+                shared_maps_place_tokens is not None
+                and maps_place_token in shared_maps_place_tokens
+            )
+            or (
+                protected_maps_place_tokens is not None
+                and maps_place_token in protected_maps_place_tokens
+            )
         )
-    ):
+    )
+    if maps_place_token_should_be_cleared:
         updates["maps_place_token"] = None
+    if preserved_maps_place_token is not None and (
+        as_string(place.maps_place_token) is None
+        or maps_place_token_should_be_cleared
+    ):
+        updates["maps_place_token"] = preserved_maps_place_token
+    if not updates:
+        return place
     return place.model_copy(update=updates)
 
 
@@ -7999,102 +8333,141 @@ def clear_duplicate_raw_place_cids(
     payload: RawSavedList,
     existing_payload: RawSavedList | None,
 ) -> RawSavedList:
-    indexes_by_cid: dict[str, list[int]] = {}
-    for index, place in enumerate(payload.places):
-        cid = raw_place_cid_identity(place)
-        if cid:
-            indexes_by_cid.setdefault(cid, []).append(index)
-
-    duplicate_indexes_by_cid = {
-        cid: indexes for cid, indexes in indexes_by_cid.items() if len(indexes) > 1
-    }
-    if not duplicate_indexes_by_cid:
-        return payload
-
     prior_places_by_cid: dict[str, list[RawPlace]] = {}
     if existing_payload is not None:
         for prior_place in existing_payload.places:
-            cid = raw_place_cid_identity(prior_place)
-            if cid:
+            for cid in raw_place_cid_identities(prior_place):
                 prior_places_by_cid.setdefault(cid, []).append(prior_place)
 
     updated_places = list(payload.places)
-    for cid, indexes in duplicate_indexes_by_cid.items():
-        prior_places = prior_places_by_cid.get(cid, [])
-        google_id_counts = Counter(
-            google_id
-            for google_id in (raw_place_google_id_identity(updated_places[index]) for index in indexes)
-            if google_id is not None
-        )
-        shared_google_ids = {google_id for google_id, count in google_id_counts.items() if count > 1}
-        maps_place_token_counts = Counter(
-            token
-            for token in (raw_place_maps_place_token_identity(updated_places[index]) for index in indexes)
-            if token is not None
-        )
-        shared_maps_place_tokens = {
-            token for token, count in maps_place_token_counts.items() if count > 1
+    made_updates = False
+    while True:
+        indexes_by_cid: dict[str, list[int]] = {}
+        for index, place in enumerate(updated_places):
+            for cid in raw_place_cid_identities(place):
+                indexes_by_cid.setdefault(cid, []).append(index)
+
+        duplicate_indexes_by_cid = {
+            cid: indexes
+            for cid, indexes in indexes_by_cid.items()
+            if len(indexes) > 1
         }
-        maps_url_place_token_counts = Counter(
-            token
-            for token in (extract_maps_place_token(updated_places[index].maps_url) for index in indexes)
-            if token is not None
-        )
-        shared_maps_url_place_tokens = {
-            token for token, count in maps_url_place_token_counts.items() if count > 1
-        }
-        keep_index = max(
-            indexes,
-            key=lambda index: (
-                score_duplicate_raw_place_cid_candidate(
-                    updated_places[index],
-                    cid=cid,
-                    prior_places=prior_places,
+        if not duplicate_indexes_by_cid:
+            break
+
+        pass_made_updates = False
+        for cid, indexes in duplicate_indexes_by_cid.items():
+            prior_places = prior_places_by_cid.get(cid, [])
+            google_id_counts = Counter(
+                google_id
+                for google_id in (
+                    raw_place_google_id_identity(updated_places[index])
+                    for index in indexes
+                )
+                if google_id is not None
+            )
+            shared_google_ids = {
+                google_id
+                for google_id, count in google_id_counts.items()
+                if count > 1
+            }
+            maps_place_token_counts = Counter(
+                token
+                for token in (
+                    raw_place_maps_place_token_identity(updated_places[index])
+                    for index in indexes
+                )
+                if token is not None
+            )
+            shared_maps_place_tokens = {
+                token
+                for token, count in maps_place_token_counts.items()
+                if count > 1
+            }
+            maps_url_place_token_counts = Counter(
+                token
+                for token in (
+                    extract_maps_place_token(updated_places[index].maps_url)
+                    for index in indexes
+                )
+                if token is not None
+            )
+            shared_maps_url_place_tokens = {
+                token
+                for token, count in maps_url_place_token_counts.items()
+                if count > 1
+            }
+            keep_index = max(
+                indexes,
+                key=lambda index: (
+                    len(raw_place_cid_identities(updated_places[index])) <= 1,
+                    score_duplicate_raw_place_cid_candidate(
+                        updated_places[index],
+                        cid=cid,
+                        prior_places=prior_places,
+                    ),
+                    -index,
                 ),
-                -index,
-            ),
-        )
-        kept_place = updated_places[keep_index]
-        protected_google_ids = {
-            google_id
-            for prior_place in prior_places
-            if raw_place_names_are_compatible(as_string(prior_place.name), as_string(kept_place.name))
-            for google_id in [raw_place_google_id_identity(prior_place)]
-            if google_id is not None
-        }
-        protected_maps_place_tokens = {
-            token
-            for prior_place in prior_places
-            if raw_place_names_are_compatible(as_string(prior_place.name), as_string(kept_place.name))
-            for token in [raw_place_maps_place_token_identity(prior_place)]
-            if token is not None
-        }
-        cleared_names: list[str] = []
-        for index in indexes:
-            if index == keep_index:
-                continue
-            original_place = updated_places[index]
-            updated_place = strip_duplicate_raw_place_cid(
-                original_place,
-                cid=cid,
-                shared_google_ids=shared_google_ids,
-                shared_maps_place_tokens=shared_maps_place_tokens,
-                shared_maps_url_place_tokens=shared_maps_url_place_tokens,
-                protected_google_ids=protected_google_ids,
-                protected_maps_place_tokens=protected_maps_place_tokens,
             )
-            if updated_place != original_place:
-                updated_places[index] = updated_place
-                cleared_names.append(updated_place.name or f"place #{index + 1}")
+            kept_place = updated_places[keep_index]
+            protected_google_ids = {
+                google_id
+                for prior_place in prior_places
+                if raw_place_names_are_compatible(
+                    as_string(prior_place.name),
+                    as_string(kept_place.name),
+                )
+                for google_id in [raw_place_google_id_identity(prior_place)]
+                if google_id is not None
+            }
+            protected_maps_place_tokens = {
+                token
+                for prior_place in prior_places
+                if raw_place_names_are_compatible(
+                    as_string(prior_place.name),
+                    as_string(kept_place.name),
+                )
+                for token in [raw_place_maps_place_token_identity(prior_place)]
+                if token is not None
+            }
+            cleared_names: list[str] = []
+            for index in indexes:
+                if index == keep_index:
+                    continue
+                original_place = updated_places[index]
+                updated_place = strip_duplicate_raw_place_cid(
+                    original_place,
+                    cid=cid,
+                    shared_google_ids=shared_google_ids,
+                    shared_maps_place_tokens=shared_maps_place_tokens,
+                    shared_maps_url_place_tokens=shared_maps_url_place_tokens,
+                    protected_google_ids=protected_google_ids,
+                    protected_maps_place_tokens=protected_maps_place_tokens,
+                )
+                if updated_place != original_place:
+                    updated_places[index] = updated_place
+                    cleared_names.append(
+                        updated_place.name or f"place #{index + 1}"
+                    )
 
-        if cleared_names:
-            kept_name = updated_places[keep_index].name or f"place #{keep_index + 1}"
-            print(
-                f"WARNING: Clearing duplicate raw CID {cid} in {slug}: "
-                f"kept [{kept_name}], cleared [{', '.join(cleared_names)}].",
-                flush=True,
-            )
+            if cleared_names:
+                pass_made_updates = True
+                made_updates = True
+                kept_name = (
+                    updated_places[keep_index].name
+                    or f"place #{keep_index + 1}"
+                )
+                print(
+                    f"WARNING: Clearing duplicate raw CID {cid} in {slug}: "
+                    f"kept [{kept_name}], cleared "
+                    f"[{', '.join(cleared_names)}].",
+                    flush=True,
+                )
+        if not pass_made_updates:
+            break
 
+    if not made_updates:
+        return payload
     return payload.model_copy(update={"places": updated_places})
 
 
@@ -8103,7 +8476,7 @@ def score_duplicate_raw_place_google_identity_candidate(
     *,
     prior_places: Sequence[RawPlace],
 ) -> int:
-    score = 50 if raw_place_cid_identity(place) else 0
+    score = 0
     best_prior_score = 0
     for prior_place in prior_places:
         prior_score = 0
@@ -8142,29 +8515,103 @@ def score_duplicate_raw_place_google_identity_candidate(
     return score + best_prior_score
 
 
+def build_raw_place_maps_url_preserving_identity(
+    place: RawPlace,
+    *,
+    cid: str | None = None,
+    google_places_id: str | None = None,
+    maps_place_token: str | None = None,
+) -> str:
+    if google_places_id is not None:
+        query = build_maps_link_query(
+            name=place.name,
+            address=place.address,
+            lat=place.lat,
+            lng=place.lng,
+        ) or google_places_id
+        return build_google_maps_search_url(
+            query,
+            google_place_id=google_places_id,
+        )
+    if maps_place_token is not None:
+        return (
+            "https://www.google.com/maps/place/data=!4m2!3m1!1s"
+            f"{maps_place_token}"
+        )
+    if cid is not None:
+        return f"https://www.google.com/maps?cid={cid}"
+    return build_public_google_maps_url(
+        name=place.name,
+        address=place.address,
+        lat=place.lat,
+        lng=place.lng,
+        raw_maps_url=None,
+    )
+
+
 def strip_duplicate_raw_place_google_identity(
     place: RawPlace,
     *,
     google_id: str | None = None,
+    google_places_id: str | None = None,
     maps_place_token: str | None = None,
 ) -> RawPlace:
     updates: dict[str, Any] = {}
+    maps_url = as_string(place.maps_url)
+    maps_url_cid = extract_maps_cid(maps_url)
+    embedded_google_places_id = extract_maps_query_place_id(maps_url)
+    embedded_maps_place_token = extract_maps_place_token(maps_url)
     if google_id is not None and raw_place_google_id_identity(place) == google_id:
         updates["google_id"] = None
+    if google_places_id is not None:
+        raw_google_id = as_string(place.google_id)
+        stored_google_places_id = None
+        if raw_google_id:
+            if raw_google_id.startswith("places/"):
+                stored_google_places_id = raw_google_id.removeprefix("places/") or None
+            elif "/" not in raw_google_id:
+                stored_google_places_id = raw_google_id
+        if stored_google_places_id == google_places_id:
+            updates["google_id"] = None
+
+    if (
+        google_places_id is not None
+        and embedded_google_places_id == google_places_id
+    ):
+        preserve_raw_place_url_cid(updates, place, maps_url_cid)
+        if (
+            embedded_maps_place_token is not None
+            and as_string(place.maps_place_token) is None
+        ):
+            updates["maps_place_token"] = embedded_maps_place_token
+        updates["maps_url"] = build_raw_place_maps_url_preserving_identity(
+            place,
+            cid=maps_url_cid,
+            maps_place_token=embedded_maps_place_token,
+        )
     if maps_place_token is not None:
         if as_string(place.maps_place_token) == maps_place_token:
             updates["maps_place_token"] = None
         if extract_maps_place_token(place.maps_url) == maps_place_token:
-            updates["maps_url"] = build_public_google_maps_url(
-                name=place.name,
-                address=place.address,
-                lat=place.lat,
-                lng=place.lng,
-                raw_maps_url=None,
+            preserve_raw_place_url_cid(updates, place, maps_url_cid)
+            updates["maps_url"] = build_raw_place_maps_url_preserving_identity(
+                place,
+                cid=maps_url_cid,
+                google_places_id=embedded_google_places_id,
             )
     if not updates:
         return place
     return place.model_copy(update=updates)
+
+
+def raw_place_duplicate_identity_candidate_is_consistent(
+    place: RawPlace,
+    *,
+    identity_name: str,
+) -> bool:
+    if identity_name in {"google_id", "google_places_id"}:
+        return len(raw_place_google_places_identities(place)) <= 1
+    return len(raw_place_maps_place_token_identities(place)) <= 1
 
 
 def clear_duplicate_raw_place_google_identities(
@@ -8174,78 +8621,119 @@ def clear_duplicate_raw_place_google_identities(
     existing_payload: RawSavedList | None,
 ) -> RawSavedList:
     updated_places = list(payload.places)
-    duplicate_groups: list[tuple[str, str, list[int]]] = []
-    for identity_name, identity_getter in (
-        ("google_id", raw_place_google_id_identity),
-        ("maps_place_token", raw_place_maps_place_token_identity),
-    ):
-        indexes_by_identity: dict[str, list[int]] = {}
-        for index, place in enumerate(updated_places):
-            identity = identity_getter(place)
-            if identity:
-                indexes_by_identity.setdefault(identity, []).append(index)
-        duplicate_groups.extend(
-            (identity_name, identity, indexes)
-            for identity, indexes in indexes_by_identity.items()
-            if len(indexes) > 1
-        )
-
-    if not duplicate_groups:
-        return payload
+    identity_getters = (
+        (
+            "google_id",
+            lambda place: {
+                identity
+                for identity in (raw_place_google_id_identity(place),)
+                if identity
+            },
+        ),
+        ("google_places_id", raw_place_google_places_identities),
+        ("maps_place_token", raw_place_maps_place_token_identities),
+    )
 
     prior_places_by_google_id: dict[str, list[RawPlace]] = {}
+    prior_places_by_google_places_id: dict[str, list[RawPlace]] = {}
     prior_places_by_maps_place_token: dict[str, list[RawPlace]] = {}
     if existing_payload is not None:
         for prior_place in existing_payload.places:
             google_id = raw_place_google_id_identity(prior_place)
             if google_id:
                 prior_places_by_google_id.setdefault(google_id, []).append(prior_place)
-            maps_place_token = raw_place_maps_place_token_identity(prior_place)
-            if maps_place_token:
-                prior_places_by_maps_place_token.setdefault(maps_place_token, []).append(prior_place)
+            for google_places_id in raw_place_google_places_identities(
+                prior_place
+            ):
+                prior_places_by_google_places_id.setdefault(
+                    google_places_id,
+                    [],
+                ).append(prior_place)
+            for maps_place_token in raw_place_maps_place_token_identities(
+                prior_place
+            ):
+                prior_places_by_maps_place_token.setdefault(
+                    maps_place_token,
+                    [],
+                ).append(prior_place)
 
-    for identity_name, identity, indexes in duplicate_groups:
-        prior_places = (
-            prior_places_by_google_id.get(identity, [])
-            if identity_name == "google_id"
-            else prior_places_by_maps_place_token.get(identity, [])
-        )
-        keep_index = max(
-            indexes,
-            key=lambda index: (
-                score_duplicate_raw_place_google_identity_candidate(
-                    updated_places[index],
-                    prior_places=prior_places,
-                ),
-                -index,
-            ),
-        )
-        cleared_names: list[str] = []
-        for index in indexes:
-            if index == keep_index:
-                continue
-            original_place = updated_places[index]
-            updated_place = strip_duplicate_raw_place_google_identity(
-                original_place,
-                google_id=identity if identity_name == "google_id" else None,
-                maps_place_token=(
-                    identity
-                    if identity_name == "maps_place_token"
-                    else raw_place_maps_place_token_identity(updated_places[keep_index])
-                ),
-            )
-            if updated_place != original_place:
-                updated_places[index] = updated_place
-                cleared_names.append(updated_place.name or f"place #{index + 1}")
+    made_updates = False
+    while True:
+        pass_made_updates = False
+        for identity_name, identity_getter in identity_getters:
+            indexes_by_identity: dict[str, list[int]] = {}
+            for index, place in enumerate(updated_places):
+                for identity in identity_getter(place):
+                    indexes_by_identity.setdefault(identity, []).append(index)
 
-        if cleared_names:
-            kept_name = updated_places[keep_index].name or f"place #{keep_index + 1}"
-            print(
-                f"WARNING: Clearing duplicate raw {identity_name} {identity} in {slug}: "
-                f"kept [{kept_name}], cleared [{', '.join(cleared_names)}].",
-                flush=True,
-            )
+            for identity, indexes in indexes_by_identity.items():
+                if len(indexes) <= 1:
+                    continue
+                if identity_name == "google_id":
+                    prior_places = prior_places_by_google_id.get(identity, [])
+                elif identity_name == "google_places_id":
+                    prior_places = prior_places_by_google_places_id.get(identity, [])
+                else:
+                    prior_places = prior_places_by_maps_place_token.get(identity, [])
+                keep_index = max(
+                    indexes,
+                    key=lambda index: (
+                        raw_place_duplicate_identity_candidate_is_consistent(
+                            updated_places[index],
+                            identity_name=identity_name,
+                        ),
+                        score_duplicate_raw_place_google_identity_candidate(
+                            updated_places[index],
+                            prior_places=prior_places,
+                        ),
+                        -index,
+                    ),
+                )
+                cleared_names: list[str] = []
+                for index in indexes:
+                    if index == keep_index:
+                        continue
+                    original_place = updated_places[index]
+                    updated_place = strip_duplicate_raw_place_google_identity(
+                        original_place,
+                        google_id=(
+                            identity if identity_name == "google_id" else None
+                        ),
+                        google_places_id=(
+                            identity
+                            if identity_name == "google_places_id"
+                            else None
+                        ),
+                        maps_place_token=(
+                            identity
+                            if identity_name == "maps_place_token"
+                            else None
+                        ),
+                    )
+                    if updated_place != original_place:
+                        updated_places[index] = updated_place
+                        cleared_names.append(
+                            updated_place.name or f"place #{index + 1}"
+                        )
 
+                if cleared_names:
+                    pass_made_updates = True
+                    made_updates = True
+                    kept_name = (
+                        updated_places[keep_index].name
+                        or f"place #{keep_index + 1}"
+                    )
+                    print(
+                        f"WARNING: Clearing duplicate raw {identity_name} "
+                        f"{identity} in {slug}: kept [{kept_name}], "
+                        f"cleared [{', '.join(cleared_names)}].",
+                        flush=True,
+                    )
+        if not pass_made_updates:
+            break
+
+    if not made_updates:
+        return payload
     return payload.model_copy(update={"places": updated_places})
 
 
@@ -8297,6 +8785,16 @@ def preserve_existing_raw_saved_list(
         )
 
     source_type = refreshed_payload.configured_source_type or existing_payload.configured_source_type
+    refreshed_payload = clear_duplicate_raw_place_cids(
+        slug=slug,
+        payload=refreshed_payload,
+        existing_payload=existing_payload,
+    )
+    refreshed_payload = clear_duplicate_raw_place_google_identities(
+        slug=slug,
+        payload=refreshed_payload,
+        existing_payload=existing_payload,
+    )
     if not allow_suspicious_identity_loss and raw_saved_list_refresh_has_suspicious_identity_loss(
         existing_payload,
         refreshed_payload,
@@ -8309,11 +8807,6 @@ def preserve_existing_raw_saved_list(
         )
         return existing_payload
 
-    refreshed_payload = clear_duplicate_raw_place_cids(
-        slug=slug,
-        payload=refreshed_payload,
-        existing_payload=existing_payload,
-    )
     existing_index = build_raw_place_preservation_index(existing_payload, source_type=source_type)
     updated_places: list[RawPlace] = []
 

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7263,6 +7263,12 @@ def raw_place_coordinate_part_has_street_marker(
     address_key: str,
     tokens: list[str],
 ) -> bool:
+    normalized_part = unicodedata.normalize("NFKC", part).casefold()
+    if re.match(
+        r"\s*(?:c(?:\.|/)|p(?:\.\s*)?za\.?|pl\.)\s*(?=[^\W\d_])",
+        normalized_part,
+    ):
+        return True
     street_suffix_indexes = {
         index
         for index, token in enumerate(tokens)
@@ -7281,9 +7287,14 @@ def raw_place_coordinate_part_has_street_marker(
 
 
 def raw_place_coordinate_part_is_premise_number(tokens: list[str]) -> bool:
-    if not tokens or not any(character.isdigit() for character in tokens[0]):
+    premise_tokens = tokens
+    if premise_tokens and premise_tokens[0] in RAW_PLACE_UNIT_NUMBER_LABEL_TOKENS:
+        premise_tokens = premise_tokens[1:]
+    if not premise_tokens or not any(
+        character.isdigit() for character in premise_tokens[0]
+    ):
         return False
-    for token in tokens:
+    for token in premise_tokens:
         compact = re.sub(r"[^a-z0-9]", "", token)
         if compact.isdigit() and 1 <= len(compact) <= 4:
             continue
@@ -7454,6 +7465,7 @@ def raw_place_coordinate_address_comparison_key(
                 part_tokens,
                 index,
                 street_numbers,
+                country_code=country or country_hint,
             )
         }
         current_part_has_valid_postal = (
@@ -7480,6 +7492,7 @@ def raw_place_coordinate_address_comparison_key(
                     next_part_tokens,
                     index,
                     street_numbers,
+                    country_code=country or country_hint,
                 )
             }
             next_part_is_postal_only = (
@@ -7561,6 +7574,7 @@ def raw_place_coordinate_address_comparison_key(
                 comparison_part_tokens,
                 index,
                 street_numbers,
+                country_code=country or country_hint,
             )
         }
         comparison_part_tokens = [
@@ -7661,20 +7675,53 @@ def raw_place_coordinate_collapse_street_number_range(
     return collapsed if replaced else None
 
 
+def raw_place_coordinate_token_is_part_of_valid_alphanumeric_postal(
+    tokens: Sequence[str],
+    index: int,
+    country_code: str | None,
+) -> bool:
+    if country_code not in {"CA", "GB"}:
+        return False
+    for span_length in (1, 2):
+        first_start = max(0, index - span_length + 1)
+        last_start = min(index, len(tokens) - span_length)
+        for start in range(first_start, last_start + 1):
+            indexes = set(range(start, start + span_length))
+            if raw_place_coordinate_postal_evidence_is_valid_for_country(
+                tokens,
+                indexes,
+                country_code,
+            ):
+                return True
+    return False
+
+
 def raw_place_coordinate_token_is_postal(
     tokens: list[str],
     index: int,
     street_numbers: set[str],
+    *,
+    country_code: str | None = None,
 ) -> bool:
     token = tokens[index]
     numbers = set(re.findall(r"\d+", token))
-    if not numbers or numbers & street_numbers:
+    if not numbers:
+        return False
+    compact = re.sub(r"[^a-z0-9]", "", token)
+    if numbers & street_numbers and not (
+        any(character.isalpha() for character in compact)
+        and any(character.isdigit() for character in compact)
+        and raw_place_coordinate_token_is_part_of_valid_alphanumeric_postal(
+            tokens,
+            index,
+            country_code,
+        )
+    ):
         return False
     previous_token = tokens[index - 1] if index > 0 else None
     if previous_token in {"hwy", "rte"}:
         return False
 
-    compact = re.sub(r"[^a-z0-9]", "", token)
     if compact.isdigit():
         if 4 <= len(compact) <= 6:
             return True

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -159,6 +159,7 @@ OPERATIONAL_CACHE_TTL = timedelta(days=14)
 PHOTOLESS_REAL_PLACE_CACHE_TTL = timedelta(days=1)
 RAW_SOURCE_CACHE_TTL = timedelta(days=14)
 RAW_SOURCE_REFRESH_JITTER = timedelta(days=3)
+RAW_PLACE_SUSPICIOUS_COORDINATE_SHIFT_METERS = 1_000.0
 SOURCE_HTTP_TIMEOUT_SECONDS = 30
 SOURCE_HTTP_USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
@@ -6715,6 +6716,19 @@ def preserve_existing_raw_place(
     if names_compatible and refreshed_place.added_by is None and existing_place.added_by is not None:
         updates["added_by"] = existing_place.added_by
         preserved_fields.append("added_by")
+    if names_compatible and raw_place_coordinates_should_be_preserved(
+        existing_place,
+        refreshed_place,
+    ):
+        updates["lat"] = existing_place.lat
+        updates["lng"] = existing_place.lng
+        preserved_fields.append("coordinates")
+    if "coordinates" in preserved_fields and raw_place_maps_url_should_be_preserved(
+        existing_place,
+        refreshed_place,
+    ):
+        updates["maps_url"] = existing_place.maps_url
+        preserved_fields.append("maps_url")
 
     if not updates:
         return refreshed_place, preserved_fields
@@ -6730,6 +6744,129 @@ def raw_place_strong_google_identity_matches(left: RawPlace, right: RawPlace) ->
     left_maps_place_token = raw_place_maps_place_token_identity(left)
     right_maps_place_token = raw_place_maps_place_token_identity(right)
     return left_maps_place_token is not None and left_maps_place_token == right_maps_place_token
+
+
+def raw_place_coordinates_should_be_preserved(
+    existing_place: RawPlace,
+    refreshed_place: RawPlace,
+) -> bool:
+    if not raw_place_coordinate_identity_matches(existing_place, refreshed_place):
+        return False
+    if not raw_place_coordinate_address_is_stable(existing_place, refreshed_place):
+        return False
+
+    existing_lat = as_float(existing_place.lat)
+    existing_lng = as_float(existing_place.lng)
+    if existing_lat is None or existing_lng is None:
+        return False
+
+    refreshed_lat = as_float(refreshed_place.lat)
+    refreshed_lng = as_float(refreshed_place.lng)
+    if refreshed_lat is None or refreshed_lng is None:
+        return True
+
+    return (
+        haversine_meters(
+            existing_lat,
+            existing_lng,
+            refreshed_lat,
+            refreshed_lng,
+        )
+        > RAW_PLACE_SUSPICIOUS_COORDINATE_SHIFT_METERS
+    )
+
+
+def raw_place_coordinate_identity_matches(left: RawPlace, right: RawPlace) -> bool:
+    if raw_place_strong_google_identity_matches(left, right):
+        return True
+
+    left_cids = {
+        cid
+        for cid in [raw_place_cid_identity(left), *left.cid_aliases]
+        if cid
+    }
+    right_cids = {
+        cid
+        for cid in [raw_place_cid_identity(right), *right.cid_aliases]
+        if cid
+    }
+    return bool(left_cids & right_cids)
+
+
+def raw_place_coordinate_address_is_stable(
+    existing_place: RawPlace,
+    refreshed_place: RawPlace,
+) -> bool:
+    existing_address = as_string(existing_place.address)
+    if not existing_address:
+        return False
+
+    refreshed_address = as_string(refreshed_place.address)
+    if not refreshed_address:
+        return raw_place_address_is_preservable(existing_place, refreshed_place)
+
+    existing_address_key = raw_place_coordinate_address_key(existing_address)
+    refreshed_address_key = raw_place_coordinate_address_key(refreshed_address)
+    return existing_address_key is not None and existing_address_key == refreshed_address_key
+
+
+def raw_place_coordinate_address_key(address: str) -> str | None:
+    normalized = unicodedata.normalize("NFKC", address).casefold()
+    normalized_characters = [
+        character if unicodedata.category(character)[0] in {"L", "N"} else " "
+        for character in normalized
+    ]
+    compact = re.sub(r"\s+", " ", "".join(normalized_characters)).strip()
+    return compact or None
+
+
+def raw_place_maps_url_should_be_preserved(
+    existing_place: RawPlace,
+    refreshed_place: RawPlace,
+) -> bool:
+    existing_url = as_string(existing_place.maps_url)
+    refreshed_url = as_string(refreshed_place.maps_url)
+    if not existing_url or existing_url == refreshed_url:
+        return False
+    if google_maps_uri_strength(existing_url) < google_maps_uri_strength(refreshed_url):
+        return False
+
+    existing_url_cid = extract_maps_cid(existing_url)
+    refreshed_cids = {
+        cid
+        for cid in [
+            as_string(refreshed_place.cid),
+            extract_maps_cid(refreshed_url),
+            *refreshed_place.cid_aliases,
+        ]
+        if cid
+    }
+    if existing_url_cid and refreshed_cids and existing_url_cid not in refreshed_cids:
+        return False
+
+    existing_query_place_id = extract_maps_query_place_id(existing_url)
+    refreshed_query_place_id = extract_maps_query_place_id(refreshed_url)
+    if (
+        existing_query_place_id
+        and refreshed_query_place_id
+        and existing_query_place_id != refreshed_query_place_id
+    ):
+        return False
+
+    existing_url_token = extract_maps_place_token(existing_url)
+    refreshed_tokens = {
+        token
+        for token in [
+            as_string(refreshed_place.maps_place_token),
+            extract_maps_place_token(refreshed_url),
+        ]
+        if token
+    }
+    return not (
+        existing_url_token
+        and refreshed_tokens
+        and existing_url_token not in refreshed_tokens
+    )
 
 
 def raw_place_names_are_compatible(existing_name: str | None, refreshed_name: str | None) -> bool:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -180,6 +180,16 @@ RAW_PLACE_ADDRESS_TOKEN_ALIASES = {
     "street": "st",
     "terrace": "ter",
 }
+RAW_PLACE_DIRECTION_TOKEN_ALIASES = {
+    "east": "e",
+    "north": "n",
+    "northeast": "ne",
+    "northwest": "nw",
+    "south": "s",
+    "southeast": "se",
+    "southwest": "sw",
+    "west": "w",
+}
 RAW_PLACE_ORDINAL_WORD_VALUES = {
     "first": 1,
     "second": 2,
@@ -6797,6 +6807,7 @@ def preserve_existing_raw_place(
         and raw_place_refreshed_url_identity_is_compatible(
             existing_place,
             refreshed_place.maps_url,
+            refreshed_cid=as_string(refreshed_place.cid),
         )
     ):
         updates["google_id"] = existing_place.google_id
@@ -6808,6 +6819,7 @@ def preserve_existing_raw_place(
         and raw_place_refreshed_url_identity_is_compatible(
             existing_place,
             refreshed_place.maps_url,
+            refreshed_cid=as_string(refreshed_place.cid),
         )
     ):
         updates["cid"] = existing_place.cid
@@ -6830,6 +6842,7 @@ def preserve_existing_raw_place(
         and raw_place_refreshed_url_identity_is_compatible(
             existing_place,
             refreshed_place.maps_url,
+            refreshed_cid=as_string(refreshed_place.cid),
         )
     ):
         updates["maps_place_token"] = existing_place.maps_place_token
@@ -6903,12 +6916,28 @@ def raw_place_coordinate_identity_matches(left: RawPlace, right: RawPlace) -> bo
     google_places_ids_are_consistent = (
         len(left_google_places_ids) <= 1 and len(right_google_places_ids) <= 1
     )
+    google_places_ids_conflict = bool(
+        left_google_places_ids
+        and right_google_places_ids
+        and left_google_places_ids.isdisjoint(right_google_places_ids)
+    )
+
+    left_legacy_google_id = raw_place_legacy_google_id_identity(left)
+    right_legacy_google_id = raw_place_legacy_google_id_identity(right)
+    legacy_google_ids_conflict = bool(
+        left_legacy_google_id
+        and right_legacy_google_id
+        and left_legacy_google_id != right_legacy_google_id
+    )
 
     left_maps_place_token = raw_place_maps_place_token_identity(left)
     right_maps_place_token = raw_place_maps_place_token_identity(right)
     if (
         left_maps_place_token is not None
         and left_maps_place_token == right_maps_place_token
+        and google_places_ids_are_consistent
+        and not google_places_ids_conflict
+        and not legacy_google_ids_conflict
     ):
         return True
 
@@ -6941,11 +6970,6 @@ def raw_place_coordinate_identity_matches(left: RawPlace, right: RawPlace) -> bo
         for cid in [right_primary_cid, *right.cid_aliases]
         if cid
     }
-    google_places_ids_conflict = bool(
-        left_google_places_ids
-        and right_google_places_ids
-        and left_google_places_ids.isdisjoint(right_google_places_ids)
-    )
     names_are_compatible = raw_place_names_are_compatible(
         as_string(left.name),
         as_string(right.name),
@@ -7135,6 +7159,43 @@ def raw_place_coordinate_address_key(address: str) -> str | None:
     return compact or None
 
 
+def raw_place_coordinate_normalize_street_prefix(
+    part: str,
+    country_code: str | None,
+) -> str:
+    normalized = unicodedata.normalize("NFKC", part)
+    prefix_replacements = (
+        (r"^\s*c(?:\.|/)\s*(?=[^\W\d_])", "Calle "),
+        (r"^\s*pl\.\s*(?=[^\W\d_])", "Plaza "),
+    )
+    for pattern, replacement in prefix_replacements:
+        if re.match(pattern, normalized, flags=re.IGNORECASE):
+            return re.sub(
+                pattern,
+                replacement,
+                normalized,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+    piazza_or_plaza_match = re.match(
+        r"^\s*p(?:\.\s*)?za\.?\s*(?=[^\W\d_])",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    if piazza_or_plaza_match is not None:
+        replacement = "Piazza " if country_code == "IT" else "Plaza "
+        return f"{replacement}{normalized[piazza_or_plaza_match.end():]}"
+    if country_code == "IT":
+        return re.sub(
+            r"^\s*str\.\s*(?=[^\W\d_])",
+            "Strada ",
+            normalized,
+            count=1,
+            flags=re.IGNORECASE,
+        )
+    return normalized
+
+
 def raw_place_coordinate_address_token_list(address_key: str) -> list[str]:
     raw_tokens = address_key.split()
     normalized_tokens: list[str] = []
@@ -7170,7 +7231,12 @@ def raw_place_coordinate_address_token_list(address_key: str) -> list[str]:
                 )
                 index += 2
                 continue
-        normalized_tokens.append(RAW_PLACE_ADDRESS_TOKEN_ALIASES.get(token, token))
+        normalized_tokens.append(
+            RAW_PLACE_DIRECTION_TOKEN_ALIASES.get(
+                token,
+                RAW_PLACE_ADDRESS_TOKEN_ALIASES.get(token, token),
+            )
+        )
         index += 1
     return normalized_tokens
 
@@ -7230,6 +7296,9 @@ def raw_place_coordinate_address_has_street_level_evidence(address: str) -> bool
             part,
             address_key,
             tokens,
+        ) and raw_place_coordinate_numeric_indexes_include_premise(
+            tokens,
+            numeric_indexes,
         ):
             return True
 
@@ -7272,12 +7341,12 @@ def raw_place_coordinate_part_has_street_marker(
     street_suffix_indexes = {
         index
         for index, token in enumerate(tokens)
-        if token in RAW_PLACE_STREET_SUFFIX_TOKENS
+        if index > 0 and token in RAW_PLACE_STREET_SUFFIX_TOKENS
     }
     if any(index > 0 for index in street_suffix_indexes):
         return True
     if re.search(
-        r"\b(?:allee|allée|av|avenida|calle|carrer|chaussee|chaussée|chemin|chome|corso|impasse|piazza|quai|r|rua|rue|str|strasse|straße|via)\b",
+        r"\b(?:allee|allée|av|avenida|calle|carrer|chaussee|chaussée|chemin|chome|corso|impasse|largo|passeig|piazza|plaza|quai|r|rua|rue|str|strada|strasse|straße|via|viale)\b",
         address_key,
     ):
         return True
@@ -7298,10 +7367,31 @@ def raw_place_coordinate_part_is_premise_number(tokens: list[str]) -> bool:
         compact = re.sub(r"[^a-z0-9]", "", token)
         if compact.isdigit() and 1 <= len(compact) <= 4:
             continue
+        if re.fullmatch(r"\d{1,4}[a-z]{1,3}", compact):
+            continue
         if compact.isalpha() and len(compact) <= 3:
             continue
         return False
     return True
+
+
+def raw_place_coordinate_numeric_indexes_include_premise(
+    tokens: Sequence[str],
+    numeric_indexes: set[int],
+) -> bool:
+    street_suffix_indexes = {
+        index
+        for index, token in enumerate(tokens)
+        if index > 0 and token in RAW_PLACE_STREET_SUFFIX_TOKENS
+    }
+    if not street_suffix_indexes:
+        return bool(numeric_indexes)
+    first_suffix_index = min(street_suffix_indexes)
+    last_suffix_index = max(street_suffix_indexes)
+    return any(
+        index < first_suffix_index or index == last_suffix_index + 1
+        for index in numeric_indexes
+    )
 
 
 def raw_place_coordinate_part_is_route_only(
@@ -7432,10 +7522,14 @@ def raw_place_coordinate_address_comparison_key(
         )
     )
     for raw_part_index, raw_part in enumerate(raw_parts):
+        part = raw_place_coordinate_normalize_street_prefix(
+            raw_part,
+            country or country_hint,
+        )
         part = re.sub(
             r"^\s*(?:unit\s+)?[^/\s,]+\s*/\s*",
             "",
-            raw_part,
+            part,
             flags=re.IGNORECASE,
         )
         part = re.sub(r"#\s*[\w-]+", "", part)
@@ -7447,7 +7541,9 @@ def raw_place_coordinate_address_comparison_key(
             part_tokens,
             part=raw_part,
         ):
-            part_tokens = [token for token in part_tokens if token != "and"]
+            part_tokens = [
+                token for token in part_tokens if token not in {"and", "at"}
+            ]
         uppercase_word_suffixes = {
             tuple(raw_place_coordinate_address_token_list(word_key))
             for word in re.findall(
@@ -8066,29 +8162,34 @@ def raw_place_maps_url_should_be_preserved(
 def raw_place_refreshed_url_identity_is_compatible(
     existing_place: RawPlace,
     refreshed_url: str | None,
+    *,
+    refreshed_cid: str | None = None,
 ) -> bool:
     if len(raw_place_google_places_identities(existing_place)) > 1:
         return False
+
+    existing_cids = {
+        cid
+        for cid in [
+            as_string(existing_place.cid),
+            extract_maps_cid(existing_place.maps_url),
+            *existing_place.cid_aliases,
+        ]
+        if cid
+    }
+    if refreshed_cid and existing_cids and refreshed_cid not in existing_cids:
+        return False
+    matched_identity = bool(refreshed_cid and refreshed_cid in existing_cids)
 
     url = as_string(refreshed_url)
     if not url or not raw_place_maps_url_has_embedded_identity(url):
         return True
 
-    matched_identity = False
-    refreshed_cid = extract_maps_cid(url)
-    if refreshed_cid:
-        existing_cids = {
-            cid
-            for cid in [
-                as_string(existing_place.cid),
-                extract_maps_cid(existing_place.maps_url),
-                *existing_place.cid_aliases,
-            ]
-            if cid
-        }
-        if existing_cids and refreshed_cid not in existing_cids:
+    refreshed_url_cid = extract_maps_cid(url)
+    if refreshed_url_cid:
+        if existing_cids and refreshed_url_cid not in existing_cids:
             return False
-        matched_identity = matched_identity or refreshed_cid in existing_cids
+        matched_identity = matched_identity or refreshed_url_cid in existing_cids
 
     refreshed_query_place_id = extract_maps_query_place_id(url)
     if refreshed_query_place_id:
@@ -8202,6 +8303,13 @@ def raw_place_google_id_identity(place: RawPlace) -> str | None:
     if not google_id:
         return None
     return google_id.strip("/").replace("/", "-")
+
+
+def raw_place_legacy_google_id_identity(place: RawPlace) -> str | None:
+    google_id = as_string(place.google_id)
+    if not google_id or google_id.startswith("places/") or "/" not in google_id:
+        return None
+    return raw_place_google_id_identity(place)
 
 
 def raw_place_google_places_id_identity(place: RawPlace) -> str | None:

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7553,6 +7553,8 @@ def raw_place_coordinate_postal_evidence_is_valid_for_country(
         return bool(re.fullmatch(r"\d{4}", compact_postal))
     if country_code == "IT":
         return bool(re.fullmatch(r"\d{5}", compact_postal))
+    if country_code == "GE":
+        return bool(re.fullmatch(r"\d{4}", compact_postal))
     if country_code == "TW":
         return bool(re.fullmatch(r"\d{3,6}", compact_postal))
     if country_code == "GB":
@@ -7570,6 +7572,21 @@ def raw_place_coordinate_country_span(
     *,
     expected_country: str | None = None,
 ) -> tuple[int, int, str] | None:
+    if expected_country == "GE":
+        for start in range(len(tokens) - 1, -1, -1):
+            if tokens[start] != "georgia":
+                continue
+            end = start + 1
+            trailing_indexes = set(range(end, len(tokens)))
+            if trailing_indexes and not (
+                raw_place_coordinate_postal_evidence_is_valid_for_country(
+                    tokens,
+                    trailing_indexes,
+                    "GE",
+                )
+            ):
+                continue
+            return start, end, "GE"
     for country_tokens, country_code in raw_place_coordinate_country_token_identities():
         if expected_country is not None and country_code != expected_country:
             continue
@@ -7588,6 +7605,27 @@ def raw_place_coordinate_country_span(
             ):
                 continue
             return start, end, country_code
+    return None
+
+
+def raw_place_coordinate_infer_georgia_country(raw_parts: Sequence[str]) -> str | None:
+    has_georgia_component = any(
+        raw_place_coordinate_address_key(part) == "georgia"
+        for part in raw_parts
+    )
+    if not has_georgia_component:
+        return None
+
+    subdivision_identities = raw_place_coordinate_subdivision_token_identities(None)
+    for part in raw_parts:
+        part_key = raw_place_coordinate_address_key(part)
+        if part_key is None or part_key == "georgia":
+            continue
+        identity = subdivision_identities.get(
+            tuple(raw_place_coordinate_address_token_list(part_key))
+        )
+        if identity is not None and identity[0] == "subdivision" and identity[1].startswith("ge-"):
+            return "GE"
     return None
 
 
@@ -7618,6 +7656,8 @@ def raw_place_coordinate_address_comparison_key(
             if country_span is not None:
                 country = country_span[2]
                 break
+    if country is None:
+        country = raw_place_coordinate_infer_georgia_country(raw_parts)
     if country is None:
         country = raw_place_coordinate_infer_country_from_subdivision_postal(
             normalized_address

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -4781,6 +4781,10 @@ def stable_place_id(place: RawPlace, *, source_type: str | None = None) -> str:
     if maps_place_token:
         return f"gms:{maps_place_token}"
 
+    query_place_id = extract_maps_query_place_id(place.maps_url)
+    if query_place_id:
+        return f"gpid:{query_place_id}"
+
     if source_type == "google_export_csv":
         maps_url_id = short_maps_url_id(place.maps_url)
         if maps_url_id:
@@ -7004,6 +7008,21 @@ def raw_place_coordinate_address_is_stable(
             existing_comparison_address,
             country_hint=refreshed_country,
         )
+    elif existing_country is None and refreshed_country is None:
+        subdivision_country_codes = (
+            raw_place_coordinate_subdivision_country_codes(existing_parts)
+            | raw_place_coordinate_subdivision_country_codes(refreshed_parts)
+        )
+        if len(subdivision_country_codes) == 1:
+            subdivision_country_code = next(iter(subdivision_country_codes))
+            existing_parts, _ = raw_place_coordinate_address_comparison_key(
+                existing_comparison_address,
+                country_hint=subdivision_country_code,
+            )
+            refreshed_parts, _ = raw_place_coordinate_address_comparison_key(
+                refreshed_comparison_address,
+                country_hint=subdivision_country_code,
+            )
     if not existing_parts or existing_parts != refreshed_parts:
         return False
     return bool(
@@ -7439,6 +7458,7 @@ def raw_place_coordinate_country_token_identities() -> tuple[
         "Northern Ireland": "GB",
         "UK": "GB",
         "UAE": "AE",
+        "US": "US",
         "USA": "US",
         "Korea": "KR",
         "South Korea": "KR",
@@ -7524,6 +7544,18 @@ def raw_place_coordinate_subdivision_token_identities(
         tokens: ("subdivision", next(iter(subdivision_codes)).casefold())
         for tokens, subdivision_codes in candidates.items()
         if len(subdivision_codes) == 1
+    }
+
+
+def raw_place_coordinate_subdivision_country_codes(
+    comparison_parts: tuple[tuple[str, ...], ...],
+) -> set[str]:
+    return {
+        part[1].split("-", 1)[0].upper()
+        for part in comparison_parts
+        if len(part) == 2
+        and part[0] == "subdivision"
+        and "-" in part[1]
     }
 
 
@@ -7764,8 +7796,15 @@ def raw_place_names_are_compatible(existing_name: str | None, refreshed_name: st
     if not existing_name or not refreshed_name:
         return True
 
+    existing_name_key = raw_place_coordinate_address_key(existing_name)
+    refreshed_name_key = raw_place_coordinate_address_key(refreshed_name)
+    if existing_name_key is not None and existing_name_key == refreshed_name_key:
+        return True
+
     existing_slug = slugify(existing_name)
     refreshed_slug = slugify(refreshed_name)
+    if existing_slug == "item" or refreshed_slug == "item":
+        return False
     if existing_slug == refreshed_slug:
         return True
 

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2205,6 +2205,64 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (38.711, -9.137))
         self.assertIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_handles_street_range_endpoint(self) -> None:
+        for refreshed_address in (
+            "Rua Augusta 195, Baixa, 1100-619 Lisboa, Portugal",
+            "Rua Augusta 197, Baixa, 1100-619 Lisboa, Portugal",
+        ):
+            with self.subTest(refreshed_address=refreshed_address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address="Rua Augusta 195-197, Baixa, 1100-619 Lisboa, Portugal",
+                    lat=38.711,
+                    lng=-9.137,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={
+                        "address": refreshed_address,
+                        "lat": 38.75,
+                        "lng": -9.2,
+                    }
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (38.711, -9.137))
+                self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_compound_german_street_suffix(
+        self,
+    ) -> None:
+        for address in (
+            "Oranienstraße 190, 10999 Berlin, Germany",
+            "Oranienstrasse 190, 10999 Berlin, Germany",
+        ):
+            with self.subTest(address=address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=address,
+                    lat=52.5,
+                    lng=13.4,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={"lat": 52.6, "lng": 13.55}
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (52.5, 13.4))
+                self.assertIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_handles_reordered_address_components(self) -> None:
         existing_place = RawPlace(
             name="Wooden Spoon",
@@ -2309,6 +2367,33 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (45.5152, -122.6784))
         self.assertNotIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_accepts_removed_country_name_locality(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, Mexico, MO, United States",
+            lat=39.1698,
+            lng=-91.8829,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main Street, MO, USA",
+                "lat": 38.5767,
+                "lng": -92.1735,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (38.5767, -92.1735))
+        self.assertNotIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_accepts_added_locality_for_suffixless_street(
         self,
     ) -> None:
@@ -2386,6 +2471,39 @@ class BuildDataTests(unittest.TestCase):
         )
 
         self.assertEqual((merged.lat, merged.lng), (37.7666529, -122.4303822))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_country_component_reordering(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address=(
+                "Japan, 〒150-0001, Tokyo, Shibuya City, "
+                "Jingumae 1 Chome-1-1"
+            ),
+            lat=35.6762,
+            lng=139.6503,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": (
+                    "〒150-0001, Tokyo, Shibuya City, "
+                    "Jingumae 1 Chome-1-1, Japan"
+                ),
+                "lat": 34.6937,
+                "lng": 135.5023,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (35.6762, 139.6503))
         self.assertIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_accepts_reordered_location_words(self) -> None:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1556,6 +1556,76 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(merged.places[0].lng, -122.4303822)
         self.assertEqual(merged.places[0].maps_url, existing_payload.places[0].maps_url)
 
+    def test_preserve_existing_raw_saved_list_matches_unique_name_after_identity_and_address_loss(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = RawPlace(
+            name="Example Cafe",
+            address=None,
+            lat=36.0,
+            lng=140.0,
+            maps_url="https://www.google.com/maps/search/?api=1&query=Example+Cafe",
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="example-city",
+            existing_payload=RawSavedList(places=[existing_place]),
+            refreshed_payload=RawSavedList(places=[refreshed_place]),
+        )
+
+        self.assertEqual(merged.places[0].address, existing_place.address)
+        self.assertEqual((merged.places[0].lat, merged.places[0].lng), (35.0, 139.0))
+        self.assertEqual(merged.places[0].cid, "111")
+
+    def test_preserve_existing_raw_saved_list_rejects_ambiguous_name_only_identity_loss(
+        self,
+    ) -> None:
+        existing_payload = RawSavedList(
+            places=[
+                RawPlace(
+                    name="Example Cafe",
+                    address="1 First St, Example City",
+                    lat=35.0,
+                    lng=139.0,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                ),
+                RawPlace(
+                    name="Example Cafe",
+                    address="2 Second St, Example City",
+                    lat=35.1,
+                    lng=139.1,
+                    maps_url="https://www.google.com/maps?cid=222",
+                    cid="222",
+                ),
+            ]
+        )
+        refreshed_place = RawPlace(
+            name="Example Cafe",
+            address=None,
+            lat=36.0,
+            lng=140.0,
+            maps_url="https://www.google.com/maps/search/?api=1&query=Example+Cafe",
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="example-city",
+            existing_payload=existing_payload,
+            refreshed_payload=RawSavedList(places=[refreshed_place]),
+        )
+
+        self.assertIsNone(merged.places[0].address)
+        self.assertEqual((merged.places[0].lat, merged.places[0].lng), (36.0, 140.0))
+        self.assertIsNone(merged.places[0].cid)
+
     def test_preserve_existing_raw_place_accepts_locality_only_coordinate_correction(
         self,
     ) -> None:
@@ -4823,6 +4893,29 @@ class BuildDataTests(unittest.TestCase):
                 "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
                 f"&query_place_id={query_place_id}"
             ),
+        )
+        selectors = {
+            query_place_id.casefold(),
+            f"gpid:{query_place_id}".casefold(),
+            f"tokyo-japan:{query_place_id}".casefold(),
+            f"tokyo-japan:gpid:{query_place_id}".casefold(),
+        }
+
+        matches = build_data.place_selector_matches(
+            "tokyo-japan",
+            place,
+            place_id=f"gpid:{query_place_id}",
+            selectors=selectors,
+        )
+
+        self.assertEqual(matches, selectors)
+
+    def test_place_selector_matches_stored_google_places_id(self) -> None:
+        query_place_id = "ChIJ-stored-example"
+        place = RawPlace(
+            name="Example Cafe",
+            maps_url="https://www.google.com/maps/search/?api=1&query=Example+Cafe",
+            google_id=f"places/{query_place_id}",
         )
         selectors = {
             query_place_id.casefold(),

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1556,6 +1556,105 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(merged.places[0].lng, -122.4303822)
         self.assertEqual(merged.places[0].maps_url, existing_payload.places[0].maps_url)
 
+    def test_preserve_existing_raw_place_accepts_locality_only_coordinate_correction(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="Seoul, South Korea",
+            lat=37.5665,
+            lng=126.978,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={"lat": 37.4979, "lng": 127.0276}
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (37.4979, 127.0276))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_accepts_missing_locality_only_address_shift(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="Paris, France",
+            lat=48.8566,
+            lng=2.3522,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={"address": None, "lat": 48.765, "lng": 2.2}
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (48.765, 2.2))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_accepts_postal_locality_coordinate_shift(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1000 Bruxelles, Belgium",
+            lat=50.8466,
+            lng=4.3528,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={"lat": 50.813, "lng": 4.381}
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (50.813, 4.381))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_tracked_international_street_terms(
+        self,
+    ) -> None:
+        addresses = (
+            "Rua Augusta 195-197, Baixa, 1100-619 Lisboa, Portugal",
+            "Av. Colón 508, García Ginerés, 97070 Mérida, Yuc., Mexico",
+            "Carrer Major 39, 07871 Sant Ferran, Spain",
+        )
+        for address in addresses:
+            with self.subTest(address=address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=address,
+                    lat=38.711,
+                    lng=-9.137,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={"lat": 38.75, "lng": -9.2}
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (38.711, -9.137))
+                self.assertIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_saved_list_rejects_large_coordinate_only_shift(
         self,
     ) -> None:
@@ -2038,6 +2137,36 @@ class BuildDataTests(unittest.TestCase):
             merged.maps_url,
             "https://www.google.com/maps?cid=740708305128434099",
         )
+        self.assertNotIn("maps_url", preserved_fields)
+
+    def test_preserve_existing_raw_place_keeps_new_name_search_url_on_rename(self) -> None:
+        existing_place = RawPlace(
+            name="Old Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url="https://www.google.com/maps/search/?api=1&query=Old+Cafe",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "name": "Completely New Cafe",
+                "lat": 36.0,
+                "lng": 140.0,
+                "maps_url": (
+                    "https://www.google.com/maps/search/?api=1&query="
+                    "Completely+New+Cafe"
+                ),
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
+        self.assertIn("query=Completely+New+Cafe", merged.maps_url or "")
         self.assertNotIn("maps_url", preserved_fields)
 
     def test_preserve_existing_raw_place_keeps_identity_bearing_refreshed_maps_url(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1484,7 +1484,7 @@ class BuildDataTests(unittest.TestCase):
                     is_favorite=False,
                     lat=21.2769032,
                     lng=-157.8278887,
-                    maps_url="https://www.google.com/maps/search/?api=1&query=Duke%27s+Waikiki",
+                    maps_url="https://www.google.com/maps?cid=8935267511126082507",
                     cid="8935267511126082507",
                     google_id=None,
                     maps_place_token=None,
@@ -1507,6 +1507,347 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(merged.places[0].maps_place_token, "0xdeadbeef:0x1")
         self.assertEqual(merged.places[0].added_by, ListAuthor(name="Second Curator", profile_id="second-id"))
         self.assertTrue(merged.places[0].is_favorite)
+        self.assertEqual(
+            merged.places[0].maps_url,
+            "https://www.google.com/maps?cid=8935267511126082507",
+        )
+
+    def test_preserve_existing_raw_saved_list_rejects_large_coordinate_shift_with_missing_address(
+        self,
+    ) -> None:
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Wooden Spoon",
+                    address="2172 Market St, San Francisco, CA 94114, United States",
+                    lat=37.7666529,
+                    lng=-122.4303822,
+                    maps_url=(
+                        "https://www.google.com/maps/search/?api=1&query="
+                        "Wooden+Spoon%2C+2172+Market+St"
+                    ),
+                    cid="740708305128434099",
+                )
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Wooden Spoon",
+                    address=None,
+                    lat=37.7818711,
+                    lng=-122.3740949,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Wooden+Spoon",
+                    cid="740708305128434099",
+                )
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="san-francisco-california-usa",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].address, existing_payload.places[0].address)
+        self.assertEqual(merged.places[0].lat, 37.7666529)
+        self.assertEqual(merged.places[0].lng, -122.4303822)
+        self.assertEqual(merged.places[0].maps_url, existing_payload.places[0].maps_url)
+
+    def test_preserve_existing_raw_saved_list_rejects_large_coordinate_only_shift(
+        self,
+    ) -> None:
+        address = "Rue Ropsy Chaudron 49, 1070 Anderlecht, Belgium"
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="La Paix",
+                    address="Rue Ropsy Chaudron 49  1070 Anderlecht, Belgium",
+                    lat=50.8437078,
+                    lng=4.32829,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=La+Paix",
+                    google_id="/g/1hf_wf5my",
+                )
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="La Paix",
+                    address=address,
+                    lat=50.8511538,
+                    lng=4.3650878,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=La+Paix",
+                    google_id="/g/1hf_wf5my",
+                )
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="brussels-belgium",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].lat, 50.8437078)
+        self.assertEqual(merged.places[0].lng, 4.32829)
+
+    def test_preserve_existing_raw_saved_list_accepts_small_coordinate_adjustment(self) -> None:
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Newscapes brewing",
+                    address="163 Washington Ave, Portland, ME 04101, United States",
+                    lat=43.6687439,
+                    lng=-70.253972,
+                    maps_url="https://maps.google.com/?cid=5526652900080480443",
+                    cid="5526652900080480443",
+                )
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Newscapes brewing",
+                    address="163 Washington Ave, Portland, ME 04101, United States",
+                    lat=43.6692216,
+                    lng=-70.2533704,
+                    maps_url="https://maps.google.com/?cid=5526652900080480443",
+                    cid="5526652900080480443",
+                )
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="portland-maine-usa",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].lat, 43.6692216)
+        self.assertEqual(merged.places[0].lng, -70.2533704)
+
+    def test_preserve_existing_raw_saved_list_accepts_relocation_with_new_address(self) -> None:
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="La Paix",
+                    address="Rue Ropsy Chaudron 49, 1070 Anderlecht, Belgium",
+                    lat=50.8437078,
+                    lng=4.32829,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=La+Paix",
+                    google_id="/g/1hf_wf5my",
+                )
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="La Paix",
+                    address="Rue Royale 103, 1000 Bruxelles, Belgium",
+                    lat=50.8511538,
+                    lng=4.3650878,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=La+Paix",
+                    google_id="/g/1hf_wf5my",
+                )
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="brussels-belgium",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].address, "Rue Royale 103, 1000 Bruxelles, Belgium")
+        self.assertEqual(merged.places[0].lat, 50.8511538)
+        self.assertEqual(merged.places[0].lng, 4.3650878)
+
+    def test_preserve_existing_raw_place_handles_equivalent_non_latin_address(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="東京都渋谷区神宮前1丁目1-1",
+            lat=35.6762,
+            lng=139.6503,
+            maps_url="https://www.google.com/maps/search/?api=1&query=Example+Cafe",
+            google_id="/g/example",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "東京都渋谷区神宮前１丁目１－１",
+                "lat": 34.6937,
+                "lng": 135.5023,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (35.6762, 139.6503))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_accepts_changed_non_latin_address(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="東京都渋谷区神宮前1丁目1-1",
+            lat=35.6762,
+            lng=139.6503,
+            maps_url="https://www.google.com/maps/search/?api=1&query=Example+Cafe",
+            google_id="/g/example",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "大阪府大阪市北区梅田1丁目1-1",
+                "lat": 34.6937,
+                "lng": 135.5023,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (34.6937, 135.5023))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_keeps_stronger_refreshed_maps_url(self) -> None:
+        existing_place = RawPlace(
+            name="Wooden Spoon",
+            address="2172 Market St, San Francisco, CA 94114, United States",
+            lat=37.7666529,
+            lng=-122.4303822,
+            maps_url="https://www.google.com/maps/search/?api=1&query=Wooden+Spoon",
+            cid="740708305128434099",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "lat": 37.7818711,
+                "lng": -122.3740949,
+                "maps_url": "https://www.google.com/maps?cid=740708305128434099",
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (37.7666529, -122.4303822))
+        self.assertEqual(
+            merged.maps_url,
+            "https://www.google.com/maps?cid=740708305128434099",
+        )
+        self.assertNotIn("maps_url", preserved_fields)
+
+    def test_preserve_existing_raw_place_rejects_conflicting_prior_maps_url(self) -> None:
+        existing_place = RawPlace(
+            name="Relocated Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+            google_id="/g/relocated",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "lat": 36.0,
+                "lng": 140.0,
+                "maps_url": "https://www.google.com/maps?cid=222",
+                "cid": "222",
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
+        self.assertEqual(merged.cid, "222")
+        self.assertEqual(merged.maps_url, "https://www.google.com/maps?cid=222")
+        self.assertNotIn("maps_url", preserved_fields)
+
+    def test_preserve_existing_raw_place_rejects_conflicting_query_place_id(self) -> None:
+        existing_place = RawPlace(
+            name="Relocated Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url=(
+                "https://www.google.com/maps/search/?api=1&query=Relocated+Cafe"
+                "&query_place_id=ChIJ-old"
+            ),
+            google_id="/g/relocated",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "lat": 36.0,
+                "lng": 140.0,
+                "maps_url": (
+                    "https://www.google.com/maps/search/?api=1&query=Relocated+Cafe"
+                    "&query_place_id=ChIJ-new"
+                ),
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
+        self.assertIn("query_place_id=ChIJ-new", merged.maps_url or "")
+        self.assertNotIn("maps_url", preserved_fields)
+
+    def test_preserve_existing_raw_saved_list_restores_incomplete_coordinates(self) -> None:
+        address = "1 Example St, Example City"
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Example Cafe",
+                    address=address,
+                    lat=35.0,
+                    lng=139.0,
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                )
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Example Cafe",
+                    address=address,
+                    lat=35.0,
+                    lng=None,
+                    maps_url="https://maps.google.com/?cid=111",
+                    cid="111",
+                )
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="example-city",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].lat, 35.0)
+        self.assertEqual(merged.places[0].lng, 139.0)
 
     def test_preserve_existing_raw_saved_list_keeps_old_cid_alias_when_cid_changes(self) -> None:
         existing_payload = RawSavedList(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2074,6 +2074,39 @@ class BuildDataTests(unittest.TestCase):
         self.assertIn("coordinates", preserved_fields)
         self.assertIn("google_id", preserved_fields)
 
+    def test_preserve_existing_raw_place_keeps_google_id_for_same_cid_query_url(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url="https://www.google.com/maps?cid=111",
+            google_id="/g/example",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "lat": 36.0,
+                "lng": 140.0,
+                "maps_url": (
+                    "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                    "&query_place_id=ChIJ-new"
+                ),
+                "google_id": None,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual(merged.google_id, "/g/example")
+        self.assertIn("google_id", preserved_fields)
+        self.assertEqual(build_data.stable_place_id(merged), "gid:g-example")
+
     def test_preserve_existing_raw_place_does_not_restore_google_id_across_url_conflict(
         self,
     ) -> None:
@@ -2136,6 +2169,60 @@ class BuildDataTests(unittest.TestCase):
         match_keys = build_data.raw_place_primary_match_keys(refreshed_place)
         self.assertNotIn("gpid:ChIJ-A", match_keys)
         self.assertNotIn("gpid:ChIJ-B", match_keys)
+
+    def test_preserve_existing_raw_place_rejects_shared_token_with_place_id_conflict(
+        self,
+    ) -> None:
+        shared_token = "0xabc:0xdef"
+        cases = (
+            (
+                "https://www.google.com/maps/search/?api=1&query=Example+Cafe",
+                "ChIJ-A",
+                "https://www.google.com/maps/search/?api=1&query=Example+Cafe",
+                "ChIJ-B",
+            ),
+            (
+                "https://www.google.com/maps/search/?api=1&query=Example+Cafe",
+                "/g/old-place",
+                "https://www.google.com/maps/search/?api=1&query=Example+Cafe",
+                "/g/new-place",
+            ),
+            (
+                "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                "&query_place_id=ChIJ-A",
+                None,
+                "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                "&query_place_id=ChIJ-B",
+                None,
+            ),
+        )
+        for existing_url, existing_google_id, refreshed_url, refreshed_google_id in cases:
+            with self.subTest(existing_url=existing_url):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address="1 Example St, Example City",
+                    lat=35.0,
+                    lng=139.0,
+                    maps_url=existing_url,
+                    google_id=existing_google_id,
+                    maps_place_token=shared_token,
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={
+                        "lat": 36.0,
+                        "lng": 140.0,
+                        "maps_url": refreshed_url,
+                        "google_id": refreshed_google_id,
+                    }
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (36.0, 140.0))
+                self.assertNotIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_does_not_restore_inconsistent_place_id(
         self,
@@ -2629,6 +2716,33 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (40.7536, -73.9803))
         self.assertIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_normalizes_at_intersection_connector(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="Main St at 5th Ave, New York, NY, United States",
+            lat=40.7536,
+            lng=-73.9803,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "Main Street & Fifth Avenue, New York, NY, USA",
+                "lat": 40.85,
+                "lng": -74.08,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (40.7536, -73.9803))
+        self.assertIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_does_not_treat_building_name_as_intersection(
         self,
     ) -> None:
@@ -2743,6 +2857,186 @@ class BuildDataTests(unittest.TestCase):
                 "Building C, 16, Queens, NY, United States"
             )
         )
+
+    def test_preserve_existing_raw_place_expands_street_prefix_abbreviation(
+        self,
+    ) -> None:
+        for existing_address, refreshed_address in (
+            (
+                "C. de la Cava Baja, 16, Centro, 28005 Madrid, Spain",
+                "Calle de la Cava Baja, 16, Centro, 28005 Madrid, Spain",
+            ),
+            (
+                "C/ de Ponzano, 11, Chamberí, 28010 Madrid, Spain",
+                "Calle de Ponzano, 11, Chamberí, 28010 Madrid, Spain",
+            ),
+            (
+                "P.za del Duomo, 21, 20121 Milano MI, Italy",
+                "Piazza del Duomo, 21, 20121 Milano MI, Italy",
+            ),
+            (
+                "Pl. de Carles Buïgas, 1, 43840 Salou, Spain",
+                "Plaza de Carles Buïgas, 1, 43840 Salou, Spain",
+            ),
+        ):
+            with self.subTest(existing_address=existing_address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=existing_address,
+                    lat=40.0,
+                    lng=-3.0,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={
+                        "address": refreshed_address,
+                        "lat": 40.1,
+                        "lng": -3.1,
+                    }
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (40.0, -3.0))
+                self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_recognizes_live_street_markers(
+        self,
+    ) -> None:
+        for existing_address, refreshed_address in (
+            (
+                "Viale Vittorio Veneto, 30, 20124 Milano MI, Italy",
+                "Viale Vittorio Veneto, 30, 20124 Milano MI, Italy",
+            ),
+            (
+                "Passeig del Born, 13, 08003 Barcelona, Spain",
+                "Passeig del Born, 13, 08003 Barcelona, Spain",
+            ),
+            (
+                "Largo da Sé 1, 1100-585 Lisboa, Portugal",
+                "Largo da Sé 1, 1100-585 Lisboa, Portugal",
+            ),
+            (
+                "Str. di Cetinale, 9, 53018 Sovicille SI, Italy",
+                "Strada di Cetinale, 9, 53018 Sovicille SI, Italy",
+            ),
+        ):
+            with self.subTest(existing_address=existing_address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=existing_address,
+                    lat=43.0,
+                    lng=11.0,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={
+                        "address": refreshed_address,
+                        "lat": 43.1,
+                        "lng": 11.1,
+                    }
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (43.0, 11.0))
+                self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_alphanumeric_split_premise_number(
+        self,
+    ) -> None:
+        for address in (
+            "Baker St, 221B, London, United Kingdom",
+            "Via Roma, 12A, Rome, Italy",
+        ):
+            with self.subTest(address=address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=address,
+                    lat=51.5,
+                    lng=-0.1,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={"lat": 51.6, "lng": -0.2}
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (51.5, -0.1))
+                self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_rejects_district_number_as_premise(
+        self,
+    ) -> None:
+        address = (
+            "17th St - Al Quoz - Al Quoz Industrial Area 1 - Dubai - "
+            "United Arab Emirates"
+        )
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address=address,
+            lat=25.13,
+            lng=55.22,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={"lat": 25.23, "lng": 55.32}
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (25.23, 55.32))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_normalizes_compass_direction(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address=(
+                "1600 Pennsylvania Ave NW, Washington, DC 20500, "
+                "United States"
+            ),
+            lat=38.8977,
+            lng=-77.0365,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": (
+                    "1600 Pennsylvania Avenue Northwest, Washington, "
+                    "District of Columbia 20500, United States"
+                ),
+                "lat": 39.0,
+                "lng": -77.14,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (38.8977, -77.0365))
+        self.assertIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_handles_no_prefixed_premise_number(
         self,

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2223,6 +2223,41 @@ class BuildDataTests(unittest.TestCase):
                 self.assertEqual((merged.lat, merged.lng), (36.0, 140.0))
                 self.assertNotIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_rejects_same_cid_place_id_conflict(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url=(
+                "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                "&query_place_id=ChIJ-A"
+            ),
+            google_id="ChIJ-A",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "lat": 36.0,
+                "lng": 140.0,
+                "maps_url": (
+                    "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                    "&query_place_id=ChIJ-B"
+                ),
+                "google_id": "ChIJ-B",
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (36.0, 140.0))
+        self.assertNotIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_does_not_restore_inconsistent_place_id(
         self,
     ) -> None:
@@ -3003,6 +3038,62 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertEqual((merged.lat, merged.lng), (25.23, 55.32))
         self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_recognizes_prefix_style_street_alias(
+        self,
+    ) -> None:
+        for address in (
+            "Avenue Louise 123, Brussels, Belgium",
+            "Boulevard Saint-Germain 10, Paris, France",
+        ):
+            with self.subTest(address=address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=address,
+                    lat=50.84,
+                    lng=4.35,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={"lat": 50.94, "lng": 4.45}
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (50.84, 4.35))
+                self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_excludes_hash_suite_from_premise_evidence(
+        self,
+    ) -> None:
+        for address, expected_coordinates, should_preserve in (
+            ("Main St #200, Springfield", (40.1, -75.1), False),
+            ("200 Main St #200, Springfield", (40.0, -75.0), True),
+        ):
+            with self.subTest(address=address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=address,
+                    lat=40.0,
+                    lng=-75.0,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={"lat": 40.1, "lng": -75.1}
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), expected_coordinates)
+                self.assertEqual("coordinates" in preserved_fields, should_preserve)
 
     def test_preserve_existing_raw_place_normalizes_compass_direction(
         self,
@@ -3974,6 +4065,106 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (35.6762, 139.6503))
         self.assertIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_strips_leading_country_component(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="日本、〒040-0064 北海道函館市大手町２２−１",
+            lat=41.7687,
+            lng=140.7288,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "北海道函館市大手町22-1",
+                "lat": 41.87,
+                "lng": 140.83,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (41.7687, 140.7288))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_normalizes_localized_country_alias(
+        self,
+    ) -> None:
+        for existing_address, refreshed_address in (
+            (
+                "Via Capo, 10, Sorrento, イタリア",
+                "Via Capo, 10, Sorrento, Italy",
+            ),
+            (
+                "Av. Reforma 10, Mexico City, メキシコ",
+                "Av. Reforma 10, Mexico City, Mexico",
+            ),
+            (
+                "10 George St, Sydney, オーストラリア",
+                "10 George Street, Sydney, Australia",
+            ),
+        ):
+            with self.subTest(existing_address=existing_address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=existing_address,
+                    lat=40.0,
+                    lng=10.0,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={
+                        "address": refreshed_address,
+                        "lat": 40.1,
+                        "lng": 10.1,
+                    }
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (40.0, 10.0))
+                self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_detects_country_before_postal_code(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address=(
+                "No. 16號, Zhongyang St, Magong City, Penghu County, 台湾 880"
+            ),
+            lat=23.5655,
+            lng=119.5863,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": (
+                    "No. 16號, Zhongyang Street, Magong City, Penghu County, Taiwan"
+                ),
+                "lat": 23.67,
+                "lng": 119.69,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (23.5655, 119.5863))
+        self.assertIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_accepts_changed_street_number(self) -> None:
         existing_place = RawPlace(
             name="Example Cafe",
@@ -4623,6 +4814,31 @@ class BuildDataTests(unittest.TestCase):
         )
 
         self.assertEqual(matches, {"cid:6924437575605096209", "tokyo-japan:cid:6924437575605096209"})
+
+    def test_place_selector_matches_query_place_id(self) -> None:
+        query_place_id = "ChIJ-example"
+        place = RawPlace(
+            name="Example Cafe",
+            maps_url=(
+                "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                f"&query_place_id={query_place_id}"
+            ),
+        )
+        selectors = {
+            query_place_id.casefold(),
+            f"gpid:{query_place_id}".casefold(),
+            f"tokyo-japan:{query_place_id}".casefold(),
+            f"tokyo-japan:gpid:{query_place_id}".casefold(),
+        }
+
+        matches = build_data.place_selector_matches(
+            "tokyo-japan",
+            place,
+            place_id=f"gpid:{query_place_id}",
+            selectors=selectors,
+        )
+
+        self.assertEqual(matches, selectors)
 
     def test_place_selector_does_not_match_shadowed_cid_alias(self) -> None:
         alias_holder = RawPlace(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1723,6 +1723,7 @@ class BuildDataTests(unittest.TestCase):
             "Suite 2 US Highway 1, Big Sur, CA",
             "US 1 Highway, Big Sur, CA",
             "State 66 Route, Albuquerque, NM",
+            "R 66, Albuquerque, NM",
         ):
             with self.subTest(address=address):
                 existing_place = RawPlace(
@@ -1987,6 +1988,148 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
         self.assertIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_matches_query_id_to_stored_place_id(
+        self,
+    ) -> None:
+        query_place_id = "GhIJ-example"
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url="https://www.google.com/maps/search/?api=1&query=Example+Cafe",
+            google_id=query_place_id,
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "lat": 36.0,
+                "lng": 140.0,
+                "maps_url": (
+                    "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                    f"&query_place_id={query_place_id}"
+                ),
+                "google_id": None,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
+        self.assertEqual(merged.google_id, query_place_id)
+        self.assertIn("coordinates", preserved_fields)
+        self.assertIn("google_id", preserved_fields)
+
+    def test_preserve_existing_raw_place_does_not_restore_google_id_across_url_conflict(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url="https://www.google.com/maps?cid=111",
+            google_id="/g/old-place",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "lat": 36.0,
+                "lng": 140.0,
+                "maps_url": "https://www.google.com/maps?cid=222",
+                "google_id": None,
+                "cid": None,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertIsNone(merged.google_id)
+        self.assertNotIn("google_id", preserved_fields)
+
+    def test_preserve_existing_raw_place_rejects_conflicting_structured_place_ids(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url=(
+                "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                "&query_place_id=ChIJ-A"
+            ),
+            google_id="ChIJ-A",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "lat": 36.0,
+                "lng": 140.0,
+                "google_id": "ChIJ-B",
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (36.0, 140.0))
+        self.assertNotIn("coordinates", preserved_fields)
+        match_keys = build_data.raw_place_primary_match_keys(refreshed_place)
+        self.assertNotIn("gpid:ChIJ-A", match_keys)
+        self.assertNotIn("gpid:ChIJ-B", match_keys)
+
+    def test_preserve_existing_raw_place_does_not_restore_inconsistent_place_id(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url=(
+                "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                "&query_place_id=ChIJ-B"
+            ),
+            google_id="ChIJ-A",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "maps_url": "https://www.google.com/maps?cid=111",
+                "google_id": None,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertIsNone(merged.google_id)
+        self.assertNotIn("google_id", preserved_fields)
+
+    def test_raw_place_google_places_ids_exclude_legacy_google_ids(self) -> None:
+        place = RawPlace(
+            name="Example Cafe",
+            maps_url=(
+                "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                "&query_place_id=GhIJ-example"
+            ),
+            google_id="g/correct-cafe",
+        )
+
+        self.assertEqual(
+            build_data.raw_place_google_places_identities(place),
+            {"GhIJ-example"},
+        )
+
     def test_preserve_existing_raw_saved_list_matches_query_place_id_identity(
         self,
     ) -> None:
@@ -2238,21 +2381,35 @@ class BuildDataTests(unittest.TestCase):
     def test_preserve_existing_raw_place_handles_compound_german_street_suffix(
         self,
     ) -> None:
-        for address in (
-            "Oranienstraße 190, 10999 Berlin, Germany",
-            "Oranienstrasse 190, 10999 Berlin, Germany",
+        for existing_address, refreshed_address in (
+            (
+                "Oranienstraße 190, 10999 Berlin, Germany",
+                "Oranienstraße 190, 10999 Berlin, Germany",
+            ),
+            (
+                "Oranienstrasse 190, 10999 Berlin, Germany",
+                "Oranienstrasse 190, 10999 Berlin, Germany",
+            ),
+            (
+                "Oranienstr. 190, 10999 Berlin, Germany",
+                "Oranienstrasse 190, 10999 Berlin, Germany",
+            ),
         ):
-            with self.subTest(address=address):
+            with self.subTest(address=existing_address):
                 existing_place = RawPlace(
                     name="Example Cafe",
-                    address=address,
+                    address=existing_address,
                     lat=52.5,
                     lng=13.4,
                     maps_url="https://www.google.com/maps?cid=111",
                     cid="111",
                 )
                 refreshed_place = existing_place.model_copy(
-                    update={"lat": 52.6, "lng": 13.55}
+                    update={
+                        "address": refreshed_address,
+                        "lat": 52.6,
+                        "lng": 13.55,
+                    }
                 )
 
                 merged, preserved_fields = build_data.preserve_existing_raw_place(
@@ -2262,6 +2419,168 @@ class BuildDataTests(unittest.TestCase):
 
                 self.assertEqual((merged.lat, merged.lng), (52.5, 13.4))
                 self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_ordinal_street_name(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1200 5th Ave, Seattle, WA, United States",
+            lat=47.608,
+            lng=-122.334,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "1200 Fifth Avenue, Seattle, WA, USA",
+                "lat": 47.7,
+                "lng": -122.45,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (47.608, -122.334))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_ordinal_street_intersection(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="5th Ave & 42nd St, New York, NY, United States",
+            lat=40.7536,
+            lng=-73.9803,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": (
+                    "Fifth Avenue and Forty-Second Street, "
+                    "New York, NY, USA"
+                ),
+                "lat": 40.85,
+                "lng": -74.08,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (40.7536, -73.9803))
+        self.assertIn("coordinates", preserved_fields)
+        self.assertFalse(
+            build_data.raw_place_coordinate_address_has_street_level_evidence(
+                "5th Ave, New York, NY, United States"
+            )
+        )
+
+    def test_preserve_existing_raw_place_handles_localized_street_alias(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="Av. Colon 508, Merida, Mexico",
+            lat=20.98,
+            lng=-89.62,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "Avenida Colon 508, Merida, Mexico",
+                "lat": 21.08,
+                "lng": -89.72,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (20.98, -89.62))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_keeps_non_latin_combining_marks(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 क St, Delhi, India",
+            lat=28.61,
+            lng=77.21,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 कि St, Delhi, India",
+                "lat": 28.7,
+                "lng": 77.3,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (28.7, 77.3))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_latin_diacritic_loss(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="Av. Colón 508, Mérida, México",
+            lat=20.98,
+            lng=-89.62,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "Av. Colon 508, Merida, Mexico",
+                "lat": 21.08,
+                "lng": -89.72,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (20.98, -89.62))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_trailing_floor_designator(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, 2nd Floor, Portland, OR, United States",
+            lat=45.5152,
+            lng=-122.6784,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main Street, Floor 2, Portland, OR, USA",
+                "lat": 45.6,
+                "lng": -122.75,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (45.5152, -122.6784))
+        self.assertIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_handles_reordered_address_components(self) -> None:
         existing_place = RawPlace(
@@ -2366,6 +2685,75 @@ class BuildDataTests(unittest.TestCase):
         )
         self.assertEqual((merged.lat, merged.lng), (45.5152, -122.6784))
         self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_locality_only_address_regression(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Wooden Spoon",
+            address="2172 Market St, San Francisco, CA 94114, United States",
+            lat=37.7666529,
+            lng=-122.4303822,
+            maps_url="https://www.google.com/maps?cid=740708305128434099",
+            cid="740708305128434099",
+        )
+        for refreshed_address in (
+            "San Francisco, CA",
+            "Market St, San Francisco, CA",
+        ):
+            with self.subTest(refreshed_address=refreshed_address):
+                refreshed_place = existing_place.model_copy(
+                    update={
+                        "address": refreshed_address,
+                        "lat": 37.7818711,
+                        "lng": -122.3740949,
+                    }
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual(
+                    merged.address,
+                    "2172 Market St, San Francisco, CA 94114, United States",
+                )
+                self.assertEqual(
+                    (merged.lat, merged.lng),
+                    (37.7666529, -122.4303822),
+                )
+                self.assertIn("address", preserved_fields)
+                self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_accepts_new_locality_only_address(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, Seattle, WA, United States",
+            lat=47.6062,
+            lng=-122.3321,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        for refreshed_address in ("New York, NY", "Toronto, Canada"):
+            with self.subTest(refreshed_address=refreshed_address):
+                refreshed_place = existing_place.model_copy(
+                    update={
+                        "address": refreshed_address,
+                        "lat": 40.7128,
+                        "lng": -74.006,
+                    }
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (40.7128, -74.006))
+                self.assertNotIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_accepts_removed_country_name_locality(
         self,

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2602,6 +2602,60 @@ class BuildDataTests(unittest.TestCase):
             )
         )
 
+    def test_preserve_existing_raw_place_handles_named_street_intersection(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="Main St & 5th Ave, New York, NY, United States",
+            lat=40.7536,
+            lng=-73.9803,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "Main Street and Fifth Avenue, New York, NY, USA",
+                "lat": 40.85,
+                "lng": -74.08,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (40.7536, -73.9803))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_normalizes_possessive_apostrophe(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 King's Rd, Hong Kong",
+            lat=22.3193,
+            lng=114.1694,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "1 Kings Road, Hong Kong",
+                "lat": 22.42,
+                "lng": 114.27,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (22.3193, 114.1694))
+        self.assertIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_handles_localized_street_alias(self) -> None:
         existing_place = RawPlace(
             name="Example Cafe",
@@ -3090,6 +3144,37 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertEqual((merged.lat, merged.lng), (42.3601, -71.0589))
         self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_dotted_us_country_alias(
+        self,
+    ) -> None:
+        for country_alias in ("U.S.", "U.S.A."):
+            with self.subTest(country_alias=country_alias):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=f"123 Main St, Boston, MA, {country_alias}",
+                    lat=42.3601,
+                    lng=-71.0589,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={
+                        "address": (
+                            "123 Main Street, Boston, MA, United States"
+                        ),
+                        "lat": 42.46,
+                        "lng": -71.16,
+                    }
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (42.3601, -71.0589))
+                self.assertIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_treats_georgia_as_us_subdivision(self) -> None:
         existing_place = RawPlace(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2629,6 +2629,33 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (40.7536, -73.9803))
         self.assertIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_does_not_treat_building_name_as_intersection(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="One Court Square, Queens, NY, United States",
+            lat=40.747,
+            lng=-73.945,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "One Ct Sq, Queens, NY, USA",
+                "lat": 40.85,
+                "lng": -74.08,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (40.85, -74.08))
+        self.assertNotIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_normalizes_possessive_apostrophe(
         self,
     ) -> None:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2708,6 +2708,147 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (20.98, -89.62))
         self.assertIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_handles_abbreviated_street_prefix(
+        self,
+    ) -> None:
+        for address in (
+            "C. de la Cava Baja, 16, Centro, 28005 Madrid, Spain",
+            "C/ de Ponzano, 11, Chamberí, 28010 Madrid, Spain",
+            "P.za del Duomo, 21, 20121 Milano MI, Italy",
+            "Pl. de Carles Buïgas, 1, 43840 Salou, Spain",
+        ):
+            with self.subTest(address=address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=address,
+                    lat=40.0,
+                    lng=-3.0,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={"lat": 40.1, "lng": -3.1}
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (40.0, -3.0))
+                self.assertIn("coordinates", preserved_fields)
+
+        self.assertFalse(
+            build_data.raw_place_coordinate_address_has_street_level_evidence(
+                "Building C, 16, Queens, NY, United States"
+            )
+        )
+
+    def test_preserve_existing_raw_place_handles_no_prefixed_premise_number(
+        self,
+    ) -> None:
+        for address in (
+            "No. 91, Xinguang Rd, Taoyuan City, 330",
+            "No. 42, Yongkang St, Taipei City, 106",
+        ):
+            with self.subTest(address=address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=address,
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={"lat": 25.1, "lng": 121.6}
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (25.0, 121.5))
+                self.assertIn("coordinates", preserved_fields)
+
+        self.assertFalse(
+            build_data.raw_place_coordinate_part_is_premise_number(["no", "name"])
+        )
+
+    def test_preserve_existing_raw_place_handles_postcode_digit_matching_street_number(
+        self,
+    ) -> None:
+        for existing_address, refreshed_address in (
+            (
+                "1 Leather Ln, London EC1N 2TD, United Kingdom",
+                "1 Leather Lane, London, United Kingdom",
+            ),
+            (
+                "1 Leather Ln, London EC1N 2TD, United Kingdom",
+                "1 Leather Lane, London EC1N2TD, United Kingdom",
+            ),
+            (
+                "1 Leather Ln, London EC1N 2TD, United Kingdom",
+                "1 Leather Lane, London EC2N 2TD, United Kingdom",
+            ),
+            (
+                "5 King St, Toronto M5V 2T6, Canada",
+                "5 King Street, Toronto, Canada",
+            ),
+        ):
+            with self.subTest(refreshed_address=refreshed_address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=existing_address,
+                    lat=51.52,
+                    lng=-0.11,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={
+                        "address": refreshed_address,
+                        "lat": 51.62,
+                        "lng": -0.21,
+                    }
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (51.52, -0.11))
+                self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_keeps_street_number_change_with_postcode(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Leather Ln, London EC1N 2TD, United Kingdom",
+            lat=51.52,
+            lng=-0.11,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "2 Leather Lane, London EC1N 2TD, United Kingdom",
+                "lat": 51.62,
+                "lng": -0.21,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (51.62, -0.21))
+        self.assertNotIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_keeps_non_latin_combining_marks(self) -> None:
         existing_place = RawPlace(
             name="Example Cafe",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2105,7 +2105,6 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertEqual(merged.google_id, "/g/example")
         self.assertIn("google_id", preserved_fields)
-        self.assertEqual(build_data.stable_place_id(merged), "gid:g-example")
 
     def test_preserve_existing_raw_place_does_not_restore_google_id_across_url_conflict(
         self,

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1655,6 +1655,117 @@ class BuildDataTests(unittest.TestCase):
                 self.assertEqual((merged.lat, merged.lng), (38.711, -9.137))
                 self.assertIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_handles_split_street_number_components(
+        self,
+    ) -> None:
+        for address in (
+            "Via Roma, 1, Roma, Italy",
+            "Rua Augusta, 195, Lisboa, Portugal",
+        ):
+            with self.subTest(address=address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=address,
+                    lat=41.9,
+                    lng=12.5,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={"lat": 41.95, "lng": 12.55}
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (41.9, 12.5))
+                self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_abbreviated_street_terms(self) -> None:
+        for address in (
+            "R. Barbosa du Bocage 5, Sintra, Portugal",
+            "Pariser Str. 16, Berlin, Germany",
+            "1 Chome-63-1 Jingumae, Shibuya City, Tokyo",
+        ):
+            with self.subTest(address=address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=address,
+                    lat=38.8,
+                    lng=-9.4,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={"lat": 38.85, "lng": -9.45}
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (38.8, -9.4))
+                self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_accepts_route_only_coordinate_correction(
+        self,
+    ) -> None:
+        for address in (
+            "Highway 1, Big Sur, CA",
+            "Route 66, Albuquerque, NM",
+            "US Highway 1, Big Sur, CA",
+            "State Route 66, Albuquerque, NM",
+            "US Highway 1 Suite 2, Big Sur, CA",
+            "M1 Highway, Watford, United Kingdom",
+            "Suite 2 US Highway 1, Big Sur, CA",
+            "US 1 Highway, Big Sur, CA",
+            "State 66 Route, Albuquerque, NM",
+        ):
+            with self.subTest(address=address):
+                existing_place = RawPlace(
+                    name="Example Overlook",
+                    address=address,
+                    lat=36.2,
+                    lng=-121.8,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={"lat": 36.25, "lng": -121.85}
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (36.25, -121.85))
+                self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_numbered_route_premise(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 US Highway 1, Big Sur, CA",
+            lat=36.2,
+            lng=-121.8,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={"lat": 36.25, "lng": -121.85}
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (36.2, -121.8))
+        self.assertIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_saved_list_rejects_large_coordinate_only_shift(
         self,
     ) -> None:
@@ -1823,6 +1934,128 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
         self.assertIn("address", preserved_fields)
         self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_refresh_identity_loss(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "lat": 36.0,
+                "lng": 140.0,
+                "maps_url": "https://www.google.com/maps/search/?api=1&query=Example+Cafe",
+                "cid": None,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
+        self.assertEqual(merged.cid, "111")
+        self.assertIn("coordinates", preserved_fields)
+        self.assertIn("cid", preserved_fields)
+
+    def test_preserve_existing_raw_place_matches_query_place_id_identity(self) -> None:
+        maps_url = (
+            "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+            "&query_place_id=ChIJ-example"
+        )
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url=maps_url,
+        )
+        refreshed_place = existing_place.model_copy(
+            update={"lat": 36.0, "lng": 140.0}
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_saved_list_matches_query_place_id_identity(
+        self,
+    ) -> None:
+        query_place_id = "ChIJ-example"
+        existing_payload = RawSavedList(
+            places=[
+                RawPlace(
+                    name="Example Cafe",
+                    address="1 Main St, Portland, Oregon, United States",
+                    lat=45.5152,
+                    lng=-122.6784,
+                    maps_url=(
+                        "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                        f"&query_place_id={query_place_id}"
+                    ),
+                )
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            places=[
+                RawPlace(
+                    name="Example Cafe",
+                    address="1 Main Street, Portland, OR, USA",
+                    lat=45.6,
+                    lng=-122.75,
+                    maps_url=(
+                        "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                        f"&query_place_id={query_place_id}"
+                    ),
+                )
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="portland-oregon-usa",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual((merged.places[0].lat, merged.places[0].lng), (45.5152, -122.6784))
+
+    def test_preserve_existing_raw_place_rejects_conflicting_cid_alias_as_identity_loss(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "lat": 36.0,
+                "lng": 140.0,
+                "maps_url": "https://www.google.com/maps/search/?api=1&query=Example+Cafe",
+                "cid": None,
+                "cid_aliases": ["222"],
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (36.0, 140.0))
+        self.assertNotIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_keeps_ids_during_guarded_rebrand(self) -> None:
         existing_place = RawPlace(
@@ -1995,6 +2228,56 @@ class BuildDataTests(unittest.TestCase):
         )
 
         self.assertEqual((merged.lat, merged.lng), (37.7666529, -122.4303822))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_normalizes_subdivision_aliases(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Main St, Portland, Oregon, United States",
+            lat=45.5152,
+            lng=-122.6784,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "1 Main Street, Portland, OR, USA",
+                "lat": 45.6,
+                "lng": -122.75,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (45.5152, -122.6784))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_treats_georgia_as_us_subdivision(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Main St, Atlanta, Georgia",
+            lat=33.749,
+            lng=-84.388,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "1 Main Street, Atlanta, GA, United States",
+                "lat": 33.8,
+                "lng": -84.45,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (33.749, -84.388))
         self.assertIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_accepts_added_locality_with_large_shift(self) -> None:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1964,6 +1964,35 @@ class BuildDataTests(unittest.TestCase):
         self.assertIn("coordinates", preserved_fields)
         self.assertIn("cid", preserved_fields)
 
+    def test_preserve_existing_raw_place_rejects_non_ascii_name_identity_loss(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="寿司一番",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "name": "ラーメン二郎",
+                "lat": 36.0,
+                "lng": 140.0,
+                "maps_url": "https://www.google.com/maps/search/?api=1&query=Restaurant",
+                "cid": None,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (36.0, 140.0))
+        self.assertNotIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_matches_query_place_id_identity(self) -> None:
         maps_url = (
             "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
@@ -1987,6 +2016,29 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
         self.assertIn("coordinates", preserved_fields)
+
+    def test_stable_place_id_uses_query_place_id(self) -> None:
+        query_place_id = "GhIJ-example"
+        place = RawPlace(
+            name="Example Cafe",
+            lat=35.0,
+            lng=139.0,
+            maps_url=(
+                "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                f"&query_place_id={query_place_id}"
+            ),
+        )
+
+        self.assertEqual(
+            build_data.stable_place_id(place),
+            f"gpid:{query_place_id}",
+        )
+        self.assertEqual(
+            build_data.stable_place_id(
+                place.model_copy(update={"lat": 36.0, "lng": 140.0})
+            ),
+            f"gpid:{query_place_id}",
+        )
 
     def test_preserve_existing_raw_place_matches_query_id_to_stored_place_id(
         self,
@@ -2630,6 +2682,58 @@ class BuildDataTests(unittest.TestCase):
         )
 
         self.assertEqual((merged.lat, merged.lng), (45.5152, -122.6784))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_infers_omitted_country_for_subdivision_alias(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="2172 Market St, San Francisco, California",
+            lat=37.7666529,
+            lng=-122.4303822,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "2172 Market Street, San Francisco, CA",
+                "lat": 37.7818711,
+                "lng": -122.3740949,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (37.7666529, -122.4303822))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_us_country_alias(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, Boston, MA, US",
+            lat=42.3601,
+            lng=-71.0589,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main Street, Boston, MA, United States",
+                "lat": 42.46,
+                "lng": -71.16,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (42.3601, -71.0589))
         self.assertIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_treats_georgia_as_us_subdivision(self) -> None:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1751,6 +1751,189 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (37.7666529, -122.4303822))
         self.assertIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_accepts_added_locality_with_large_shift(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, United States",
+            lat=37.7749,
+            lng=-122.4194,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main Street, Portland, OR 97205, United States",
+                "lat": 45.5152,
+                "lng": -122.6784,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual(
+            merged.address,
+            "123 Main Street, Portland, OR 97205, United States",
+        )
+        self.assertEqual((merged.lat, merged.lng), (45.5152, -122.6784))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_accepts_added_locality_for_suffixless_street(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="12 Rue de la Paix, France",
+            lat=48.8566,
+            lng=2.3522,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "12 Rue de la Paix, Lyon, France",
+                "lat": 45.764,
+                "lng": 4.8357,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (45.764, 4.8357))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_accepts_explicit_country_change(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, United States",
+            lat=47.6062,
+            lng=-122.3321,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main Street, Canada",
+                "lat": 49.2827,
+                "lng": -123.1207,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (49.2827, -123.1207))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_equivalent_country_aliases(self) -> None:
+        existing_place = RawPlace(
+            name="Wooden Spoon",
+            address="2172 Market St, San Francisco, CA 94114, USA",
+            lat=37.7666529,
+            lng=-122.4303822,
+            maps_url="https://www.google.com/maps?cid=740708305128434099",
+            cid="740708305128434099",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": (
+                    "2172 Market Street, San Francisco, CA 94114, United States"
+                ),
+                "lat": 37.7818711,
+                "lng": -122.3740949,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (37.7666529, -122.4303822))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_accepts_reordered_location_words(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="12 York Rd, New London, United States",
+            lat=41.3557,
+            lng=-72.0995,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "12 London Road, New York, United States",
+                "lat": 40.7128,
+                "lng": -74.006,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (40.7128, -74.006))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_keeps_unit_words_in_street_names(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Tower Rd, Boston, MA, United States",
+            lat=42.3601,
+            lng=-71.0589,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "1 Tower Avenue, Boston, MA, United States",
+                "lat": 42.3736,
+                "lng": -71.1097,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (42.3736, -71.1097))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_japanese_postal_expansion(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="東京都渋谷区神宮前1丁目1-1",
+            lat=35.6762,
+            lng=139.6503,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "〒150-0001 東京都渋谷区神宮前１丁目１－１, 日本",
+                "lat": 34.6937,
+                "lng": 135.5023,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (35.6762, 139.6503))
+        self.assertIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_accepts_changed_street_number(self) -> None:
         existing_place = RawPlace(
             name="Example Cafe",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1754,7 +1754,7 @@ class BuildDataTests(unittest.TestCase):
     def test_preserve_existing_raw_place_accepts_changed_street_number(self) -> None:
         existing_place = RawPlace(
             name="Example Cafe",
-            address="12 Main St, Boston, MA 02101",
+            address="Unit 312 12 Main St, Boston, MA 02101",
             lat=42.36,
             lng=-71.06,
             maps_url="https://www.google.com/maps?cid=111",
@@ -1762,7 +1762,7 @@ class BuildDataTests(unittest.TestCase):
         )
         refreshed_place = existing_place.model_copy(
             update={
-                "address": "312 Main St, Boston, MA 02101, Unit 12",
+                "address": "Unit 12 312 Main St, Boston, MA 02101",
                 "lat": 42.38,
                 "lng": -71.08,
             }
@@ -1773,9 +1773,35 @@ class BuildDataTests(unittest.TestCase):
             refreshed_place=refreshed_place,
         )
 
-        self.assertEqual(merged.address, "312 Main St, Boston, MA 02101, Unit 12")
+        self.assertEqual(merged.address, "Unit 12 312 Main St, Boston, MA 02101")
         self.assertEqual((merged.lat, merged.lng), (42.38, -71.08))
         self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_slash_unit_rewrite(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="5/12 Main St, Sydney NSW 2000",
+            lat=-33.8688,
+            lng=151.2093,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "Unit 5, 12 Main Street, Sydney NSW 2000",
+                "lat": -33.89,
+                "lng": 151.23,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual(merged.address, "Unit 5, 12 Main Street, Sydney NSW 2000")
+        self.assertEqual((merged.lat, merged.lng), (-33.8688, 151.2093))
+        self.assertIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_accepts_changed_non_latin_address(self) -> None:
         existing_place = RawPlace(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -3823,6 +3823,33 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (33.749, -84.388))
         self.assertIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_treats_georgia_as_country_with_georgian_subdivision(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Rustaveli Ave, Tbilisi, Georgia",
+            lat=41.7151,
+            lng=44.8271,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "1 Rustaveli Avenue, Tbilisi",
+                "lat": 41.8,
+                "lng": 44.9,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (41.7151, 44.8271))
+        self.assertIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_accepts_added_locality_with_large_shift(self) -> None:
         existing_place = RawPlace(
             name="Example Cafe",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2154,6 +2154,8 @@ class BuildDataTests(unittest.TestCase):
         )
         refreshed_place = existing_place.model_copy(
             update={
+                "lat": 36.0,
+                "lng": 140.0,
                 "maps_url": "https://www.google.com/maps?cid=111",
                 "google_id": None,
             }
@@ -2166,6 +2168,8 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertIsNone(merged.google_id)
         self.assertNotIn("google_id", preserved_fields)
+        self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
+        self.assertIn("coordinates", preserved_fields)
 
     def test_raw_place_google_places_ids_exclude_legacy_google_ids(self) -> None:
         place = RawPlace(
@@ -2241,6 +2245,72 @@ class BuildDataTests(unittest.TestCase):
                 "maps_url": "https://www.google.com/maps/search/?api=1&query=Example+Cafe",
                 "cid": None,
                 "cid_aliases": ["222"],
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (36.0, 140.0))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_accepts_compatible_cid_alias_match(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+            cid_aliases=["999"],
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "lat": 36.0,
+                "lng": 140.0,
+                "maps_url": "https://www.google.com/maps?cid=222",
+                "cid": "222",
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_rejects_alias_only_match_with_conflicting_ids(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url=(
+                "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                "&query_place_id=ChIJ-B"
+            ),
+            google_id="ChIJ-A",
+            cid="111",
+            cid_aliases=["999"],
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "lat": 36.0,
+                "lng": 140.0,
+                "maps_url": (
+                    "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                    "&query_place_id=ChIJ-C"
+                ),
+                "google_id": "ChIJ-C",
+                "cid": "222",
             }
         )
 
@@ -2683,6 +2753,291 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertEqual((merged.lat, merged.lng), (45.5152, -122.6784))
         self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_normalizes_subdivision_suffix_in_locality(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, Boston MA 02108, US",
+            lat=42.3601,
+            lng=-71.0589,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main Street, Boston, MA 02108, United States",
+                "lat": 42.46,
+                "lng": -71.16,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (42.3601, -71.0589))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_normalizes_subdivision_before_alphanumeric_postcode(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, Toronto ON M5V 2T6, Canada",
+            lat=43.6532,
+            lng=-79.3832,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main Street, Toronto, ON M5V 2T6, Canada",
+                "lat": 43.75,
+                "lng": -79.48,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (43.6532, -79.3832))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_keeps_subdivision_code_that_looks_like_unit(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, Orlando FL 32801, US",
+            lat=28.5383,
+            lng=-81.3792,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main Street, Orlando, FL 32801, United States",
+                "lat": 28.64,
+                "lng": -81.48,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (28.5383, -81.3792))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_normalizes_subdivision_before_next_postcode_part(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, Boston MA, 02108, US",
+            lat=42.3601,
+            lng=-71.0589,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main Street, Boston, MA 02108, United States",
+                "lat": 42.46,
+                "lng": -71.16,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (42.3601, -71.0589))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_infers_country_from_subdivision_postcode(
+        self,
+    ) -> None:
+        for existing_address, refreshed_address in (
+            (
+                "123 Main St, Boston MA 02108",
+                "123 Main Street, Boston, MA 02108",
+            ),
+            (
+                "123 Main St, Toronto ON, M5V 2T6",
+                "123 Main Street, Toronto, ON M5V 2T6",
+            ),
+        ):
+            with self.subTest(existing_address=existing_address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=existing_address,
+                    lat=42.3601,
+                    lng=-71.0589,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={
+                        "address": refreshed_address,
+                        "lat": 42.46,
+                        "lng": -71.16,
+                    }
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (42.3601, -71.0589))
+                self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_does_not_treat_floor_as_subdivision(
+        self,
+    ) -> None:
+        for unit in ("B12", "2000"):
+            with self.subTest(unit=unit):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=f"123 Main St, FL {unit}, Orlando, US",
+                    lat=28.5383,
+                    lng=-81.3792,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={
+                        "address": (
+                            f"123 Main Street, Floor {unit}, Orlando, "
+                            "United States"
+                        ),
+                        "lat": 28.64,
+                        "lng": -81.48,
+                    }
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (28.5383, -81.3792))
+                self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_does_not_treat_international_unit_as_subdivision(
+        self,
+    ) -> None:
+        for existing_address, refreshed_address in (
+            (
+                "123 Main St, RM B12, Rome, RM 00100, Italy",
+                "123 Main Street, Room B12, Rome, RM 00100, Italy",
+            ),
+            (
+                "123 Main St, RM 2000, Rome, RM 00100, Italy",
+                "123 Main Street, Room 2000, Rome, RM 00100, Italy",
+            ),
+            (
+                "123 Main St, STE B12, London, ENG SW1A 1AA, United Kingdom",
+                "123 Main Street, Suite B12, London, ENG SW1A 1AA, United Kingdom",
+            ),
+        ):
+            with self.subTest(existing_address=existing_address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=existing_address,
+                    lat=41.9028,
+                    lng=12.4964,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={
+                        "address": refreshed_address,
+                        "lat": 42.0,
+                        "lng": 12.6,
+                    }
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (41.9028, 12.4964))
+                self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_normalizes_postal_led_subdivision_suffix(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, 00100 Roma RM, Italy",
+            lat=41.9028,
+            lng=12.4964,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main Street, 00100 Roma, RM, Italy",
+                "lat": 42.0,
+                "lng": 12.6,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (41.9028, 12.4964))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_does_not_split_name_like_subdivision_suffixes(
+        self,
+    ) -> None:
+        for existing_address, refreshed_address in (
+            (
+                "123 Main St, Hotel California, US",
+                "123 Main Street, Hotel, CA, United States",
+            ),
+            (
+                "123 Main St, Made In, US",
+                "123 Main Street, Made, IN, United States",
+            ),
+        ):
+            with self.subTest(existing_address=existing_address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=existing_address,
+                    lat=42.3601,
+                    lng=-71.0589,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={
+                        "address": refreshed_address,
+                        "lat": 42.46,
+                        "lng": -71.16,
+                    }
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (42.46, -71.16))
+                self.assertNotIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_infers_omitted_country_for_subdivision_alias(
         self,
@@ -4224,6 +4579,49 @@ class BuildDataTests(unittest.TestCase):
             build_data.stable_place_id(merged.places[1], source_type=merged.configured_source_type),
         )
 
+    def test_preserve_existing_raw_saved_list_rechecks_cid_exposed_by_duplicate_cleanup(
+        self,
+    ) -> None:
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="First Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                ),
+                RawPlace(
+                    name="Contaminated Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url="https://www.google.com/maps?cid=222",
+                    cid="111",
+                ),
+                RawPlace(
+                    name="Second Cafe",
+                    address="2 Main St, Taipei",
+                    lat=25.1,
+                    lng=121.6,
+                    maps_url="https://www.google.com/maps?cid=222",
+                    cid="222",
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=None,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(build_data.raw_place_cid_identity(merged.places[0]), "111")
+        self.assertIsNone(build_data.raw_place_cid_identity(merged.places[1]))
+        self.assertEqual(build_data.raw_place_cid_identity(merged.places[2]), "222")
+
     def test_preserve_existing_raw_saved_list_keeps_independent_google_ids_for_duplicate_cid(
         self,
     ) -> None:
@@ -4612,6 +5010,709 @@ class BuildDataTests(unittest.TestCase):
             build_data.stable_place_id(merged.places[0], source_type=merged.configured_source_type),
             build_data.stable_place_id(merged.places[1], source_type=merged.configured_source_type),
         )
+
+    def test_preserve_existing_raw_saved_list_does_not_reward_competing_cid_for_duplicate_google_id(
+        self,
+    ) -> None:
+        shared_google_id = "/g/shared"
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Correct+Cafe",
+                    google_id=shared_google_id,
+                ),
+                RawPlace(
+                    name="Wrong Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url="https://www.google.com/maps?cid=222",
+                    google_id=shared_google_id,
+                    cid="222",
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=None,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].google_id, shared_google_id)
+        self.assertIsNone(merged.places[1].google_id)
+
+    def test_preserve_existing_raw_saved_list_clears_duplicate_url_query_id_hidden_by_stored_id(
+        self,
+    ) -> None:
+        shared_query_id = "ChIJ-shared"
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Query Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=(
+                        "https://www.google.com/maps/search/?api=1&query=Query+Cafe"
+                        f"&query_place_id={shared_query_id}"
+                    ),
+                ),
+                RawPlace(
+                    name="Stored ID Cafe",
+                    address="2 Main St, Taipei",
+                    lat=25.1,
+                    lng=121.6,
+                    maps_url=(
+                        "https://www.google.com/maps?cid=222"
+                        f"&query_place_id={shared_query_id}"
+                    ),
+                    google_id="ChIJ-unique",
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=None,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(
+            build_data.extract_maps_query_place_id(merged.places[0].maps_url),
+            shared_query_id,
+        )
+        self.assertIsNone(
+            build_data.extract_maps_query_place_id(merged.places[1].maps_url)
+        )
+        self.assertEqual(merged.places[1].google_id, "ChIJ-unique")
+        self.assertEqual(build_data.raw_place_cid_identity(merged.places[1]), "222")
+
+    def test_duplicate_cleanup_matches_identities_across_fields_and_urls(
+        self,
+    ) -> None:
+        google_places_id = "ChIJ-shared"
+        google_payload = RawSavedList(
+            places=[
+                RawPlace(
+                    name="Conflicted Google Cafe",
+                    maps_url=(
+                        "https://www.google.com/maps/search/?api=1"
+                        "&query=Conflicted+Google+Cafe"
+                        f"&query_place_id={google_places_id}"
+                    ),
+                    google_id="ChIJ-unique",
+                ),
+                RawPlace(
+                    name="Clean Google Cafe",
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Clean+Google+Cafe",
+                    google_id=google_places_id,
+                ),
+            ]
+        )
+
+        cleaned_google = build_data.clear_duplicate_raw_place_google_identities(
+            slug="taipei-taiwan",
+            payload=google_payload,
+            existing_payload=None,
+        )
+
+        self.assertEqual(cleaned_google.places[0].google_id, "ChIJ-unique")
+        self.assertIsNone(
+            build_data.extract_maps_query_place_id(
+                cleaned_google.places[0].maps_url
+            )
+        )
+        self.assertEqual(cleaned_google.places[1].google_id, google_places_id)
+
+        maps_place_token = "0xabc123:0x111111"
+        token_payload = RawSavedList(
+            places=[
+                RawPlace(
+                    name="Conflicted Token Cafe",
+                    maps_url=(
+                        "https://www.google.com/maps/place/data=!4m2!3m1!1s"
+                        f"{maps_place_token}"
+                    ),
+                    maps_place_token="0xabc123:0x222222",
+                ),
+                RawPlace(
+                    name="Clean Token Cafe",
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Clean+Token+Cafe",
+                    maps_place_token=maps_place_token,
+                ),
+            ]
+        )
+
+        cleaned_tokens = build_data.clear_duplicate_raw_place_google_identities(
+            slug="taipei-taiwan",
+            payload=token_payload,
+            existing_payload=None,
+        )
+
+        self.assertEqual(
+            cleaned_tokens.places[0].maps_place_token,
+            "0xabc123:0x222222",
+        )
+        self.assertIsNone(
+            build_data.extract_maps_place_token(cleaned_tokens.places[0].maps_url)
+        )
+        self.assertEqual(
+            cleaned_tokens.places[1].maps_place_token,
+            maps_place_token,
+        )
+
+        cid_payload = RawSavedList(
+            places=[
+                RawPlace(
+                    name="Conflicted CID Cafe",
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="222",
+                ),
+                RawPlace(
+                    name="Clean CID Cafe",
+                    maps_url="https://www.google.com/maps/search/?api=1&query=Clean+CID+Cafe",
+                    cid="111",
+                ),
+            ]
+        )
+
+        cleaned_cids = build_data.clear_duplicate_raw_place_cids(
+            slug="taipei-taiwan",
+            payload=cid_payload,
+            existing_payload=None,
+        )
+
+        self.assertEqual(cleaned_cids.places[0].cid, "222")
+        self.assertIsNone(
+            build_data.extract_maps_cid(cleaned_cids.places[0].maps_url)
+        )
+        self.assertEqual(cleaned_cids.places[1].cid, "111")
+
+    def test_preserve_existing_raw_saved_list_prefers_consistent_duplicate_google_id(
+        self,
+    ) -> None:
+        shared_google_id = "ChIJ-shared"
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=(
+                        "https://www.google.com/maps/search/?api=1&query=Correct+Cafe"
+                        f"&query_place_id={shared_google_id}"
+                    ),
+                    google_id=shared_google_id,
+                ),
+                RawPlace(
+                    name="Wrong Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url=(
+                        "https://www.google.com/maps/search/?api=1&query=Wrong+Cafe"
+                        "&query_place_id=ChIJ-other"
+                    ),
+                    google_id=shared_google_id,
+                    cid="999",
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=None,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].google_id, shared_google_id)
+        self.assertIsNone(merged.places[1].google_id)
+        self.assertEqual(
+            build_data.extract_maps_query_place_id(merged.places[1].maps_url),
+            "ChIJ-other",
+        )
+
+    def test_preserve_existing_raw_saved_list_rechecks_exposed_google_places_id_duplicates(
+        self,
+    ) -> None:
+        first_google_id = "ChIJ-first"
+        second_google_id = "ChIJ-second"
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="First Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=(
+                        "https://www.google.com/maps/search/?api=1&query=First+Cafe"
+                        f"&query_place_id={first_google_id}"
+                    ),
+                    google_id=first_google_id,
+                ),
+                RawPlace(
+                    name="Second Cafe",
+                    address="2 Main St, Taipei",
+                    lat=25.1,
+                    lng=121.6,
+                    maps_url=(
+                        "https://www.google.com/maps/search/?api=1&query=Second+Cafe"
+                        f"&query_place_id={second_google_id}"
+                    ),
+                ),
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                existing_payload.places[0],
+                RawPlace(
+                    name="Contaminated Cafe",
+                    address="99 Other St, Taipei",
+                    lat=25.2,
+                    lng=121.7,
+                    maps_url=(
+                        "https://www.google.com/maps/search/?api=1"
+                        "&query=Contaminated+Cafe"
+                        f"&query_place_id={second_google_id}"
+                    ),
+                    google_id=first_google_id,
+                    cid="999",
+                ),
+                existing_payload.places[1],
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(
+            build_data.raw_place_google_places_id_identity(merged.places[0]),
+            first_google_id,
+        )
+        self.assertIsNone(
+            build_data.raw_place_google_places_id_identity(merged.places[1])
+        )
+        self.assertEqual(
+            build_data.raw_place_google_places_id_identity(merged.places[2]),
+            second_google_id,
+        )
+
+    def test_preserve_existing_raw_saved_list_keeps_separately_anchored_place_token(
+        self,
+    ) -> None:
+        google_places_id = "ChIJ-correct-cafe"
+        maps_place_token = "0xabc123:0x111111"
+        token_url = (
+            "https://www.google.com/maps/place/data=!4m2!3m1!1s"
+            f"{maps_place_token}"
+        )
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Place ID Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=(
+                        "https://www.google.com/maps/search/?api=1&query=Place+ID+Cafe"
+                        f"&query_place_id={google_places_id}"
+                    ),
+                    google_id=google_places_id,
+                ),
+                RawPlace(
+                    name="Token Cafe",
+                    address="2 Main St, Taipei",
+                    lat=25.1,
+                    lng=121.6,
+                    maps_url=token_url,
+                    maps_place_token=maps_place_token,
+                ),
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Place ID Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=token_url,
+                    google_id=google_places_id,
+                ),
+                RawPlace(
+                    name="Token Cafe",
+                    address="2 Main St, Taipei",
+                    lat=25.1,
+                    lng=121.6,
+                    maps_url=token_url,
+                    google_id=google_places_id,
+                    maps_place_token=maps_place_token,
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(merged.places[0].google_id, google_places_id)
+        self.assertIsNone(
+            build_data.raw_place_maps_place_token_identity(merged.places[0])
+        )
+        self.assertIsNone(merged.places[1].google_id)
+        self.assertEqual(
+            build_data.raw_place_maps_place_token_identity(merged.places[1]),
+            maps_place_token,
+        )
+
+    def test_preserve_existing_raw_saved_list_keeps_query_id_when_duplicate_token_is_removed(
+        self,
+    ) -> None:
+        google_places_id = "ChIJ-place-id-cafe"
+        maps_place_token = "0xabc123:0x111111"
+        token_url = (
+            "https://www.google.com/maps/place/data=!4m2!3m1!1s"
+            f"{maps_place_token}"
+        )
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Token Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=token_url,
+                    maps_place_token=maps_place_token,
+                ),
+                RawPlace(
+                    name="Place ID Cafe",
+                    address="2 Main St, Taipei",
+                    lat=25.1,
+                    lng=121.6,
+                    maps_url=(
+                        "https://www.google.com/maps/search/?api=1"
+                        "&query=Place+ID+Cafe"
+                        f"&query_place_id={google_places_id}"
+                    ),
+                ),
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                existing_payload.places[0],
+                RawPlace(
+                    name="Place ID Cafe",
+                    address="2 Main St, Taipei",
+                    lat=25.1,
+                    lng=121.6,
+                    maps_url=(
+                        f"{token_url}?api=1&query=Token+Cafe"
+                        f"&query_place_id={google_places_id}"
+                    ),
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(
+            build_data.raw_place_maps_place_token_identity(merged.places[0]),
+            maps_place_token,
+        )
+        self.assertEqual(
+            build_data.raw_place_google_places_id_identity(merged.places[1]),
+            google_places_id,
+        )
+        self.assertIsNone(
+            build_data.raw_place_maps_place_token_identity(merged.places[1])
+        )
+
+    def test_preserve_existing_raw_saved_list_keeps_token_when_duplicate_query_id_is_removed(
+        self,
+    ) -> None:
+        google_places_id = "ChIJ-place-id-cafe"
+        maps_place_token = "0xabc123:0x111111"
+        token_url = (
+            "https://www.google.com/maps/place/data=!4m2!3m1!1s"
+            f"{maps_place_token}"
+        )
+        query_url = (
+            "https://www.google.com/maps/search/?api=1&query=Place+ID+Cafe"
+            f"&query_place_id={google_places_id}"
+        )
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Place ID Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=query_url,
+                ),
+                RawPlace(
+                    name="Token Cafe",
+                    address="2 Main St, Taipei",
+                    lat=25.1,
+                    lng=121.6,
+                    maps_url=token_url,
+                    maps_place_token=maps_place_token,
+                ),
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                existing_payload.places[0],
+                RawPlace(
+                    name="Token Cafe",
+                    address="2 Main St, Taipei",
+                    lat=25.1,
+                    lng=121.6,
+                    maps_url=(
+                        f"{token_url}?api=1&query=Place+ID+Cafe"
+                        f"&query_place_id={google_places_id}"
+                    ),
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual(
+            build_data.raw_place_google_places_id_identity(merged.places[0]),
+            google_places_id,
+        )
+        self.assertEqual(
+            build_data.raw_place_maps_place_token_identity(merged.places[1]),
+            maps_place_token,
+        )
+        self.assertIsNone(
+            build_data.raw_place_google_places_id_identity(merged.places[1])
+        )
+
+    def test_strip_duplicate_raw_place_google_identity_keeps_independent_url_cid(
+        self,
+    ) -> None:
+        google_places_id = "ChIJ-shared"
+        maps_place_token = "0xabc123:0x111111"
+        for maps_url, strip_kwargs in (
+            (
+                (
+                    "https://www.google.com/maps?cid=222"
+                    f"&query_place_id={google_places_id}"
+                ),
+                {"google_places_id": google_places_id},
+            ),
+            (
+                (
+                    "https://www.google.com/maps/place/data=!4m2!3m1!1s"
+                    f"{maps_place_token}?cid=222"
+                ),
+                {"maps_place_token": maps_place_token},
+            ),
+        ):
+            with self.subTest(strip_kwargs=strip_kwargs):
+                stripped = build_data.strip_duplicate_raw_place_google_identity(
+                    RawPlace(
+                        name="CID Cafe",
+                        address="2 Main St, Taipei",
+                        lat=25.1,
+                        lng=121.6,
+                        maps_url=maps_url,
+                    ),
+                    **strip_kwargs,
+                )
+
+                self.assertEqual(build_data.raw_place_cid_identity(stripped), "222")
+                if "google_places_id" in strip_kwargs:
+                    self.assertIsNone(
+                        build_data.raw_place_google_places_id_identity(stripped)
+                    )
+                else:
+                    self.assertIsNone(
+                        build_data.raw_place_maps_place_token_identity(stripped)
+                    )
+
+    def test_strip_duplicate_raw_place_cid_keeps_independent_url_identity(
+        self,
+    ) -> None:
+        google_places_id = "ChIJ-unique"
+        query_place = RawPlace(
+            name="Query Cafe",
+            maps_url=(
+                "https://www.google.com/maps?cid=111"
+                f"&query_place_id={google_places_id}"
+            ),
+        )
+
+        stripped_query = build_data.strip_duplicate_raw_place_cid(
+            query_place,
+            cid="111",
+        )
+
+        self.assertEqual(
+            build_data.extract_maps_query_place_id(stripped_query.maps_url),
+            google_places_id,
+        )
+        self.assertIsNone(build_data.raw_place_cid_identity(stripped_query))
+
+        maps_place_token = "0xabc123:0x111111"
+        token_place = RawPlace(
+            name="Token Cafe",
+            maps_url=(
+                "https://www.google.com/maps/place/data=!4m2!3m1!1s"
+                f"{maps_place_token}?cid=111"
+            ),
+        )
+
+        stripped_token = build_data.strip_duplicate_raw_place_cid(
+            token_place,
+            cid="111",
+        )
+
+        self.assertEqual(
+            build_data.raw_place_maps_place_token_identity(stripped_token),
+            maps_place_token,
+        )
+        self.assertIsNone(build_data.raw_place_cid_identity(stripped_token))
+
+    def test_strip_duplicate_token_keeps_query_id_without_query_text(self) -> None:
+        google_places_id = "ChIJ-unique"
+        maps_place_token = "0xabc123:0x111111"
+        place = RawPlace(
+            name="",
+            maps_url=(
+                "https://www.google.com/maps/place/data=!4m2!3m1!1s"
+                f"{maps_place_token}?query_place_id={google_places_id}"
+            ),
+        )
+
+        stripped = build_data.strip_duplicate_raw_place_google_identity(
+            place,
+            maps_place_token=maps_place_token,
+        )
+
+        self.assertEqual(
+            build_data.extract_maps_query_place_id(stripped.maps_url),
+            google_places_id,
+        )
+        self.assertIsNone(
+            build_data.raw_place_maps_place_token_identity(stripped)
+        )
+
+    def test_strip_duplicate_token_keeps_url_cid_as_alias_when_primary_is_occupied(
+        self,
+    ) -> None:
+        google_places_id = "ChIJ-unique"
+        maps_place_token = "0xabc123:0x111111"
+        place = RawPlace(
+            name="Compound Cafe",
+            maps_url=(
+                "https://www.google.com/maps/place/data=!4m2!3m1!1s"
+                f"{maps_place_token}?cid=222"
+                f"&query_place_id={google_places_id}"
+            ),
+            cid="333",
+        )
+
+        stripped = build_data.strip_duplicate_raw_place_google_identity(
+            place,
+            maps_place_token=maps_place_token,
+        )
+
+        self.assertEqual(stripped.cid, "333")
+        self.assertEqual(stripped.cid_aliases, ["222"])
+        self.assertEqual(
+            build_data.extract_maps_query_place_id(stripped.maps_url),
+            google_places_id,
+        )
+        self.assertIsNone(
+            build_data.raw_place_maps_place_token_identity(stripped)
+        )
+
+    def test_preserve_existing_raw_saved_list_clears_duplicate_google_places_id_before_matching(
+        self,
+    ) -> None:
+        query_place_id = "ChIJ-correct-cafe"
+        query_url = (
+            "https://www.google.com/maps/search/?api=1&query=Correct+Cafe"
+            f"&query_place_id={query_place_id}"
+        )
+        existing_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main St, Taipei",
+                    lat=25.0,
+                    lng=121.5,
+                    maps_url=query_url,
+                )
+            ],
+        )
+        refreshed_payload = RawSavedList(
+            configured_source_type="google_list_url",
+            places=[
+                RawPlace(
+                    name="Correct Cafe",
+                    address="1 Main Street, Taipei",
+                    lat=25.1,
+                    lng=121.6,
+                    maps_url=query_url,
+                ),
+                RawPlace(
+                    name="Wrong Cafe",
+                    address="1 Main Street, Taipei",
+                    lat=26.0,
+                    lng=122.5,
+                    maps_url=f"{query_url}&hl=en",
+                ),
+            ],
+        )
+
+        merged = build_data.preserve_existing_raw_saved_list(
+            slug="taipei-taiwan",
+            existing_payload=existing_payload,
+            refreshed_payload=refreshed_payload,
+        )
+
+        self.assertEqual((merged.places[0].lat, merged.places[0].lng), (25.0, 121.5))
+        self.assertEqual(
+            build_data.extract_maps_query_place_id(merged.places[0].maps_url),
+            query_place_id,
+        )
+        self.assertEqual((merged.places[1].lat, merged.places[1].lng), (26.0, 122.5))
+        self.assertIsNone(build_data.extract_maps_query_place_id(merged.places[1].maps_url))
+        self.assertIn("query=Wrong+Cafe", merged.places[1].maps_url or "")
 
     def test_preserve_existing_raw_saved_list_strips_keeper_url_token_from_duplicate_google_id_loser(
         self,

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1708,6 +1708,7 @@ class BuildDataTests(unittest.TestCase):
         refreshed_place = existing_place.model_copy(
             update={
                 "name": "Completely New Concept",
+                "address": None,
                 "lat": 36.0,
                 "lng": 140.0,
             }
@@ -1719,8 +1720,62 @@ class BuildDataTests(unittest.TestCase):
         )
 
         self.assertEqual(merged.name, "Completely New Concept")
+        self.assertEqual(merged.address, "1 Example St, Example City")
         self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
+        self.assertIn("address", preserved_fields)
         self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_cosmetic_address_suffix_change(self) -> None:
+        existing_place = RawPlace(
+            name="Wooden Spoon",
+            address="2172 Market St, San Francisco, CA 94114, United States",
+            lat=37.7666529,
+            lng=-122.4303822,
+            maps_url="https://www.google.com/maps?cid=740708305128434099",
+            cid="740708305128434099",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "2172 Market Street, San Francisco, CA 94114",
+                "lat": 37.7818711,
+                "lng": -122.3740949,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual(merged.address, "2172 Market Street, San Francisco, CA 94114")
+        self.assertEqual((merged.lat, merged.lng), (37.7666529, -122.4303822))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_accepts_changed_street_number(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="12 Main St, Boston, MA 02101",
+            lat=42.36,
+            lng=-71.06,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "312 Main St, Boston, MA 02101, Unit 12",
+                "lat": 42.38,
+                "lng": -71.08,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual(merged.address, "312 Main St, Boston, MA 02101, Unit 12")
+        self.assertEqual((merged.lat, merged.lng), (42.38, -71.08))
+        self.assertNotIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_accepts_changed_non_latin_address(self) -> None:
         existing_place = RawPlace(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1696,6 +1696,32 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (35.6762, 139.6503))
         self.assertIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_handles_name_change_with_stable_identity(self) -> None:
+        existing_place = RawPlace(
+            name="Old Cafe Name",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "name": "Completely New Concept",
+                "lat": 36.0,
+                "lng": 140.0,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual(merged.name, "Completely New Concept")
+        self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
+        self.assertIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_accepts_changed_non_latin_address(self) -> None:
         existing_place = RawPlace(
             name="Example Cafe",

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1824,6 +1824,78 @@ class BuildDataTests(unittest.TestCase):
         self.assertIn("address", preserved_fields)
         self.assertIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_keeps_ids_during_guarded_rebrand(self) -> None:
+        existing_place = RawPlace(
+            name="Old Cafe Name",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+            google_id="/g/example",
+            maps_place_token="0xabc:0xdef",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "name": "Completely New Concept",
+                "address": None,
+                "lat": 36.0,
+                "lng": 140.0,
+                "google_id": None,
+                "maps_place_token": None,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual(merged.google_id, "/g/example")
+        self.assertEqual(merged.maps_place_token, "0xabc:0xdef")
+        self.assertIn("google_id", preserved_fields)
+        self.assertIn("maps_place_token", preserved_fields)
+
+    def test_preserve_existing_raw_place_rejects_conflicting_ids_during_rebrand(
+        self,
+    ) -> None:
+        cases = (
+            "https://www.google.com/maps?cid=222",
+            "https://www.google.com/maps/place/New/data=!4m2!3m1!1s0x222:0x333",
+        )
+        for refreshed_url in cases:
+            with self.subTest(url=refreshed_url):
+                existing_place = RawPlace(
+                    name="Old Cafe Name",
+                    address="1 Example St, Example City",
+                    lat=35.0,
+                    lng=139.0,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                    google_id="/g/example",
+                    maps_place_token="0xabc:0xdef",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={
+                        "name": "Completely New Concept",
+                        "lat": 36.0,
+                        "lng": 140.0,
+                        "maps_url": refreshed_url,
+                        "cid": None,
+                        "maps_place_token": None,
+                    }
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertIsNone(merged.cid)
+                self.assertIsNone(merged.maps_place_token)
+                self.assertNotIn("cid", preserved_fields)
+                self.assertNotIn("maps_place_token", preserved_fields)
+
     def test_preserve_existing_raw_place_handles_cosmetic_address_suffix_change(self) -> None:
         existing_place = RawPlace(
             name="Wooden Spoon",
@@ -1847,6 +1919,81 @@ class BuildDataTests(unittest.TestCase):
         )
 
         self.assertEqual(merged.address, "2172 Market Street, San Francisco, CA 94114")
+        self.assertEqual((merged.lat, merged.lng), (37.7666529, -122.4303822))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_postal_code_only_change(self) -> None:
+        existing_place = RawPlace(
+            name="Wooden Spoon",
+            address="2172 Market St, San Francisco, CA",
+            lat=37.7666529,
+            lng=-122.4303822,
+            maps_url="https://www.google.com/maps?cid=740708305128434099",
+            cid="740708305128434099",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "2172 Market Street, San Francisco, CA 94114",
+                "lat": 37.7818711,
+                "lng": -122.3740949,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (37.7666529, -122.4303822))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_split_postal_code_change(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="Rua Augusta 195-197, Baixa, 1100-619 Lisboa, Portugal",
+            lat=38.711,
+            lng=-9.137,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "Rua Augusta 195-197, Baixa, 1100-620 Lisboa, Portugal",
+                "lat": 38.75,
+                "lng": -9.2,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (38.711, -9.137))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_reordered_address_components(self) -> None:
+        existing_place = RawPlace(
+            name="Wooden Spoon",
+            address="2172 Market St, San Francisco, CA 94114, United States",
+            lat=37.7666529,
+            lng=-122.4303822,
+            maps_url="https://www.google.com/maps?cid=740708305128434099",
+            cid="740708305128434099",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "CA 94114, San Francisco, 2172 Market Street, USA",
+                "lat": 37.7818711,
+                "lng": -122.3740949,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
         self.assertEqual((merged.lat, merged.lng), (37.7666529, -122.4303822))
         self.assertIn("coordinates", preserved_fields)
 
@@ -2257,6 +2404,38 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
         self.assertIn("query_place_id=ChIJ-new", merged.maps_url or "")
+        self.assertNotIn("maps_url", preserved_fields)
+
+    def test_preserve_existing_raw_place_rejects_unverifiable_mixed_url_identity(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url=(
+                "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                "&query_place_id=ChIJ-old"
+            ),
+            google_id="/g/example",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "lat": 36.0,
+                "lng": 140.0,
+                "maps_url": "https://www.google.com/maps?cid=222",
+                "cid": "222",
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
+        self.assertEqual(merged.maps_url, "https://www.google.com/maps?cid=222")
         self.assertNotIn("maps_url", preserved_fields)
 
     def test_preserve_existing_raw_saved_list_restores_incomplete_coordinates(self) -> None:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -1857,6 +1857,35 @@ class BuildDataTests(unittest.TestCase):
         )
         self.assertNotIn("maps_url", preserved_fields)
 
+    def test_preserve_existing_raw_place_keeps_identity_bearing_refreshed_maps_url(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url="https://www.google.com/maps/place/Example+Cafe",
+            google_id="/g/example",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "lat": 36.0,
+                "lng": 140.0,
+                "maps_url": "https://www.google.com/maps?cid=111",
+                "cid": "111",
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (35.0, 139.0))
+        self.assertEqual(merged.maps_url, "https://www.google.com/maps?cid=111")
+        self.assertNotIn("maps_url", preserved_fields)
+
     def test_preserve_existing_raw_place_rejects_conflicting_prior_maps_url(self) -> None:
         existing_place = RawPlace(
             name="Relocated Cafe",


### PR DESCRIPTION
## Summary

- preserve prior coordinates when a refreshed record keeps a strong identity and stable address but moves more than 1 km or loses half of its coordinate pair
- keep normal coordinate jitter and relocations with a changed address
- compare international addresses with Unicode-safe normalization and keep Maps URLs only when their embedded identity is compatible

## Why

Google saved-list payloads can temporarily mix a stable place identity and old address with stale or future coordinates. That surfaced as 5.23 km and 2.71 km marker jumps in [demflyers-favorites PR #101](https://github.com/michaelmwu/demflyers-favorites/pull/101).

## Verification

- `bun run test` — 137 frontend and 658 Python tests passed
- `bun run check`
- `bun run build`
- `uv run ruff check scripts/build_data.py tests/python/test_build_data.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core raw-place merge, coordinate, and Google identity heuristics in the data build path; mistakes could mis-merge places or leave bad map positions, but behavior is heavily regression-tested.
> 
> **Overview**
> **Hardens raw saved-list refresh merging** so stale Google payloads do not overwrite good coordinates, addresses, or Maps links when the place is still the same.
> 
> When refreshed data keeps a **compatible identity** and a **stable street-level address** but lat/lng jump more than **1 km** (or one coordinate is missing), `preserve_existing_raw_place` now keeps the prior coordinates and can also keep address, `google_id`/`cid`/`maps_place_token`, and `maps_url` when URL embedded IDs still match. Address “stability” and precision regression use new **international address normalization** (aliases, ordinals, postal/subdivision/country handling, unit stripping, etc.). Name matching is tightened (e.g. rejects generic `item` slugs).
> 
> **Identity and dedup:** `query_place_id` from Maps URLs is treated as **`gpid`** in stable IDs and match keys. Duplicate **CID** and **Google identity** cleanup now considers identities from URLs and fields, runs in a **loop** until stable, prefers consistent single-identity rows, and rebuilds Maps URLs via **`build_raw_place_maps_url_preserving_identity`** instead of always falling back to generic search links. A **fallback matcher** can re-link a refreshed name-only row to a single prior row that still has durable Google identity and stable address.
> 
> **Pipeline order:** duplicate clearing runs on the refreshed payload **before** the suspicious identity-loss guard and per-place preservation merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03a4a6724ee72bfabdaa8d391461601dd254febd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved place refresh merging to better preserve existing coordinates and address details when the refreshed data clearly refers to the same location, including safeguards against precision/format regressions.
  * More reliably preserved Google Maps links by tightening identity matching and resolving duplicates without causing unintended identity changes.
  * Enhanced duplicate cleanup so place identity signals are deduplicated consistently during refresh/merge.
* **Tests**
  * Expanded regression tests to cover coordinate/address preservation and Google Maps link handling across many refresh and deduplication edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->