### PR TITLE
fix: remove stale place photo variants

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -11166,7 +11166,9 @@ def sync_place_photo(
 
     place_prefix = f"{safe_place_photo_stem(place_id)}-"
     protected_photo_filenames = {Path(path).name for path in protected_photo_paths}
-    protected_photo_stems = {Path(path).stem for path in protected_photo_paths}
+    protected_photo_stems = {
+        place_photo_stem_from_path(path) for path in protected_photo_paths
+    }
     filename = canonical_place_photo_filename(place_id, photo_url, extension=extension)
     output_path = photo_dir / filename
     temp_path = photo_dir / f".{filename}.tmp"
@@ -11206,6 +11208,14 @@ def canonical_place_photo_stem(place_id: str, photo_url: str) -> str:
     place_prefix = safe_place_photo_stem(place_id)
     photo_hash = hashlib.sha256(photo_url.encode("utf-8")).hexdigest()[:12]
     return f"{place_prefix}-{photo_hash}"
+
+
+def place_photo_stem_from_path(path: str) -> str:
+    filename = Path(path).name
+    for extension in (".webp", ".jpg", ".jpeg", ".png"):
+        if filename.endswith(extension):
+            return filename[: -len(extension)]
+    return filename
 
 
 def migrate_legacy_place_photo_to_flat_dir(

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -10909,6 +10909,12 @@ def populate_place_photos_for_guides(
         for filename, reference_count in photo_path_references.items()
         if reference_count > 0
     }
+    pending_place_counts = Counter(safe_place_photo_stem(job.place_id) for job in pending_jobs)
+    protected_photo_paths.update(
+        public_photo_path(canonical_place_photo_stem(job.place_id, job.photo_url))
+        for job in pending_jobs
+        if pending_place_counts[safe_place_photo_stem(job.place_id)] > 1
+    )
 
     if not pending_jobs:
         print(
@@ -11160,6 +11166,7 @@ def sync_place_photo(
 
     place_prefix = f"{safe_place_photo_stem(place_id)}-"
     protected_photo_filenames = {Path(path).name for path in protected_photo_paths}
+    protected_photo_stems = {Path(path).stem for path in protected_photo_paths}
     filename = canonical_place_photo_filename(place_id, photo_url, extension=extension)
     output_path = photo_dir / filename
     temp_path = photo_dir / f".{filename}.tmp"
@@ -11172,6 +11179,7 @@ def sync_place_photo(
             or stale_path.name == filename
             or stale_path.name.startswith(".")
             or stale_path.name in protected_photo_filenames
+            or stale_path.stem in protected_photo_stems
             or place_photo_prefix_from_stem(stale_path.stem) != place_prefix
         ):
             continue

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -11120,14 +11120,14 @@ def sync_place_photo(
     if optimized_content is None:
         return None
 
-    place_prefix = canonical_place_photo_stem(place_id, photo_url)
+    place_prefix = f"{safe_place_photo_stem(place_id)}-"
     filename = canonical_place_photo_filename(place_id, photo_url, extension=extension)
     output_path = photo_dir / filename
     temp_path = photo_dir / f".{filename}.tmp"
     temp_path.write_bytes(optimized_content)
     temp_path.replace(output_path)
 
-    for stale_path in photo_dir.glob(f"{place_prefix}-*"):
+    for stale_path in photo_dir.glob(f"{place_prefix}*"):
         if stale_path.name == filename or stale_path.name.startswith("."):
             continue
         stale_path.unlink(missing_ok=True)

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -10844,13 +10844,18 @@ def populate_place_photos_for_guides(
                     )
         return
 
-    protected_photo_paths = {
-        Path(place.main_photo_path).name
-        for guide in guides
-        for place in guide.places
-        if place.main_photo_path
-        and place.main_photo_path.startswith("/place-photos/")
-    }
+    photo_path_references: Counter[str] = Counter()
+    for guide in guides:
+        if guide.place_photo_mode == "remote_url":
+            continue
+        for place in guide.places:
+            if place.main_photo_path and place.main_photo_path.startswith("/place-photos/"):
+                photo_path_references[Path(place.main_photo_path).name] += 1
+
+    def unreference_current_photo(place: NormalizedPlace) -> None:
+        if place.main_photo_path and place.main_photo_path.startswith("/place-photos/"):
+            photo_path_references[Path(place.main_photo_path).name] -= 1
+
     pending_jobs: list[PendingPhotoJob] = []
     reused_count = 0
     missing_photo_url_count = 0
@@ -10863,6 +10868,7 @@ def populate_place_photos_for_guides(
         for place in guide.places:
             photo_url = cached_place_photo_url(enrichment_cache.get(place.id))
             if not photo_url:
+                unreference_current_photo(place)
                 place.main_photo_path = None
                 missing_photo_url_count += 1
                 continue
@@ -10874,10 +10880,21 @@ def populate_place_photos_for_guides(
                 flat_index=flat_index,
             )
             if existing_path is not None:
+                previous_filename = (
+                    Path(place.main_photo_path).name
+                    if place.main_photo_path
+                    and place.main_photo_path.startswith("/place-photos/")
+                    else None
+                )
+                existing_filename = Path(existing_path).name
+                if previous_filename != existing_filename:
+                    unreference_current_photo(place)
+                    photo_path_references[existing_filename] += 1
                 place.main_photo_path = existing_path
                 reused_count += 1
                 continue
 
+            unreference_current_photo(place)
             pending_jobs.append(
                 PendingPhotoJob(
                     guide_slug=guide.slug,
@@ -10886,6 +10903,12 @@ def populate_place_photos_for_guides(
                     photo_url=photo_url,
                 )
             )
+
+    protected_photo_paths = {
+        filename
+        for filename, reference_count in photo_path_references.items()
+        if reference_count > 0
+    }
 
     if not pending_jobs:
         print(

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -10844,6 +10844,13 @@ def populate_place_photos_for_guides(
                     )
         return
 
+    protected_photo_paths = {
+        Path(place.main_photo_path).name
+        for guide in guides
+        for place in guide.places
+        if place.main_photo_path
+        and place.main_photo_path.startswith("/place-photos/")
+    }
     pending_jobs: list[PendingPhotoJob] = []
     reused_count = 0
     missing_photo_url_count = 0
@@ -10905,27 +10912,34 @@ def populate_place_photos_for_guides(
 
     if max_workers == 1 or len(pending_jobs) == 1:
         for index, job in enumerate(pending_jobs, start=1):
-            photo_path = sync_place_photo(
-                job.guide_slug,
-                job.place_id,
-                photo_url=job.photo_url,
-                startup_jitter_seconds=effective_startup_jitter_seconds,
-            )
+            sync_kwargs = {
+                "photo_url": job.photo_url,
+                "startup_jitter_seconds": effective_startup_jitter_seconds,
+            }
+            if protected_photo_paths:
+                sync_kwargs["protected_photo_paths"] = protected_photo_paths
+            photo_path = sync_place_photo(job.guide_slug, job.place_id, **sync_kwargs)
             place_by_key[(job.guide_slug, job.place_id)].main_photo_path = photo_path
             print(photo_progress_line(index, len(pending_jobs), job, photo_path), flush=True)
         return
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        future_map = {
-            executor.submit(
-                sync_place_photo,
-                job.guide_slug,
-                job.place_id,
-                photo_url=job.photo_url,
-                startup_jitter_seconds=effective_startup_jitter_seconds,
-            ): job
-            for job in pending_jobs
-        }
+        future_map = {}
+        for job in pending_jobs:
+            sync_kwargs = {
+                "photo_url": job.photo_url,
+                "startup_jitter_seconds": effective_startup_jitter_seconds,
+            }
+            if protected_photo_paths:
+                sync_kwargs["protected_photo_paths"] = protected_photo_paths
+            future_map[
+                executor.submit(
+                    sync_place_photo,
+                    job.guide_slug,
+                    job.place_id,
+                    **sync_kwargs,
+                )
+            ] = job
         for index, future in enumerate(as_completed(future_map), start=1):
             job = future_map[future]
             photo_path = future.result()
@@ -11084,6 +11098,7 @@ def sync_place_photo(
     *,
     photo_url: str | None,
     startup_jitter_seconds: float = 0,
+    protected_photo_paths: Sequence[str] = (),
 ) -> str | None:
     if not photo_url:
         return None
@@ -11121,18 +11136,25 @@ def sync_place_photo(
         return None
 
     place_prefix = f"{safe_place_photo_stem(place_id)}-"
+    protected_photo_filenames = {Path(path).name for path in protected_photo_paths}
     filename = canonical_place_photo_filename(place_id, photo_url, extension=extension)
     output_path = photo_dir / filename
     temp_path = photo_dir / f".{filename}.tmp"
     temp_path.write_bytes(optimized_content)
     temp_path.replace(output_path)
 
-    for stale_path in photo_dir.glob(f"{place_prefix}*"):
-        if stale_path.name == filename or stale_path.name.startswith("."):
+    for stale_path in photo_dir.iterdir():
+        if (
+            not stale_path.is_file()
+            or stale_path.name == filename
+            or stale_path.name.startswith(".")
+            or stale_path.name in protected_photo_filenames
+            or place_photo_prefix_from_stem(stale_path.stem) != place_prefix
+        ):
             continue
         stale_path.unlink(missing_ok=True)
 
-    remove_legacy_place_photo_matches(slug, filename_glob=canonical_place_photo_glob(place_id, photo_url))
+    remove_legacy_place_photo_variants(slug, place_id)
     return public_photo_path(filename)
 
 
@@ -11179,6 +11201,28 @@ def remove_legacy_place_photo_matches(slug: str, *, filename_glob: str) -> None:
 
     for stale_path in legacy_dir.glob(filename_glob):
         stale_path.unlink(missing_ok=True)
+
+    try:
+        next(legacy_dir.iterdir())
+    except StopIteration:
+        legacy_dir.rmdir()
+    except FileNotFoundError:
+        return
+
+
+def remove_legacy_place_photo_variants(slug: str, place_id: str) -> None:
+    legacy_dir = PLACE_PHOTOS_DIR / slug
+    if not legacy_dir.exists():
+        return
+
+    place_prefix = f"{safe_place_photo_stem(place_id)}-"
+    for stale_path in legacy_dir.iterdir():
+        if (
+            stale_path.is_file()
+            and not stale_path.name.startswith(".")
+            and place_photo_prefix_from_stem(stale_path.stem) == place_prefix
+        ):
+            stale_path.unlink(missing_ok=True)
 
     try:
         next(legacy_dir.iterdir())

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -6,6 +6,7 @@ import os
 import sqlite3
 import sys
 import unittest
+from collections.abc import Sequence
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import UTC, datetime, timedelta
 from io import BytesIO, StringIO
@@ -9887,6 +9888,62 @@ class BuildDataTests(unittest.TestCase):
                 "[photos 2/2] downloaded: tokyo-japan / Second Place",
             ],
         )
+
+    def test_populate_place_photos_for_guides_does_not_protect_replaced_variant(self) -> None:
+        guide = Guide(
+            slug="tokyo-japan",
+            title="Tokyo, Japan",
+            country_name="Japan",
+            city_name="Tokyo",
+            generated_at="2026-04-20T00:00:00+00:00",
+            place_count=1,
+            places=[
+                NormalizedPlace(
+                    id="cid:123",
+                    name="Example Place",
+                    maps_url="https://maps.google.com/?cid=123",
+                    main_photo_path="/place-photos/cid-123-old.jpg",
+                    status="active",
+                )
+            ],
+        )
+        protected_paths: list[tuple[str, ...]] = []
+
+        def fake_sync_place_photo(
+            slug: str,
+            place_id: str,
+            *,
+            photo_url: str | None,
+            startup_jitter_seconds: float = 0,
+            protected_photo_paths: Sequence[str] = (),
+        ) -> str:
+            protected_paths.append(tuple(protected_photo_paths))
+            return "/place-photos/cid-123-new.jpg"
+
+        with (
+            patch.object(build_data, "sync_place_photo", side_effect=fake_sync_place_photo),
+            patch("builtins.print"),
+        ):
+            build_data.populate_place_photos_for_guides(
+                [guide],
+                enrichment_caches={
+                    "tokyo-japan": {
+                        "cid:123": EnrichmentCacheEntry(
+                            fetched_at="2026-04-20T00:00:00+00:00",
+                            query="Example Place",
+                            matched=True,
+                            place=EnrichmentPlace(
+                                main_photo_url="https://example.com/new.jpg"
+                            ),
+                        )
+                    }
+                },
+                refresh_photos=True,
+                photo_workers=1,
+                startup_jitter_seconds=8,
+            )
+
+        self.assertEqual(protected_paths, [()])
 
     def test_populate_place_photos_for_guides_uses_existing_local_files_without_refresh(self) -> None:
         guide = Guide(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -9665,6 +9665,62 @@ class BuildDataTests(unittest.TestCase):
             self.assertEqual(current_path.read_bytes(), b"optimized")
             self.assertFalse(stale_path.exists())
 
+    def test_sync_place_photo_preserves_referenced_and_prefix_similar_variants(self) -> None:
+        class FakeHeaders:
+            def get_content_type(self) -> str:
+                return "image/png"
+
+        class FakeResponse:
+            headers = FakeHeaders()
+
+            def read(self) -> bytes:
+                return b"source-image"
+
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> bool:
+                return False
+
+        photo_url = "https://lh3.googleusercontent.com/p/current=s680-w680-h510"
+        stale_photo_url = "https://lh3.googleusercontent.com/p/stale=s680-w680-h510"
+        other_photo_url = "https://lh3.googleusercontent.com/p/other=s680-w680-h510"
+        current_hash = hashlib.sha256(photo_url.encode("utf-8")).hexdigest()[:12]
+        stale_hash = hashlib.sha256(stale_photo_url.encode("utf-8")).hexdigest()[:12]
+        other_hash = hashlib.sha256(other_photo_url.encode("utf-8")).hexdigest()[:12]
+
+        with TemporaryDirectory() as tmpdir:
+            photo_dir = Path(tmpdir)
+            protected_path = photo_dir / f"cid-123-{stale_hash}.jpg"
+            prefix_similar_path = photo_dir / f"cid-123-def-{other_hash}.jpg"
+            protected_path.write_bytes(b"referenced-image")
+            prefix_similar_path.write_bytes(b"other-place-image")
+            legacy_protected_path = photo_dir / "tokyo-japan" / protected_path.name
+            legacy_prefix_similar_path = photo_dir / "tokyo-japan" / prefix_similar_path.name
+            legacy_protected_path.parent.mkdir(parents=True, exist_ok=True)
+            legacy_protected_path.write_bytes(b"legacy-referenced-image")
+            legacy_prefix_similar_path.write_bytes(b"legacy-other-place-image")
+
+            with (
+                patch.object(build_data, "PLACE_PHOTOS_DIR", photo_dir),
+                patch.object(build_data, "urlopen", return_value=FakeResponse()),
+                patch.object(build_data, "optimize_place_photo_asset", return_value=(b"optimized", ".jpg")),
+            ):
+                result = build_data.sync_place_photo(
+                    "tokyo-japan",
+                    "cid:123",
+                    photo_url=photo_url,
+                    protected_photo_paths=(f"/place-photos/{protected_path.name}",),
+                )
+
+            current_path = photo_dir / f"cid-123-{current_hash}.jpg"
+            self.assertEqual(result, f"/place-photos/{current_path.name}")
+            self.assertTrue(current_path.exists())
+            self.assertTrue(protected_path.exists())
+            self.assertTrue(prefix_similar_path.exists())
+            self.assertFalse(legacy_protected_path.exists())
+            self.assertTrue(legacy_prefix_similar_path.exists())
+
     def test_sync_place_photo_migrates_legacy_guide_scoped_file_to_flat_storage(self) -> None:
         photo_url = "https://lh3.googleusercontent.com/p/example=s680-w680-h510"
         photo_hash = hashlib.sha256(photo_url.encode("utf-8")).hexdigest()[:12]

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -9711,7 +9711,7 @@ class BuildDataTests(unittest.TestCase):
                     "tokyo-japan",
                     "cid:123",
                     photo_url=photo_url,
-                    protected_photo_paths=(f"/place-photos/{protected_path.name}",),
+                    protected_photo_paths=(f"/place-photos/{protected_path.stem}",),
                 )
 
             current_path = photo_dir / f"cid-123-{current_hash}.jpg"
@@ -9944,6 +9944,99 @@ class BuildDataTests(unittest.TestCase):
             )
 
         self.assertEqual(protected_paths, [()])
+
+    def test_populate_place_photos_for_guides_protects_pending_sibling_variants(self) -> None:
+        guides = [
+            Guide(
+                slug="tokyo-japan",
+                title="Tokyo, Japan",
+                country_name="Japan",
+                city_name="Tokyo",
+                generated_at="2026-04-20T00:00:00+00:00",
+                place_count=1,
+                places=[
+                    NormalizedPlace(
+                        id="cid:123",
+                        name="Example Place",
+                        maps_url="https://maps.google.com/?cid=123",
+                        status="active",
+                    )
+                ],
+            ),
+            Guide(
+                slug="osaka-japan",
+                title="Osaka, Japan",
+                country_name="Japan",
+                city_name="Osaka",
+                generated_at="2026-04-20T00:00:00+00:00",
+                place_count=1,
+                places=[
+                    NormalizedPlace(
+                        id="cid:123",
+                        name="Example Place (alternate)",
+                        maps_url="https://maps.google.com/?cid=123",
+                        status="active",
+                    )
+                ],
+            ),
+        ]
+        protected_paths: list[tuple[str, ...]] = []
+        photo_urls = (
+            "https://example.com/first.jpg",
+            "https://example.com/second.jpg",
+        )
+
+        def fake_sync_place_photo(
+            slug: str,
+            place_id: str,
+            *,
+            photo_url: str | None,
+            startup_jitter_seconds: float = 0,
+            protected_photo_paths: Sequence[str] = (),
+        ) -> str:
+            protected_paths.append(tuple(protected_photo_paths))
+            return f"/place-photos/{place_id}.jpg"
+
+        with (
+            patch.object(build_data, "sync_place_photo", side_effect=fake_sync_place_photo),
+            patch("builtins.print"),
+        ):
+            build_data.populate_place_photos_for_guides(
+                guides,
+                enrichment_caches={
+                    "tokyo-japan": {
+                        "cid:123": EnrichmentCacheEntry(
+                            fetched_at="2026-04-20T00:00:00+00:00",
+                            query="Example Place",
+                            matched=True,
+                            place=EnrichmentPlace(main_photo_url=photo_urls[0]),
+                        )
+                    },
+                    "osaka-japan": {
+                        "cid:123": EnrichmentCacheEntry(
+                            fetched_at="2026-04-20T00:00:00+00:00",
+                            query="Example Place (alternate)",
+                            matched=True,
+                            place=EnrichmentPlace(main_photo_url=photo_urls[1]),
+                        )
+                    },
+                },
+                refresh_photos=True,
+                photo_workers=1,
+                startup_jitter_seconds=0,
+            )
+
+        expected_stems = {
+            "cid-123-"
+            + hashlib.sha256(photo_url.encode("utf-8")).hexdigest()[:12]
+            for photo_url in photo_urls
+        }
+        self.assertEqual(len(protected_paths), 2)
+        self.assertTrue(
+            expected_stems.issubset(
+                {Path(path).name for path in protected_paths[0]}
+            )
+        )
 
     def test_populate_place_photos_for_guides_uses_existing_local_files_without_refresh(self) -> None:
         guide = Guide(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -9722,6 +9722,52 @@ class BuildDataTests(unittest.TestCase):
             self.assertFalse(legacy_protected_path.exists())
             self.assertTrue(legacy_prefix_similar_path.exists())
 
+    def test_sync_place_photo_preserves_dotted_extensionless_protected_stem(self) -> None:
+        class FakeHeaders:
+            def get_content_type(self) -> str:
+                return "image/png"
+
+        class FakeResponse:
+            headers = FakeHeaders()
+
+            def read(self) -> bytes:
+                return b"source-image"
+
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> bool:
+                return False
+
+        place_id = "google_maps_uri:maps.google.com/place"
+        photo_url = "https://lh3.googleusercontent.com/p/current=s680-w680-h510"
+        protected_url = "https://lh3.googleusercontent.com/p/protected=s680-w680-h510"
+        current_hash = hashlib.sha256(photo_url.encode("utf-8")).hexdigest()[:12]
+        protected_hash = hashlib.sha256(protected_url.encode("utf-8")).hexdigest()[:12]
+        place_stem = build_data.safe_place_photo_stem(place_id)
+        protected_filename = f"{place_stem}-{protected_hash}.jpg"
+        protected_stem = protected_filename.removesuffix(".jpg")
+
+        with TemporaryDirectory() as tmpdir:
+            photo_dir = Path(tmpdir)
+            protected_path = photo_dir / protected_filename
+            protected_path.write_bytes(b"protected-image")
+
+            with (
+                patch.object(build_data, "PLACE_PHOTOS_DIR", photo_dir),
+                patch.object(build_data, "urlopen", return_value=FakeResponse()),
+                patch.object(build_data, "optimize_place_photo_asset", return_value=(b"optimized", ".jpg")),
+            ):
+                result = build_data.sync_place_photo(
+                    "tokyo-japan",
+                    place_id,
+                    photo_url=photo_url,
+                    protected_photo_paths=(f"/place-photos/{protected_stem}",),
+                )
+
+            self.assertEqual(result, f"/place-photos/{place_stem}-{current_hash}.jpg")
+            self.assertTrue(protected_path.exists())
+
     def test_sync_place_photo_migrates_legacy_guide_scoped_file_to_flat_storage(self) -> None:
         photo_url = "https://lh3.googleusercontent.com/p/example=s680-w680-h510"
         photo_hash = hashlib.sha256(photo_url.encode("utf-8")).hexdigest()[:12]

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -9626,6 +9626,45 @@ class BuildDataTests(unittest.TestCase):
         self.assertFalse(legacy_path.exists())
         self.assertFalse(legacy_path.parent.exists())
 
+    def test_sync_place_photo_removes_stale_hashed_variants(self) -> None:
+        class FakeHeaders:
+            def get_content_type(self) -> str:
+                return "image/png"
+
+        class FakeResponse:
+            headers = FakeHeaders()
+
+            def read(self) -> bytes:
+                return b"source-image"
+
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> bool:
+                return False
+
+        photo_url = "https://lh3.googleusercontent.com/p/current=s680-w680-h510"
+        stale_photo_url = "https://lh3.googleusercontent.com/p/stale=s680-w680-h510"
+        current_hash = hashlib.sha256(photo_url.encode("utf-8")).hexdigest()[:12]
+        stale_hash = hashlib.sha256(stale_photo_url.encode("utf-8")).hexdigest()[:12]
+
+        with TemporaryDirectory() as tmpdir:
+            photo_dir = Path(tmpdir)
+            stale_path = photo_dir / f"cid-123-{stale_hash}.jpg"
+            stale_path.write_bytes(b"stale-image")
+
+            with (
+                patch.object(build_data, "PLACE_PHOTOS_DIR", photo_dir),
+                patch.object(build_data, "urlopen", return_value=FakeResponse()),
+                patch.object(build_data, "optimize_place_photo_asset", return_value=(b"optimized", ".jpg")),
+            ):
+                result = build_data.sync_place_photo("tokyo-japan", "cid:123", photo_url=photo_url)
+
+            current_path = photo_dir / f"cid-123-{current_hash}.jpg"
+            self.assertEqual(result, f"/place-photos/{current_path.name}")
+            self.assertEqual(current_path.read_bytes(), b"optimized")
+            self.assertFalse(stale_path.exists())
+
     def test_sync_place_photo_migrates_legacy_guide_scoped_file_to_flat_storage(self) -> None:
         photo_url = "https://lh3.googleusercontent.com/p/example=s680-w680-h510"
         photo_hash = hashlib.sha256(photo_url.encode("utf-8")).hexdigest()[:12]


### PR DESCRIPTION
## Trigger

Downstream daily refresh review identified that a refreshed place photo adds a new hash-suffixed asset without removing older variants for the same place.

## Root cause

The cleanup glob used the canonical filename stem, which includes the source URL hash. When the source URL changes, older sibling variants are not matched.

## Fix

Match stale variants by the stable place-ID filename prefix, keeping only the newly generated asset.

## Verification

- `/Users/michaelwu/dev/favorite-places/.context/venv-cid-test/bin/python -m unittest tests.python.test_build_data` (568 tests)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes asset deletion during data builds; incorrect protection logic could delete live images or leave orphans, but behavior is scoped to build-time photo sync with new unit tests.
> 
> **Overview**
> **Place photo refresh** no longer leaves old hash-suffixed files when the source URL changes. Stale cleanup in `sync_place_photo` now keys off the **stable place-ID filename prefix** instead of the canonical stem that includes the URL hash.
> 
> **Safety during parallel downloads:** `populate_place_photos_for_guides` tracks which flat `/place-photos/` files are still referenced by guides and passes a **`protected_photo_paths`** set into each `sync_place_photo` call so cleanup does not delete images another guide or in-flight job still needs (including sibling variants for the same `place_id` with different URLs). Reference counts are adjusted when paths are cleared or swapped to a reused file.
> 
> **Legacy cleanup** switches from hash-specific globs to **`remove_legacy_place_photo_variants`**, which removes guide-scoped files matching the place prefix only. New helpers support stem parsing for extensionless protected paths.
> 
> Tests cover stale hash removal, protected/referenced variants, dotted place IDs, populate-level protection behavior, and sibling pending jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7732fd998a69f3228513c43b92972e6367c93bf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved place-photo refresh to avoid deleting photos that are still required by other pending downloads.
  * Updated stale-photo cleanup to use place-id/prefix-based matching, preserving the canonical image and protected variants (including tricky dotted/extensionless stems).
  * Added safer legacy cleanup limited to the relevant place-photo prefix variants.

* **Tests**
  * Added unit tests covering sync behavior: stale variant removal, canonical file preservation, and protected-variant handling across guide updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->