### PR TITLE
fix: harden coordinate address precision checks

### DIFF
--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -190,6 +190,57 @@ RAW_PLACE_DIRECTION_TOKEN_ALIASES = {
     "southwest": "sw",
     "west": "w",
 }
+RAW_PLACE_JAPANESE_PREFECTURE_MARKERS = frozenset(
+    {
+        "北海道",
+        "青森県",
+        "岩手県",
+        "宮城県",
+        "秋田県",
+        "山形県",
+        "福島県",
+        "茨城県",
+        "栃木県",
+        "群馬県",
+        "埼玉県",
+        "千葉県",
+        "東京都",
+        "神奈川県",
+        "新潟県",
+        "富山県",
+        "石川県",
+        "福井県",
+        "山梨県",
+        "長野県",
+        "岐阜県",
+        "静岡県",
+        "愛知県",
+        "三重県",
+        "滋賀県",
+        "京都府",
+        "大阪府",
+        "兵庫県",
+        "奈良県",
+        "和歌山県",
+        "鳥取県",
+        "島根県",
+        "岡山県",
+        "広島県",
+        "山口県",
+        "徳島県",
+        "香川県",
+        "愛媛県",
+        "高知県",
+        "福岡県",
+        "佐賀県",
+        "長崎県",
+        "熊本県",
+        "大分県",
+        "宮崎県",
+        "鹿児島県",
+        "沖縄県",
+    }
+)
 RAW_PLACE_ORDINAL_WORD_VALUES = {
     "first": 1,
     "second": 2,
@@ -7257,7 +7308,24 @@ def raw_place_coordinate_address_precision_regressed(
         for existing_part in set(existing_parts) - set(refreshed_parts)
     ):
         return False
-    directional_tokens = {"e", "east", "n", "north", "s", "south", "w", "west"}
+    directional_tokens = {
+        "e",
+        "east",
+        "n",
+        "north",
+        "ne",
+        "northeast",
+        "nw",
+        "northwest",
+        "s",
+        "south",
+        "se",
+        "southeast",
+        "sw",
+        "southwest",
+        "w",
+        "west",
+    }
     if any(
         set(existing_part).difference(refreshed_part) & directional_tokens
         for existing_part in existing_parts
@@ -7575,8 +7643,12 @@ def raw_place_coordinate_hash_premise_token_indexes(
         re.finditer(r"#\s*(\d+(?:\s*-\s*[A-Za-z]{1,3})?)\b", normalized_part)
     )
     for match in reversed(hash_premises):
+        unit_prefix_pattern = "|".join(
+            re.escape(token)
+            for token in sorted(RAW_PLACE_UNIT_PREFIX_TOKENS, key=len, reverse=True)
+        )
         if re.search(
-            r"\b(?:apt|apartment|suite|ste|unit)\s*$",
+            rf"\b(?:{unit_prefix_pattern})\s*$",
             normalized_part[: match.start()],
             flags=re.IGNORECASE,
         ):
@@ -8065,16 +8137,17 @@ def raw_place_coordinate_collapse_street_number_range(
     _comparison_parts, country_code = raw_place_coordinate_address_comparison_key(
         normalized_address
     )
+    is_japanese_address = raw_place_coordinate_address_is_japanese(
+        normalized_address,
+        country_code=country_code,
+    )
     replaced = False
 
     def collapse(match: re.Match[str]) -> str:
         nonlocal replaced
-        if (
-            contains_cjk
-            and (
-                country_code == "JP"
-                or not re.match(r"\s*[號号]", normalized_address[match.end() :])
-            )
+        if contains_cjk and (
+            is_japanese_address
+            or not re.match(r"\s*[號号]", normalized_address[match.end() :])
         ):
             return match.group(0)
         if endpoint not in {match.group("start"), match.group("end")}:
@@ -8088,6 +8161,20 @@ def raw_place_coordinate_collapse_street_number_range(
         normalized_address,
     )
     return collapsed if replaced else None
+
+
+def raw_place_coordinate_address_is_japanese(
+    address: str,
+    *,
+    country_code: str | None,
+) -> bool:
+    if country_code == "JP":
+        return True
+    if country_code is not None:
+        return False
+    if re.search(r"[\u3040-\u30ff]", address):
+        return True
+    return any(marker in address for marker in RAW_PLACE_JAPANESE_PREFECTURE_MARKERS)
 
 
 def raw_place_coordinate_token_is_part_of_valid_alphanumeric_postal(

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -6848,6 +6848,7 @@ def preserve_existing_raw_place(
             existing_place,
             refreshed_place.maps_url,
             refreshed_cid=as_string(refreshed_place.cid),
+            refreshed_maps_place_token=as_string(refreshed_place.maps_place_token),
         )
     ):
         updates["google_id"] = existing_place.google_id
@@ -6860,6 +6861,7 @@ def preserve_existing_raw_place(
             existing_place,
             refreshed_place.maps_url,
             refreshed_cid=as_string(refreshed_place.cid),
+            refreshed_maps_place_token=as_string(refreshed_place.maps_place_token),
         )
     ):
         updates["cid"] = existing_place.cid
@@ -6883,6 +6885,7 @@ def preserve_existing_raw_place(
             existing_place,
             refreshed_place.maps_url,
             refreshed_cid=as_string(refreshed_place.cid),
+            refreshed_maps_place_token=as_string(refreshed_place.maps_place_token),
         )
     ):
         updates["maps_place_token"] = existing_place.maps_place_token
@@ -7061,11 +7064,13 @@ def raw_place_coordinate_address_is_stable(
     refreshed_address = as_string(refreshed_place.address)
     if not refreshed_address:
         return raw_place_address_is_preservable(existing_place, refreshed_place)
+    if raw_place_coordinate_address_precision_regressed(
+        existing_place,
+        refreshed_place,
+    ):
+        return True
     if not raw_place_coordinate_address_has_street_level_evidence(refreshed_address):
-        return raw_place_coordinate_address_precision_regressed(
-            existing_place,
-            refreshed_place,
-        )
+        return False
 
     existing_address_key = raw_place_coordinate_address_key(existing_address)
     refreshed_address_key = raw_place_coordinate_address_key(refreshed_address)
@@ -7148,8 +7153,6 @@ def raw_place_coordinate_address_precision_regressed(
         return False
     if not raw_place_coordinate_address_has_street_level_evidence(existing_address):
         return False
-    if raw_place_coordinate_address_has_street_level_evidence(refreshed_address):
-        return False
     if not raw_place_address_is_preservable(existing_place, refreshed_place):
         return False
 
@@ -7164,6 +7167,21 @@ def raw_place_coordinate_address_precision_regressed(
         existing_country is not None
         and refreshed_country is not None
         and existing_country != refreshed_country
+    ):
+        return False
+    is_strict_precision_subset = len(refreshed_parts) < len(existing_parts) or any(
+        all(refreshed_part != existing_part for existing_part in existing_parts)
+        for refreshed_part in refreshed_parts
+    )
+    if not is_strict_precision_subset:
+        return False
+    country_name_parts = {
+        country_tokens
+        for country_tokens, _ in raw_place_coordinate_country_token_identities()
+    }
+    if any(
+        existing_part in country_name_parts
+        for existing_part in set(existing_parts) - set(refreshed_parts)
     ):
         return False
     return bool(
@@ -7319,6 +7337,7 @@ def raw_place_coordinate_part_has_street_intersection(
 
 def raw_place_coordinate_address_has_street_level_evidence(address: str) -> bool:
     normalized_address = raw_place_coordinate_strip_japanese_postal_prefix(address)
+    _, country_code = raw_place_coordinate_address_comparison_key(normalized_address)
     parsed_parts: list[tuple[str, str, list[str]]] = []
     for part in re.split(r"[,、]", normalized_address):
         address_key = raw_place_coordinate_address_key(part)
@@ -7339,6 +7358,11 @@ def raw_place_coordinate_address_has_street_level_evidence(address: str) -> bool
             and not raw_place_coordinate_token_is_ordinal(token)
             and index not in hash_unit_token_indexes
         }
+        if not numeric_indexes and country_code == "MX":
+            numeric_indexes = raw_place_coordinate_hash_premise_token_indexes(
+                part,
+                tokens,
+            )
         if not numeric_indexes:
             continue
         if raw_place_coordinate_part_is_route_only(tokens, address_key=address_key):
@@ -7368,13 +7392,11 @@ def raw_place_coordinate_address_has_street_level_evidence(address: str) -> bool
             continue
         if set(tokens) & {"hwy", "rte"}:
             continue
-        for neighbor_index in (index - 1, index + 1):
-            if not 0 <= neighbor_index < len(parsed_parts):
-                continue
-            if raw_place_coordinate_part_is_premise_number(
-                parsed_parts[neighbor_index][2]
-            ):
-                return True
+        if raw_place_coordinate_street_part_has_nearby_premise(
+            parsed_parts,
+            index,
+        ):
+            return True
     return False
 
 
@@ -7451,6 +7473,53 @@ def raw_place_coordinate_hash_unit_token_indexes(
             search_end = start
             break
     return matched_indexes
+
+
+def raw_place_coordinate_hash_premise_token_indexes(
+    part: str,
+    tokens: Sequence[str],
+) -> set[int]:
+    matched_indexes: set[int] = set()
+    search_end = len(tokens)
+    hash_premises = re.findall(
+        r"#\s*(\d+(?:\s*-\s*[A-Za-z]{1,3})?)\b",
+        unicodedata.normalize("NFKC", part),
+    )
+    for hash_premise in reversed(hash_premises):
+        address_key = raw_place_coordinate_address_key(hash_premise)
+        if address_key is None:
+            continue
+        premise_tokens = raw_place_coordinate_address_token_list(address_key)
+        if not premise_tokens:
+            continue
+        for start in range(search_end - len(premise_tokens), -1, -1):
+            end = start + len(premise_tokens)
+            if list(tokens[start:end]) != premise_tokens:
+                continue
+            matched_indexes.update(range(start, end))
+            search_end = start
+            break
+    return matched_indexes
+
+
+def raw_place_coordinate_street_part_has_nearby_premise(
+    parsed_parts: Sequence[tuple[str, str, list[str]]],
+    street_part_index: int,
+) -> bool:
+    for direction in (-1, 1):
+        candidate_index = street_part_index + direction
+        while 0 <= candidate_index < len(parsed_parts):
+            candidate_tokens = parsed_parts[candidate_index][2]
+            if raw_place_coordinate_part_is_premise_number(candidate_tokens):
+                return True
+            if not raw_place_coordinate_part_is_section_component(candidate_tokens):
+                break
+            candidate_index += direction
+    return False
+
+
+def raw_place_coordinate_part_is_section_component(tokens: Sequence[str]) -> bool:
+    return bool(tokens) and tokens[0] in {"sec", "section"}
 
 
 def raw_place_coordinate_numeric_indexes_include_premise(
@@ -7896,6 +7965,9 @@ def raw_place_coordinate_collapse_street_number_range(
     if len(endpoint_numbers) != 1:
         return None
     endpoint = next(iter(endpoint_numbers))
+    normalized_address = unicodedata.normalize("NFKC", address)
+    if re.search(r"[\u3040-\u30ff\u3400-\u9fff]", normalized_address):
+        return None
     replaced = False
 
     def collapse(match: re.Match[str]) -> str:
@@ -7908,7 +7980,7 @@ def raw_place_coordinate_collapse_street_number_range(
     collapsed = re.sub(
         r"(?<!\d)(?P<start>\d+)\s*[-–—−]\s*(?P<end>\d+)(?!\d)",
         collapse,
-        unicodedata.normalize("NFKC", address),
+        normalized_address,
     )
     return collapsed if replaced else None
 
@@ -8311,6 +8383,7 @@ def raw_place_refreshed_url_identity_is_compatible(
     refreshed_url: str | None,
     *,
     refreshed_cid: str | None = None,
+    refreshed_maps_place_token: str | None = None,
 ) -> bool:
     if len(raw_place_google_places_identities(existing_place)) > 1:
         return False
@@ -8327,6 +8400,19 @@ def raw_place_refreshed_url_identity_is_compatible(
     if refreshed_cid and existing_cids and refreshed_cid not in existing_cids:
         return False
     matched_identity = bool(refreshed_cid and refreshed_cid in existing_cids)
+
+    existing_tokens = {
+        token
+        for token in [
+            as_string(existing_place.maps_place_token),
+            extract_maps_place_token(existing_place.maps_url),
+        ]
+        if token
+    }
+    if refreshed_maps_place_token and existing_tokens:
+        if refreshed_maps_place_token in existing_tokens:
+            return True
+        return False
 
     url = as_string(refreshed_url)
     if not url or not raw_place_maps_url_has_embedded_identity(url):
@@ -8355,14 +8441,6 @@ def raw_place_refreshed_url_identity_is_compatible(
 
     refreshed_token = extract_maps_place_token(url)
     if refreshed_token:
-        existing_tokens = {
-            token
-            for token in [
-                as_string(existing_place.maps_place_token),
-                extract_maps_place_token(existing_place.maps_url),
-            ]
-            if token
-        }
         if existing_tokens and refreshed_token not in existing_tokens:
             return False
         matched_identity = matched_identity or refreshed_token in existing_tokens

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7153,10 +7153,10 @@ def raw_place_coordinate_street_name_tokens(address: str) -> set[str]:
             continue
         return {
             token
-            for token in tokens
+            for index, token in enumerate(tokens)
             if not any(character.isdigit() for character in token)
             and not raw_place_coordinate_token_is_ordinal(token)
-            and token not in RAW_PLACE_STREET_SUFFIX_TOKENS
+            and (token not in RAW_PLACE_STREET_SUFFIX_TOKENS or index != len(tokens) - 1)
             and token not in RAW_PLACE_UNIT_PREFIX_TOKENS
         }
     return set()
@@ -7195,6 +7195,21 @@ def raw_place_coordinate_address_precision_regressed(
         refreshed_address,
         country_hint=existing_country,
     )
+    if existing_country is None or refreshed_country is None:
+        subdivision_country_codes = (
+            raw_place_coordinate_subdivision_country_codes(existing_parts)
+            | raw_place_coordinate_subdivision_country_codes(refreshed_parts)
+        )
+        if len(subdivision_country_codes) == 1:
+            country_hint = next(iter(subdivision_country_codes))
+            existing_parts, existing_country = raw_place_coordinate_address_comparison_key(
+                existing_address,
+                country_hint=country_hint,
+            )
+            refreshed_parts, refreshed_country = raw_place_coordinate_address_comparison_key(
+                refreshed_address,
+                country_hint=country_hint,
+            )
     if (
         existing_country is not None
         and refreshed_country is not None
@@ -7216,6 +7231,14 @@ def raw_place_coordinate_address_precision_regressed(
     if any(
         country_name_parts.get(existing_part) in address_country_codes
         for existing_part in set(existing_parts) - set(refreshed_parts)
+    ):
+        return False
+    directional_tokens = {"e", "east", "n", "north", "s", "south", "w", "west"}
+    if any(
+        set(existing_part).difference(refreshed_part) & directional_tokens
+        for existing_part in existing_parts
+        for refreshed_part in refreshed_parts
+        if set(refreshed_part).issubset(existing_part)
     ):
         return False
     return bool(
@@ -7523,12 +7546,18 @@ def raw_place_coordinate_hash_premise_token_indexes(
 ) -> set[int]:
     matched_indexes: set[int] = set()
     search_end = len(tokens)
-    hash_premises = re.findall(
-        r"#\s*(\d+(?:\s*-\s*[A-Za-z]{1,3})?)\b",
-        unicodedata.normalize("NFKC", part),
+    normalized_part = unicodedata.normalize("NFKC", part)
+    hash_premises = list(
+        re.finditer(r"#\s*(\d+(?:\s*-\s*[A-Za-z]{1,3})?)\b", normalized_part)
     )
-    for hash_premise in reversed(hash_premises):
-        address_key = raw_place_coordinate_address_key(hash_premise)
+    for match in reversed(hash_premises):
+        if re.search(
+            r"\b(?:apt|apartment|suite|ste|unit)\s*$",
+            normalized_part[: match.start()],
+            flags=re.IGNORECASE,
+        ):
+            continue
+        address_key = raw_place_coordinate_address_key(match.group(1))
         if address_key is None:
             continue
         premise_tokens = raw_place_coordinate_address_token_list(address_key)

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7175,12 +7175,14 @@ def raw_place_coordinate_address_precision_regressed(
     )
     if not is_strict_precision_subset:
         return False
-    country_name_parts = {
-        country_tokens
-        for country_tokens, _ in raw_place_coordinate_country_token_identities()
+    country_name_parts = dict(raw_place_coordinate_country_token_identities())
+    address_country_codes = {
+        country_code
+        for country_code in (existing_country, refreshed_country)
+        if country_code is not None
     }
     if any(
-        existing_part in country_name_parts
+        country_name_parts.get(existing_part) in address_country_codes
         for existing_part in set(existing_parts) - set(refreshed_parts)
     ):
         return False
@@ -7966,12 +7968,13 @@ def raw_place_coordinate_collapse_street_number_range(
         return None
     endpoint = next(iter(endpoint_numbers))
     normalized_address = unicodedata.normalize("NFKC", address)
-    if re.search(r"[\u3040-\u30ff\u3400-\u9fff]", normalized_address):
-        return None
+    contains_cjk = bool(re.search(r"[\u3040-\u30ff\u3400-\u9fff]", normalized_address))
     replaced = False
 
     def collapse(match: re.Match[str]) -> str:
         nonlocal replaced
+        if contains_cjk and not re.match(r"\s*[号號]", normalized_address[match.end() :]):
+            return match.group(0)
         if endpoint not in {match.group("start"), match.group("end")}:
             return match.group(0)
         replaced = True
@@ -8410,9 +8413,9 @@ def raw_place_refreshed_url_identity_is_compatible(
         if token
     }
     if refreshed_maps_place_token and existing_tokens:
-        if refreshed_maps_place_token in existing_tokens:
-            return True
-        return False
+        if refreshed_maps_place_token not in existing_tokens:
+            return False
+        matched_identity = True
 
     url = as_string(refreshed_url)
     if not url or not raw_place_maps_url_has_embedded_identity(url):

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7143,6 +7143,25 @@ def raw_place_coordinate_address_is_stable(
     )
 
 
+def raw_place_coordinate_street_name_tokens(address: str) -> set[str]:
+    for part in re.split(r"[,、]", address):
+        address_key = raw_place_coordinate_address_key(part)
+        if address_key is None:
+            continue
+        tokens = raw_place_coordinate_address_token_list(address_key)
+        if not raw_place_coordinate_part_has_street_marker(part, address_key, tokens):
+            continue
+        return {
+            token
+            for token in tokens
+            if not any(character.isdigit() for character in token)
+            and not raw_place_coordinate_token_is_ordinal(token)
+            and token not in RAW_PLACE_STREET_SUFFIX_TOKENS
+            and token not in RAW_PLACE_UNIT_PREFIX_TOKENS
+        }
+    return set()
+
+
 def raw_place_coordinate_address_precision_regressed(
     existing_place: RawPlace,
     refreshed_place: RawPlace,
@@ -7154,6 +7173,19 @@ def raw_place_coordinate_address_precision_regressed(
     if not raw_place_coordinate_address_has_street_level_evidence(existing_address):
         return False
     if not raw_place_address_is_preservable(existing_place, refreshed_place):
+        return False
+
+    existing_street_name_tokens = raw_place_coordinate_street_name_tokens(
+        existing_address
+    )
+    refreshed_street_name_tokens = raw_place_coordinate_street_name_tokens(
+        refreshed_address
+    )
+    if (
+        existing_street_name_tokens
+        and refreshed_street_name_tokens
+        and existing_street_name_tokens != refreshed_street_name_tokens
+    ):
         return False
 
     existing_parts, existing_country = raw_place_coordinate_address_comparison_key(
@@ -7339,7 +7371,15 @@ def raw_place_coordinate_part_has_street_intersection(
 
 def raw_place_coordinate_address_has_street_level_evidence(address: str) -> bool:
     normalized_address = raw_place_coordinate_strip_japanese_postal_prefix(address)
-    _, country_code = raw_place_coordinate_address_comparison_key(normalized_address)
+    comparison_parts, country_code = raw_place_coordinate_address_comparison_key(
+        normalized_address
+    )
+    if country_code is None:
+        subdivision_country_codes = raw_place_coordinate_subdivision_country_codes(
+            comparison_parts
+        )
+        if len(subdivision_country_codes) == 1:
+            country_code = next(iter(subdivision_country_codes))
     parsed_parts: list[tuple[str, str, list[str]]] = []
     for part in re.split(r"[,、]", normalized_address):
         address_key = raw_place_coordinate_address_key(part)
@@ -7973,7 +8013,7 @@ def raw_place_coordinate_collapse_street_number_range(
 
     def collapse(match: re.Match[str]) -> str:
         nonlocal replaced
-        if contains_cjk and not re.match(r"\s*[号號]", normalized_address[match.end() :]):
+        if contains_cjk and not re.match(r"\s*號", normalized_address[match.end() :]):
             return match.group(0)
         if endpoint not in {match.group("start"), match.group("end")}:
             return match.group(0)

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7208,11 +7208,23 @@ def raw_place_coordinate_street_name_tokens(address: str) -> tuple[str, ...]:
             tokens,
         ):
             continue
+        street_suffix_indexes = {
+            index
+            for index, token in enumerate(tokens)
+            if index > 0 and token in RAW_PLACE_STREET_SUFFIX_TOKENS
+        }
+        first_street_suffix_index = min(street_suffix_indexes, default=len(tokens))
         return tuple(
             token
             for index, token in enumerate(tokens)
-            if not any(character.isdigit() for character in token)
-            and not raw_place_coordinate_token_is_ordinal(token)
+            if (
+                raw_place_coordinate_token_is_ordinal(token)
+                or not any(character.isdigit() for character in token)
+            )
+            and (
+                not raw_place_coordinate_token_is_ordinal(token)
+                or index < first_street_suffix_index
+            )
             and (
                 token not in RAW_PLACE_STREET_SUFFIX_TOKENS
                 or index == 0
@@ -7221,7 +7233,10 @@ def raw_place_coordinate_street_name_tokens(address: str) -> tuple[str, ...]:
                     and tokens[index + 1] not in RAW_PLACE_UNIT_PREFIX_TOKENS
                 )
             )
-            and token not in RAW_PLACE_UNIT_PREFIX_TOKENS
+            and (
+                token not in RAW_PLACE_UNIT_PREFIX_TOKENS
+                or index < first_street_suffix_index
+            )
         )
     return ()
 
@@ -7239,6 +7254,15 @@ def raw_place_coordinate_address_precision_regressed(
     if not raw_place_address_is_preservable(existing_place, refreshed_place):
         return False
 
+    existing_street_numbers = raw_place_coordinate_street_numbers(existing_address)
+    refreshed_street_numbers = raw_place_coordinate_street_numbers(refreshed_address)
+    if (
+        existing_street_numbers
+        and refreshed_street_numbers
+        and existing_street_numbers != refreshed_street_numbers
+    ):
+        return False
+
     existing_street_name_tokens = raw_place_coordinate_street_name_tokens(
         existing_address
     )
@@ -7246,8 +7270,8 @@ def raw_place_coordinate_address_precision_regressed(
         refreshed_address
     )
     if (
-        existing_street_name_tokens
-        and refreshed_street_name_tokens
+        raw_place_coordinate_address_has_street_level_evidence(refreshed_address)
+        and (existing_street_name_tokens or refreshed_street_name_tokens)
         and existing_street_name_tokens != refreshed_street_name_tokens
     ):
         return False
@@ -7648,7 +7672,7 @@ def raw_place_coordinate_hash_premise_token_indexes(
             for token in sorted(RAW_PLACE_UNIT_PREFIX_TOKENS, key=len, reverse=True)
         )
         if re.search(
-            rf"\b(?:{unit_prefix_pattern})\s*$",
+            rf"\b(?:{unit_prefix_pattern})(?:\s+(?:no|number)\.?)?\s*$",
             normalized_part[: match.start()],
             flags=re.IGNORECASE,
         ):

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7143,23 +7143,36 @@ def raw_place_coordinate_address_is_stable(
     )
 
 
-def raw_place_coordinate_street_name_tokens(address: str) -> set[str]:
+def raw_place_coordinate_street_name_tokens(address: str) -> tuple[str, ...]:
+    _comparison_parts, country_code = raw_place_coordinate_address_comparison_key(address)
     for part in re.split(r"[,、]", address):
-        address_key = raw_place_coordinate_address_key(part)
+        normalized_part = raw_place_coordinate_normalize_street_prefix(part, country_code)
+        address_key = raw_place_coordinate_address_key(normalized_part)
         if address_key is None:
             continue
         tokens = raw_place_coordinate_address_token_list(address_key)
-        if not raw_place_coordinate_part_has_street_marker(part, address_key, tokens):
+        if not raw_place_coordinate_part_has_street_marker(
+            normalized_part,
+            address_key,
+            tokens,
+        ):
             continue
-        return {
+        return tuple(
             token
             for index, token in enumerate(tokens)
             if not any(character.isdigit() for character in token)
             and not raw_place_coordinate_token_is_ordinal(token)
-            and (token not in RAW_PLACE_STREET_SUFFIX_TOKENS or index != len(tokens) - 1)
+            and (
+                token not in RAW_PLACE_STREET_SUFFIX_TOKENS
+                or index == 0
+                or (
+                    index != len(tokens) - 1
+                    and tokens[index + 1] not in RAW_PLACE_UNIT_PREFIX_TOKENS
+                )
+            )
             and token not in RAW_PLACE_UNIT_PREFIX_TOKENS
-        }
-    return set()
+        )
+    return ()
 
 
 def raw_place_coordinate_address_precision_regressed(
@@ -7216,6 +7229,17 @@ def raw_place_coordinate_address_precision_regressed(
         and existing_country != refreshed_country
     ):
         return False
+    if not raw_place_coordinate_address_has_street_level_evidence(refreshed_address):
+        return bool(
+            refreshed_parts
+            and all(
+                any(
+                    set(refreshed_part).issubset(set(existing_part))
+                    for existing_part in existing_parts
+                )
+                for refreshed_part in refreshed_parts
+            )
+        )
     is_strict_precision_subset = len(refreshed_parts) < len(existing_parts) or any(
         all(refreshed_part != existing_part for existing_part in existing_parts)
         for refreshed_part in refreshed_parts
@@ -8038,11 +8062,20 @@ def raw_place_coordinate_collapse_street_number_range(
     endpoint = next(iter(endpoint_numbers))
     normalized_address = unicodedata.normalize("NFKC", address)
     contains_cjk = bool(re.search(r"[\u3040-\u30ff\u3400-\u9fff]", normalized_address))
+    _comparison_parts, country_code = raw_place_coordinate_address_comparison_key(
+        normalized_address
+    )
     replaced = False
 
     def collapse(match: re.Match[str]) -> str:
         nonlocal replaced
-        if contains_cjk and not re.match(r"\s*號", normalized_address[match.end() :]):
+        if (
+            contains_cjk
+            and (
+                country_code == "JP"
+                or not re.match(r"\s*[號号]", normalized_address[match.end() :])
+            )
+        ):
             return match.group(0)
         if endpoint not in {match.group("start"), match.group("end")}:
             return match.group(0)

--- a/scripts/build_data.py
+++ b/scripts/build_data.py
@@ -7262,6 +7262,14 @@ def raw_place_coordinate_address_precision_regressed(
         and existing_street_numbers != refreshed_street_numbers
     ):
         return False
+    existing_hash_premise_keys = raw_place_coordinate_hash_premise_keys(existing_address)
+    refreshed_hash_premise_keys = raw_place_coordinate_hash_premise_keys(refreshed_address)
+    if (
+        existing_hash_premise_keys
+        and refreshed_hash_premise_keys
+        and existing_hash_premise_keys != refreshed_hash_premise_keys
+    ):
+        return False
 
     existing_street_name_tokens = raw_place_coordinate_street_name_tokens(
         existing_address
@@ -7304,7 +7312,32 @@ def raw_place_coordinate_address_precision_regressed(
         and existing_country != refreshed_country
     ):
         return False
+    directional_tokens = {
+        "e",
+        "east",
+        "n",
+        "north",
+        "ne",
+        "northeast",
+        "nw",
+        "northwest",
+        "s",
+        "south",
+        "se",
+        "southeast",
+        "sw",
+        "southwest",
+        "w",
+        "west",
+    }
     if not raw_place_coordinate_address_has_street_level_evidence(refreshed_address):
+        if any(
+            set(existing_part).difference(refreshed_part) & directional_tokens
+            for existing_part in existing_parts
+            for refreshed_part in refreshed_parts
+            if set(refreshed_part).issubset(existing_part)
+        ):
+            return False
         return bool(
             refreshed_parts
             and all(
@@ -7332,24 +7365,6 @@ def raw_place_coordinate_address_precision_regressed(
         for existing_part in set(existing_parts) - set(refreshed_parts)
     ):
         return False
-    directional_tokens = {
-        "e",
-        "east",
-        "n",
-        "north",
-        "ne",
-        "northeast",
-        "nw",
-        "northwest",
-        "s",
-        "south",
-        "se",
-        "southeast",
-        "sw",
-        "southwest",
-        "w",
-        "west",
-    }
     if any(
         set(existing_part).difference(refreshed_part) & directional_tokens
         for existing_part in existing_parts
@@ -7691,6 +7706,29 @@ def raw_place_coordinate_hash_premise_token_indexes(
             search_end = start
             break
     return matched_indexes
+
+
+def raw_place_coordinate_hash_premise_keys(address: str) -> set[str]:
+    keys: set[str] = set()
+    normalized_address = unicodedata.normalize("NFKC", address)
+    unit_prefix_pattern = "|".join(
+        re.escape(token)
+        for token in sorted(RAW_PLACE_UNIT_PREFIX_TOKENS, key=len, reverse=True)
+    )
+    for match in re.finditer(
+        r"#\s*(\d+(?:\s*[-/]\s*[A-Za-z]{1,3})?)\b",
+        normalized_address,
+    ):
+        if re.search(
+            rf"\b(?:{unit_prefix_pattern})(?:\s+(?:no|number)\.?)?\s*$",
+            normalized_address[: match.start()],
+            flags=re.IGNORECASE,
+        ):
+            continue
+        key = raw_place_coordinate_address_key(match.group(1))
+        if key is not None:
+            keys.add(key)
+    return keys
 
 
 def raw_place_coordinate_street_part_has_nearby_premise(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -3174,6 +3174,33 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (17.06, -96.72))
         self.assertIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_rejects_changed_mexican_hash_premise(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="C. Morelos #191, Oaxaca, Mexico",
+            lat=17.06,
+            lng=-96.72,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "C. Morelos #192, Mexico",
+                "lat": 17.15,
+                "lng": -96.81,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (17.15, -96.81))
+        self.assertNotIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_normalizes_street_prefix_before_precision_check(
         self,
     ) -> None:
@@ -3210,6 +3237,17 @@ class BuildDataTests(unittest.TestCase):
 
     def test_raw_place_coordinate_ignores_hash_unit_labels_as_mexican_premises(self) -> None:
         for unit_label in ("Room", "rm", "floor", "fl", "level", "building"):
+            with self.subTest(unit_label=unit_label):
+                self.assertFalse(
+                    build_data.raw_place_coordinate_address_has_street_level_evidence(
+                        f"C. Morelos {unit_label} #5, Oaxaca, Mexico"
+                    )
+                )
+
+    def test_raw_place_coordinate_ignores_hash_unit_number_labels_as_mexican_premises(
+        self,
+    ) -> None:
+        for unit_label in ("Room No.", "Suite Number"):
             with self.subTest(unit_label=unit_label):
                 self.assertFalse(
                     build_data.raw_place_coordinate_address_has_street_level_evidence(
@@ -4688,6 +4726,56 @@ class BuildDataTests(unittest.TestCase):
         )
 
         self.assertEqual((merged.lat, merged.lng), (42.3736, -71.1097))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_rejects_lost_unit_word_street_name(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Tower Rd, Boston, MA, United States",
+            lat=42.3601,
+            lng=-71.0589,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "1 Rd, Boston, MA, United States",
+                "lat": 42.3736,
+                "lng": -71.1097,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (42.3736, -71.1097))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_rejects_lost_ordinal_street_name(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1200 5th Ave, Seattle, WA, United States",
+            lat=47.61,
+            lng=-122.33,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "1200 Ave, WA, United States",
+                "lat": 47.62,
+                "lng": -122.32,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (47.62, -122.32))
         self.assertNotIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_handles_japanese_postal_expansion(self) -> None:

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -3042,6 +3042,33 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (37.44, -122.15))
         self.assertNotIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_rejects_directional_locality_loss(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, East Palo Alto, CA, United States",
+            lat=37.47,
+            lng=-122.14,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "Palo Alto, CA, United States",
+                "lat": 37.44,
+                "lng": -122.15,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (37.44, -122.15))
+        self.assertNotIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_rejects_diagonal_directional_locality_change(
         self,
     ) -> None:
@@ -3188,6 +3215,33 @@ class BuildDataTests(unittest.TestCase):
         refreshed_place = existing_place.model_copy(
             update={
                 "address": "C. Morelos #192, Mexico",
+                "lat": 17.15,
+                "lng": -96.81,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (17.15, -96.81))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_rejects_changed_alphanumeric_hash_premise(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="C/ de la Constitución #104-A, Oaxaca, Mexico",
+            lat=17.06,
+            lng=-96.72,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "C/ de la Constitución #104-B",
                 "lat": 17.15,
                 "lng": -96.81,
             }

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2752,6 +2752,33 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (41.85, 140.8))
         self.assertNotIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_collapses_cjk_house_number_ranges(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="中山北路 195-197號, Taipei, Taiwan",
+            lat=25.03,
+            lng=121.52,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "中山北路 195號, Taipei, Taiwan",
+                "lat": 25.12,
+                "lng": 121.63,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (25.03, 121.52))
+        self.assertIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_handles_split_taiwan_premise_and_street(
         self,
     ) -> None:
@@ -2801,6 +2828,33 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertEqual(merged.address, existing_place.address)
         self.assertEqual((merged.lat, merged.lng), (37.7666, -122.4303))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_keeps_country_named_locality_on_precision_loss(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, Canada, KY, United States",
+            lat=37.1,
+            lng=-84.2,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main St, KY, United States",
+                "lat": 37.2,
+                "lng": -84.3,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (37.1, -84.2))
         self.assertIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_recognizes_hash_prefixed_premises(
@@ -4088,7 +4142,7 @@ class BuildDataTests(unittest.TestCase):
                 self.assertEqual((merged.lat, merged.lng), (40.7128, -74.006))
                 self.assertNotIn("coordinates", preserved_fields)
 
-    def test_preserve_existing_raw_place_accepts_removed_country_name_locality(
+    def test_preserve_existing_raw_place_keeps_removed_country_name_locality(
         self,
     ) -> None:
         existing_place = RawPlace(
@@ -4112,8 +4166,8 @@ class BuildDataTests(unittest.TestCase):
             refreshed_place=refreshed_place,
         )
 
-        self.assertEqual((merged.lat, merged.lng), (38.5767, -92.1735))
-        self.assertNotIn("coordinates", preserved_fields)
+        self.assertEqual((merged.lat, merged.lng), (39.1698, -91.8829))
+        self.assertIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_accepts_added_locality_for_suffixless_street(
         self,

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2779,6 +2779,33 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (41.85, 140.8))
         self.assertNotIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_does_not_collapse_countryless_japanese_block_lot_numbers(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="北海道函館市大手町２２−１号",
+            lat=41.77,
+            lng=140.72,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "北海道函館市大手町１号",
+                "lat": 41.85,
+                "lng": 140.8,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (41.85, 140.8))
+        self.assertNotIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_collapses_cjk_house_number_ranges(
         self,
     ) -> None:
@@ -3015,6 +3042,33 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (37.44, -122.15))
         self.assertNotIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_rejects_diagonal_directional_locality_change(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, Northeast Harbor, ME, United States",
+            lat=44.29,
+            lng=-68.29,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main St, Harbor, ME, United States",
+                "lat": 44.3,
+                "lng": -68.2,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (44.3, -68.2))
+        self.assertNotIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_keeps_country_named_locality_on_precision_loss(
         self,
     ) -> None:
@@ -3153,6 +3207,15 @@ class BuildDataTests(unittest.TestCase):
                 "C. Morelos Suite #5, Oaxaca, Mexico"
             )
         )
+
+    def test_raw_place_coordinate_ignores_hash_unit_labels_as_mexican_premises(self) -> None:
+        for unit_label in ("Room", "rm", "floor", "fl", "level", "building"):
+            with self.subTest(unit_label=unit_label):
+                self.assertFalse(
+                    build_data.raw_place_coordinate_address_has_street_level_evidence(
+                        f"C. Morelos {unit_label} #5, Oaxaca, Mexico"
+                    )
+                )
 
     def test_preserve_existing_raw_place_normalizes_countryless_subdivision_precision_loss(
         self,

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2806,6 +2806,33 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (25.03, 121.52))
         self.assertIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_collapses_simplified_cjk_house_number_ranges(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="中山路 195-197号, Shanghai, China",
+            lat=31.23,
+            lng=121.47,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "中山路 195号, Shanghai, China",
+                "lat": 31.32,
+                "lng": 121.58,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (31.23, 121.47))
+        self.assertIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_handles_split_taiwan_premise_and_street(
         self,
     ) -> None:
@@ -2883,6 +2910,58 @@ class BuildDataTests(unittest.TestCase):
 
         self.assertEqual((merged.lat, merged.lng), (42.2, -72.7))
         self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_rejects_reordered_street_name_on_precision_loss(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main West St, Springfield, MA, United States",
+            lat=42.1,
+            lng=-72.6,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 West Main St, Springfield, MA, United States",
+                "lat": 42.2,
+                "lng": -72.7,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (42.2, -72.7))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_ignores_street_suffix_before_unit(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St Suite 5, Springfield, MA, United States",
+            lat=42.1,
+            lng=-72.6,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main St, Springfield, MA, United States",
+                "lat": 42.2,
+                "lng": -72.7,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (42.1, -72.6))
+        self.assertIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_keeps_saint_street_tokens(self) -> None:
         existing_place = RawPlace(
@@ -3004,6 +3083,60 @@ class BuildDataTests(unittest.TestCase):
         )
         refreshed_place = existing_place.model_copy(
             update={"lat": 17.15, "lng": -96.81}
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (17.06, -96.72))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_keeps_mexican_hash_premise_on_precision_loss(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="C. Morelos #191, Oaxaca, Mexico",
+            lat=17.06,
+            lng=-96.72,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "C. Morelos, Oaxaca, Mexico",
+                "lat": 17.15,
+                "lng": -96.81,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (17.06, -96.72))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_normalizes_street_prefix_before_precision_check(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="C. Morelos 191, Oaxaca, Mexico",
+            lat=17.06,
+            lng=-96.72,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "Calle Morelos 191, Mexico",
+                "lat": 17.15,
+                "lng": -96.81,
+            }
         )
 
         merged, preserved_fields = build_data.preserve_existing_raw_place(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2884,6 +2884,58 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (42.2, -72.7))
         self.assertNotIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_keeps_saint_street_tokens(self) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 St John St, Springfield, MA, United States",
+            lat=42.1,
+            lng=-72.6,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 John St, Springfield, MA, United States",
+                "lat": 42.2,
+                "lng": -72.7,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (42.2, -72.7))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_rejects_directional_locality_change(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, East Palo Alto, CA, United States",
+            lat=37.47,
+            lng=-122.14,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main St, Palo Alto, CA, United States",
+                "lat": 37.44,
+                "lng": -122.15,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (37.44, -122.15))
+        self.assertNotIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_keeps_country_named_locality_on_precision_loss(
         self,
     ) -> None:
@@ -2960,6 +3012,40 @@ class BuildDataTests(unittest.TestCase):
         )
 
         self.assertEqual((merged.lat, merged.lng), (17.06, -96.72))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_raw_place_coordinate_ignores_hash_suite_as_mexican_premise(self) -> None:
+        self.assertFalse(
+            build_data.raw_place_coordinate_address_has_street_level_evidence(
+                "C. Morelos Suite #5, Oaxaca, Mexico"
+            )
+        )
+
+    def test_preserve_existing_raw_place_normalizes_countryless_subdivision_precision_loss(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 Main St, Springfield, MA",
+            lat=42.1,
+            lng=-72.6,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main St, MA, United States",
+                "lat": 42.2,
+                "lng": -72.7,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (42.1, -72.6))
         self.assertIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_handles_compound_german_street_suffix(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2176,6 +2176,40 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual(merged.google_id, "/g/example")
         self.assertIn("google_id", preserved_fields)
 
+    def test_preserve_existing_raw_place_keeps_google_id_for_matching_token_field(
+        self,
+    ) -> None:
+        token = "0xabc:0xdef"
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="1 Example St, Example City",
+            lat=35.0,
+            lng=139.0,
+            maps_url="https://www.google.com/maps/search/?api=1&query=Example+Cafe",
+            google_id="/g/example",
+            maps_place_token=token,
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "lat": 36.0,
+                "lng": 140.0,
+                "maps_url": (
+                    "https://www.google.com/maps/search/?api=1&query=Example+Cafe"
+                    "&query_place_id=ChIJ-new"
+                ),
+                "google_id": None,
+                "maps_place_token": token,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual(merged.google_id, "/g/example")
+        self.assertIn("google_id", preserved_fields)
+
     def test_preserve_existing_raw_place_does_not_restore_google_id_across_url_conflict(
         self,
     ) -> None:
@@ -2689,6 +2723,112 @@ class BuildDataTests(unittest.TestCase):
                 )
 
                 self.assertEqual((merged.lat, merged.lng), (38.711, -9.137))
+                self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_does_not_collapse_japanese_block_lot_numbers(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="日本、〒040-0064 北海道函館市大手町２２−１",
+            lat=41.77,
+            lng=140.72,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "北海道函館市大手町１",
+                "lat": 41.85,
+                "lng": 140.8,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (41.85, 140.8))
+        self.assertNotIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_handles_split_taiwan_premise_and_street(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="No. 323, Section 2, Fuxing S Rd, Taipei City, Taiwan",
+            lat=25.03,
+            lng=121.54,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={"lat": 25.12, "lng": 121.63}
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (25.03, 121.54))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_treats_street_only_refresh_as_precision_loss(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="2172 Market St, San Francisco, CA 94114",
+            lat=37.7666,
+            lng=-122.4303,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "2172 Market St",
+                "lat": 37.82,
+                "lng": -122.36,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual(merged.address, existing_place.address)
+        self.assertEqual((merged.lat, merged.lng), (37.7666, -122.4303))
+        self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_recognizes_hash_prefixed_premises(
+        self,
+    ) -> None:
+        for address in (
+            "C. Morelos #191, Oaxaca, Mexico",
+            "C/ de la Constitución #104-A, Oaxaca, Mexico",
+        ):
+            with self.subTest(address=address):
+                existing_place = RawPlace(
+                    name="Example Cafe",
+                    address=address,
+                    lat=17.06,
+                    lng=-96.72,
+                    maps_url="https://www.google.com/maps?cid=111",
+                    cid="111",
+                )
+                refreshed_place = existing_place.model_copy(
+                    update={"lat": 17.15, "lng": -96.81}
+                )
+
+                merged, preserved_fields = build_data.preserve_existing_raw_place(
+                    existing_place=existing_place,
+                    refreshed_place=refreshed_place,
+                )
+
+                self.assertEqual((merged.lat, merged.lng), (17.06, -96.72))
                 self.assertIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_handles_compound_german_street_suffix(

--- a/tests/python/test_build_data.py
+++ b/tests/python/test_build_data.py
@@ -2752,6 +2752,33 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (41.85, 140.8))
         self.assertNotIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_does_not_collapse_japanese_block_lot_numbers_before_go(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="日本、〒040-0064 北海道函館市大手町２２−１号",
+            lat=41.77,
+            lng=140.72,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "北海道函館市大手町１号",
+                "lat": 41.85,
+                "lng": 140.8,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (41.85, 140.8))
+        self.assertNotIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_collapses_cjk_house_number_ranges(
         self,
     ) -> None:
@@ -2830,6 +2857,33 @@ class BuildDataTests(unittest.TestCase):
         self.assertEqual((merged.lat, merged.lng), (37.7666, -122.4303))
         self.assertIn("coordinates", preserved_fields)
 
+    def test_preserve_existing_raw_place_rejects_changed_street_name_on_precision_loss(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="123 West Main St, Springfield, MA, United States",
+            lat=42.1,
+            lng=-72.6,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={
+                "address": "123 Main St, Springfield, MA, United States",
+                "lat": 42.2,
+                "lng": -72.7,
+            }
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (42.2, -72.7))
+        self.assertNotIn("coordinates", preserved_fields)
+
     def test_preserve_existing_raw_place_keeps_country_named_locality_on_precision_loss(
         self,
     ) -> None:
@@ -2884,6 +2938,29 @@ class BuildDataTests(unittest.TestCase):
 
                 self.assertEqual((merged.lat, merged.lng), (17.06, -96.72))
                 self.assertIn("coordinates", preserved_fields)
+
+    def test_preserve_existing_raw_place_recognizes_hash_prefixed_premises_with_mexican_subdivision(
+        self,
+    ) -> None:
+        existing_place = RawPlace(
+            name="Example Cafe",
+            address="C. Morelos #191, Oaxaca",
+            lat=17.06,
+            lng=-96.72,
+            maps_url="https://www.google.com/maps?cid=111",
+            cid="111",
+        )
+        refreshed_place = existing_place.model_copy(
+            update={"lat": 17.15, "lng": -96.81}
+        )
+
+        merged, preserved_fields = build_data.preserve_existing_raw_place(
+            existing_place=existing_place,
+            refreshed_place=refreshed_place,
+        )
+
+        self.assertEqual((merged.lat, merged.lng), (17.06, -96.72))
+        self.assertIn("coordinates", preserved_fields)
 
     def test_preserve_existing_raw_place_handles_compound_german_street_suffix(
         self,


### PR DESCRIPTION
## Trigger

Follow-up to downstream refresh PR #102, which exposed address-precision cases that could either keep stale coordinates or accept a degraded refresh.

## Fix

- Preserve street-name order while ignoring a suffix immediately before a unit label.
- Normalize street prefixes before comparing street names.
- Preserve a Mexican hash-prefixed premise when the refresh drops it.
- Support simplified Chinese `号` ranges without collapsing Japanese block/lot values.
- Include the earlier reviewed coordinate-identity and address-precision refinements from #102.

## Verification

- `/Users/michaelwu/dev/favorite-places/.context/venv-cid-test/bin/python -m unittest tests.python.test_build_data` (586 tests)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core merge logic that decides whether stored lat/lng and addresses win over refreshed Maps data; mistakes could pin wrong coordinates or accept bad refreshes, though behavior is heavily regression-tested.
> 
> **Overview**
> **Hardens when `preserve_existing_raw_place` keeps address, coordinates, and Google identity** when a refreshed record has fuzzier or conflicting location data.
> 
> **Address precision** — `raw_place_coordinate_address_precision_regressed` and related preservable-address paths are reworked: street-name comparison (prefix normalization, ordinals, suffix-before-unit), rejection when street numbers, `#` premises, or locality directionals change, and smarter handling when the refresh drops city/state but keeps the street. **Locale-specific parsing** adds Japanese prefecture detection, skips collapsing block/lot `22−1` style ranges while still collapsing Taiwan/China `號/号` ranges, Mexican `#` street numbers (excluding suite/unit `#`), section-adjacent premises, and subdivision hints when country is missing.
> 
> **Identity preservation** — `raw_place_refreshed_url_identity_is_compatible` now accepts an explicit `refreshed_maps_place_token` so `google_id` / `cid` / `maps_place_token` can still be restored when the refresh URL diverges but the token still matches.
> 
> Coverage is expanded heavily in `test_build_data.py` for JP, MX, TW/CN, US directional localities, and token-matched `google_id` preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aaa532f62fbef906454be2491e5e66eda75dd71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved place matching so existing place details are preserved more reliably during refreshed data updates.
  - Improved address parsing and normalization for Japanese, Mexican, and CJK-based addresses.
  - Reduced incorrect coordinate changes when street names, address components, or locality details vary.
  - Improved handling of nearby premises, suites, units, sections, and street-level address evidence.
  - Preserved location coordinates more accurately when address precision changes are ambiguous.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->